### PR TITLE
Fix typo in /manufacturing

### DIFF
--- a/src/solutions/manufacturing.njk
+++ b/src/solutions/manufacturing.njk
@@ -147,7 +147,7 @@ description:
                     <h4>Streamlined Application Delivery</h4>
                     <div>
                         <p>
-                            With FlowFuse, you can not set up devops delivery pipelines to support
+                            With FlowFuse, you can now set up devops delivery pipelines to support
                             development, test and production environments. A key to ensuring your Node-RED
                             application delivery is reliable, secure and high quality.
                         </p>


### PR DESCRIPTION
## Description

It says: With FlowFuse, you can **not** set up devops delivery pipelines to support development...
With this change it will be: With FlowFuse, you can **now** set up devops delivery pipelines to support development,

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
