### PR TITLE
Missing reference: FF Managed to FF Cloud

### DIFF
--- a/src/pricing.njk
+++ b/src/pricing.njk
@@ -26,7 +26,7 @@ layout: layouts/page.njk
         </div>
         <div class="flex flex-col sm:flex-row items-center gap-4 mt-4">
             <div class="sm:w-6/12">
-                <h5>FlowForge-Managed</h5>
+                <h5>FlowForge Cloud</h5>
                 <p class="mt-2">Get started in less than a minute, fully managed, fully secure.</p>
                 <a class="ff-btn ff-btn--primary" href="https://app.flowforge.com/account/create">Sign up</a>
             </div>


### PR DESCRIPTION
Update a missed reference to "FlowForge Managed" on the Pricing Page - should now be FlowForge Cloud