### PR TITLE
Remove 404.html from site index

### DIFF
--- a/src/sitemap.njk
+++ b/src/sitemap.njk
@@ -5,10 +5,12 @@ eleventyExcludeFromCollections: true
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     {% for page in collections.all %}
+        {% if page.url != '/404.html' %}
         <url>
             <loc>{{ site.baseURL }}{{ page.url | url }}</loc>
             <lastmod>{{ page.date.toISOString() }}</lastmod>
             <priority>{{ page.data.sitemapPriority | default(0.6) }}</priority>
         </url>
+        {% endif %}
     {% endfor %}
 </urlset>


### PR DESCRIPTION
Fixes #335

Remove 404.html from siteindex as we don't want it indexing our 404 page and causing upset with Google Site Indexing thinking that page should have a 404 status code to match.