### PR TITLE
announcement: FF Cloud features 3.1 Beta 2

### DIFF
--- a/src/blog/2023/03/node-red-3.1-beta-available-flowforge-cloud.md
+++ b/src/blog/2023/03/node-red-3.1-beta-available-flowforge-cloud.md
@@ -1,0 +1,33 @@
+---
+title: Node-RED 3.1 Beta 2 available on FlowForge Cloud
+subtitle: Test drive the next version of Node-RED
+description: To allow testing of the next version of Node-RED, FlowForge Cloud made the 3.1-beta-2 release available.
+date: 2022-03-10
+authors: ["zeger-jan-van-de-weg"]
+---
+
+We are excited to announce that Node-RED 3.1 Beta 2 is now available on
+FlowForge Cloud! By making this version available as beta release we hope users
+validate the beta release and provide feedback on the release before the beta
+badge is dropped.
+
+<!--more-->
+
+To help our users test their flows in this new version, FlowForge allows you to
+copy an application through the "Duplicate Project" button in the settings. By
+clicking this button the version of Node-RED can be changed to the Beta release.
+We'd appreciate any feedback on the new Node-RED version, especially if there's
+backward incompatible changes. This way we can improve the release before the
+new version of Node-RED is deployed to production.
+
+While testing if your flows work as expected, you might enjoy using the improved
+editor context menu through right-clicking on the workspace, try out the flow
+locking, or add images to flow descriptions.
+
+
+We encourage all our users to take advantage of this opportunity to test their
+flows in Node-RED 3.1. This will not only help them identify any potential
+issues but also allow them to try out the new features and improvements in this
+version. We believe that this new version of Node-RED will make it even easier
+for our users to create powerful applications and automate their workflows.
+

--- a/src/blog/2023/03/node-red-3.1-beta-available-flowforge-cloud.md
+++ b/src/blog/2023/03/node-red-3.1-beta-available-flowforge-cloud.md
@@ -4,6 +4,8 @@ subtitle: Test drive the next version of Node-RED
 description: To allow testing of the next version of Node-RED, FlowForge Cloud made the 3.1-beta-2 release available.
 date: 2022-03-10
 authors: ["zeger-jan-van-de-weg"]
+tags:
+    - posts
 ---
 
 We are excited to announce that Node-RED 3.1 Beta 2 is now available on


### PR DESCRIPTION
Soonish we'll allow folks to preview Node-RED 3.1 Beta 2. This blog post announces that.

See also: https://github.com/flowforge/admin/issues/149
