### PR TITLE
policy: CEO underperformance

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -185,11 +185,11 @@ module.exports = function(eleventyConfig) {
     })
 
     eleventyConfig.addFilter("handbookBreadcrumbs", (url) => {
-        const parts = url.split("/");
-        parts.shift();
+        let parts = url.split("/").filter(e => e !== '');
         if (parts[parts.length-1] === "index") {
             parts.pop();
         }
+        
         let path = "";
         return "/"+parts.map(p => {
             let url = `${path}/${p}`;

--- a/src/handbook/peopleops/organization.md
+++ b/src/handbook/peopleops/organization.md
@@ -132,3 +132,6 @@ Directors.
 
 All employees are free to provide feedback or input to the board of directors
 through email. It's adviced not to include the CEO in such an email.
+
+If the board agrees with the CEO underperforming a seperate process will be followed
+tailored to the sitation and the bylaws of FlowFuse.

--- a/src/handbook/peopleops/organization.md
+++ b/src/handbook/peopleops/organization.md
@@ -123,3 +123,12 @@ a PIP. This ensures that a PIP is a genuine change.
 If an employee's performance does not improve, or if they violate the terms of
 their PIP, they may be terminated. Termination will be based on a documented
 pattern of underperformance or unacceptable behavior.
+
+## CEO underperformance
+
+As with all employees in the company the CEO can underperform. Generally speaking
+the CEO does get performance reviews, though these are provided by the Board of
+Directors.
+
+All employees are free to provide feedback or input to the board of directors
+through email. It's adviced not to include the CEO in such an email.

--- a/src/handbook/peopleops/organization.md
+++ b/src/handbook/peopleops/organization.md
@@ -131,7 +131,8 @@ the CEO does get performance reviews, though these are provided by the Board of
 Directors.
 
 All employees are free to provide feedback or input to the board of directors
-through email. It's adviced not to include the CEO in such an email.
+through email. This venue is to be used in all cases where you'd usually also go to someone's manager
+to discuss a reports underperformance. It's advised not to include the CEO in such an email.
 
 If the board agrees with the CEO underperforming a seperate process will be followed
 tailored to the sitation and the bylaws of FlowFuse.


### PR DESCRIPTION
The performance of a CEO is reviewed by the full company, including employees. This change makes it clear, I hope, that there's a process for that too and the CEO doesn't have benefits in their role others don't enjoy with regards to underperformance.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
