### PR TITLE
Fix stories logo on mobile

### DIFF
--- a/src/_includes/layouts/story.njk
+++ b/src/_includes/layouts/story.njk
@@ -37,7 +37,7 @@ layout: layouts/base.njk
                         style="box-shadow: 4px 4px 6px rgba(75,85,99,0.05)">
 
                         {% if story.logo %}
-                        <div class="h-[180px] object-contain flex items-center justify-center bg-white">
+                        <div class="h-[180px] object-contain flex items-center justify-center bg-white p-2">
                             <a href="{{ story.url }}" target="_blank" class="h-full ff-image-cover">
                                 {% set imageSrc = ["./", story.logo ] | join %}
                                 {% set imageDescription = ["Image representing ", story.brand, " logo"] | join %}

--- a/src/_includes/layouts/story.njk
+++ b/src/_includes/layouts/story.njk
@@ -32,16 +32,18 @@ layout: layouts/base.njk
                         {{ content | safe }}
                     </div>
                 </div>
-                <div class="w-80 max-w-full flex-shrink-0">
+                <div class="w-80 max-w-full flex-shrink-0 self-center md:self-auto">
                     <div class="sticky top-4 flex flex-col border rounded-lg py-6 px-6"
                         style="box-shadow: 4px 4px 6px rgba(75,85,99,0.05)">
 
                         {% if story.logo %}
-                        <a href="{{ story.url }}" target="_blank">
-                            {% set imageSrc = ["./", story.logo ] | join %}
-                            {% set imageDescription = ["Image representing ", story.brand, " logo"] | join %}
-                            {% image imageSrc, imageDescription, [285] %}
-                        </a>
+                        <div class="h-[180px] object-contain flex items-center justify-center bg-white">
+                            <a href="{{ story.url }}" target="_blank" class="h-full ff-image-cover">
+                                {% set imageSrc = ["./", story.logo ] | join %}
+                                {% set imageDescription = ["Image representing ", story.brand, " logo"] | join %}
+                                {% image imageSrc, imageDescription, [270] %}
+                            </a>
+                        </div>
                         <div class="border-t pb-3"></div>
                         {% endif %}
                         <div class="border-b pb-3">

--- a/src/customer-stories.njk
+++ b/src/customer-stories.njk
@@ -23,7 +23,7 @@ meta:
                             {% image imageSrc, imageDescription, [768] %}
                         </div>
                         {% if item.data.logo %}
-                        <div class="w-1/2 h-full md:w-40 md:h-40 absolute left-0 top-0 bg-white flex items-center justify-center object-contain border border-gray-200">
+                        <div class="w-1/2 h-full md:w-40 md:h-40 absolute left-0 top-0 bg-white p-2 flex items-center justify-center object-contain border border-gray-200">
                             <div class="h-full ff-image-cover">
                                 {% set imageSrc = ["./", item.data.logo ] | join %}
                                 {% set imageDescription = ["Image representing ", item.data.story.brand, " logo"] | join %}

--- a/src/customer-stories.njk
+++ b/src/customer-stories.njk
@@ -24,9 +24,11 @@ meta:
                         </div>
                         {% if item.data.logo %}
                         <div class="w-1/2 h-full md:w-40 md:h-40 absolute left-0 top-0 bg-white flex items-center justify-center object-contain border border-gray-200">
-                            {% set imageSrc = ["./", item.data.logo ] | join %}
-                            {% set imageDescription = ["Image representing ", item.data.story.brand, " logo"] | join %}
-                            {% image imageSrc, imageDescription, [285] %}
+                            <div class="h-full ff-image-cover">
+                                {% set imageSrc = ["./", item.data.logo ] | join %}
+                                {% set imageDescription = ["Image representing ", item.data.story.brand, " logo"] | join %}
+                                {% image imageSrc, imageDescription, [285] %}
+                            </div>
                         </div>
                         {% endif %}                        
                     </div>


### PR DESCRIPTION
## Description

Currently, the size of each customer story logo is defined by the image file size rather than the container. This fix ensures that any image should fit correctly, regardless of its file dimensions.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
