### PR TITLE
actions: Upgrade deprecated setup-node action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           path: 'flowfuse'
       - name: Install jq
         run: sudo apt-get -qy install jq
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           cache: 'npm'
           cache-dependency-path: './website/package-lock.json'

--- a/src/handbook/.github/workflows/test.yml
+++ b/src/handbook/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
       # Install NPM dependencies


### PR DESCRIPTION
## Description

See also: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/ 

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
