### PR TITLE
Fallback to .description for page description if present

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -29,6 +29,8 @@
     <!-- Browser Description -->
     {% if meta and meta.description %}
     <meta name="description" content="{{ meta.description }}">
+    {% elif description %}
+    <meta name="description" content="{{ description }}">
     {% else %}
     <meta name="description" content="Scale your Node-RED deployments in production. Open-Source and available on Docker, Kubernetes or Cloud">
     {% endif %}


### PR DESCRIPTION
## Description

The social sharing description was set, but not the base page description. This updates it to use `.description` if present )previously only used `.meta.description`

## Related Issue(s)

Fixes #506

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)