### PR TITLE
show large card when sharing articles on Twitter

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -70,7 +70,7 @@
 
     {% if tags and 'posts' in tags %}
     <!-- Twitter Card -->
-    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@flowforgeinc" />
     <meta name="twitter:creator" content="@{{ team[authors|first].twitter }}" />
     {% else %}


### PR DESCRIPTION
## Description

Noticed when sharing blogs/articles from our site, that the preview image is still very small, this is a legacy setting from before we had bespoke images for each article.

We'd now like to be having larger images to draw more attention to our articles.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
