### PR TITLE
Add development tools section and note on copilot

### DIFF
--- a/src/handbook/development/index.md
+++ b/src/handbook/development/index.md
@@ -21,6 +21,7 @@ This includes, but is not limited to:
 - [Security Policy](./security.md)
 - [Packaging](./packaging.md) - how we manage repos and npm packaging
 - [Contributing](./contributing.md) - tips on our development style to help get started contributing
+- [Tools](./tools.md) - the tools we use
 
 ## Releases
 

--- a/src/handbook/development/tools.md
+++ b/src/handbook/development/tools.md
@@ -1,0 +1,21 @@
+# Tools
+
+## GitHub
+
+This is at the heart of how we work. Everyone in the company will be made part of the
+[FlowFuse organisation](https://github.com/FlowFuse) as part of their on-boarding
+activities.
+
+## GitHub Copilot
+
+We do not currently provide organisation-wide licenses for GitHub Copilot, but if
+team members wish to purchase an individual license they can do so via their Brex
+card and expense the cost.
+
+As it stands, some of the team already have Copilot access via their Open Source work
+at no cost. To enable it at the organisation level will cost almost twice that of
+individual access; and currently the benefits do not justify that increased cost.
+
+We will keep this under review - if you feel we are missing out by not having
+the organisation level access, please speak to the CTO.
+


### PR DESCRIPTION
## Description
Adds a page to summarise the tools we use as part of our development processes. More to add, but this is a quick iteration to get our position on Copilot documented.