### PR TITLE
dependency: Spacetime bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
                 "postcss-minify": "^1.1.0",
                 "seedrandom": "^3.0.5",
                 "should": "^13.2.3",
-                "spacetime": "^6.16.3",
+                "spacetime": "^7.4.7",
                 "tailwindcss": "^2.2.17",
                 "terser": "^5.9.0",
                 "vanilla-cookieconsent": "^2.6.1",
@@ -22425,9 +22425,9 @@
             "peer": true
         },
         "node_modules/spacetime": {
-            "version": "6.16.3",
-            "resolved": "https://registry.npmjs.org/spacetime/-/spacetime-6.16.3.tgz",
-            "integrity": "sha512-JQEfj3VHT1gU1IMV5NvhgAP8P+2mDFd84ZCiHN//dp6hRKmuW0IizHissy62lO0nilfFjVhnoSaMC7te+Y5f4A==",
+            "version": "7.4.7",
+            "resolved": "https://registry.npmjs.org/spacetime/-/spacetime-7.4.7.tgz",
+            "integrity": "sha512-5qVgPHUQj9TD4g1Xl68tXXwEi/27Xatvroyj8VU8/E7RgaqLJNaTte5tu3GRowuMqHcNMxs7UfzKeqAlLCo3tQ==",
             "dev": true
         },
         "node_modules/spdx-correct": {
@@ -39938,9 +39938,9 @@
             "peer": true
         },
         "spacetime": {
-            "version": "6.16.3",
-            "resolved": "https://registry.npmjs.org/spacetime/-/spacetime-6.16.3.tgz",
-            "integrity": "sha512-JQEfj3VHT1gU1IMV5NvhgAP8P+2mDFd84ZCiHN//dp6hRKmuW0IizHissy62lO0nilfFjVhnoSaMC7te+Y5f4A==",
+            "version": "7.4.7",
+            "resolved": "https://registry.npmjs.org/spacetime/-/spacetime-7.4.7.tgz",
+            "integrity": "sha512-5qVgPHUQj9TD4g1Xl68tXXwEi/27Xatvroyj8VU8/E7RgaqLJNaTte5tu3GRowuMqHcNMxs7UfzKeqAlLCo3tQ==",
             "dev": true
         },
         "spdx-correct": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "@flowforge/forge-ui-components": "^0.2.2",
         "@kevingimbel/eleventy-plugin-mermaid": "^2.0.0",
         "@tailwindcss/typography": "^0.4.1",
+        "@xmldom/xmldom": "^0.7.0",
         "autoprefixer": "^10.3.7",
         "cross-env": "^7.0.3",
         "del-cli": "^5.0.0",
@@ -48,11 +49,10 @@
         "postcss-minify": "^1.1.0",
         "seedrandom": "^3.0.5",
         "should": "^13.2.3",
-        "spacetime": "^6.16.3",
+        "spacetime": "^7.4.7",
         "tailwindcss": "^2.2.17",
         "terser": "^5.9.0",
         "vanilla-cookieconsent": "^2.6.1",
-        "@xmldom/xmldom": "^0.7.0",
         "xpath": "^0.0.32"
     },
     "dependencies": {


### PR DESCRIPTION
After the upgrade of my mac to the newest version the interaction with spacetime and the host system broke down. The host provided the TZ as 'cet', and initially expected `Europe/Amsterdam` in my case.

This broke the build of the website:

```
> spacetime.today()
Uncaught:
Error: Spacetime: Cannot find timezone named: 'cet'. Please enter an IANA timezone id.
    at lookupTz (/Users/zegerjan/src/github.com/FlowFuse/website/node_modules/spacetime/builds/spacetime.js:391:11)
    at new SpaceTime (/Users/zegerjan/src/github.com/FlowFuse/website/node_modules/spacetime/builds/spacetime.js:4292:15)
    at SpaceTime.clone (/Users/zegerjan/src/github.com/FlowFuse/website/node_modules/spacetime/builds/spacetime.js:4354:12)
    at Object.startOf (/Users/zegerjan/src/github.com/FlowFuse/website/node_modules/spacetime/builds/spacetime.js:2525:15)
    at SpaceTime.startOf (/Users/zegerjan/src/github.com/FlowFuse/website/node_modules/spacetime/builds/spacetime.js:2762:19)
    at main.today (/Users/zegerjan/src/github.com/FlowFuse/website/node_modules/spacetime/builds/spacetime.js:4457:14)
```

By bumping the dependency upstream improved the parsing to allow 'cet'.
