### PR TITLE
Add hosting parameter to /pricing URL

### DIFF
--- a/src/pricing.njk
+++ b/src/pricing.njk
@@ -278,26 +278,57 @@ meta:
         }
     }
 </script>
+
 <script>
     const btns = document.querySelectorAll(".mainToggle");
     const cloud = document.querySelectorAll(".contentCloud");
     const selfHosted = document.querySelectorAll(".contentSelfHosted");
 
+    // Get the hosting parameter from the URL
+    const urlParams = new URLSearchParams(window.location.search);
+    const hosting = urlParams.get('hosting');
+
+    // Check the hosting parameter when the page loads
+    if (hosting === 'self-hosted') {
+        // Show Self-Hosted state
+        btns.forEach((item) => item.classList.add("slides"));
+        cloud.forEach((item) => item.classList.add("hide"));
+        selfHosted.forEach((item) => item.classList.remove("hide"));
+    } else {
+        // Show Cloud state
+        btns.forEach((item) => item.classList.remove("slides"));
+        cloud.forEach((item) => item.classList.remove("hide"));
+        selfHosted.forEach((item) => item.classList.add("hide"));
+    }
+
     btns.forEach(btn => {
         btn.addEventListener("click", function() {
-        // Toggle .slides class on buttons
-        btns.forEach((item) => item.classList.toggle("slides"));
+            // Toggle .slides class on buttons
+            btns.forEach((item) => item.classList.toggle("slides"));
 
-        // // Toggle .hide class on cloud and selfHosted elements
-        cloud.forEach((item) => {
-            item.classList.toggle("hide");
-        });
+            // Toggle .hide class on cloud and selfHosted elements
+            cloud.forEach((item) => {
+                item.classList.toggle("hide");
+            });
 
-        selfHosted.forEach((item) => {
-            item.classList.toggle("hide");
+            selfHosted.forEach((item) => {
+                item.classList.toggle("hide");
+            });
+
+            // Change the hosting parameter based on toggle state
+            if (btn.classList.contains("slides")) {
+                // Change hosting parameter to Self-Hosted state
+                urlParams.set('hosting', 'self-hosted');
+                // Update the URL with the new hosting parameter
+                window.history.replaceState({}, '', `${window.location.pathname}?${urlParams}`);
+            } else {
+                // Remove the hosting parameter for Cloud state
+                urlParams.delete('hosting');
+                // Update the URL without the hosting parameter
+                window.history.replaceState({}, '', window.location.pathname);
+            }
         });
-  });
-});
+    });
 </script>
 
 <script>


### PR DESCRIPTION
## Description

Updated the script to ensure that the /pricing URL accurately reflects the state of the toggle. This enhancement allows for easy sharing of the pricing page in the self-hosted state, using the direct link `https://flowfuse.com/pricing?hosting=self-hosted`

## Related Issue(s)

closes #1348

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
