### PR TITLE
Remove video z-index

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -31,7 +31,7 @@ sitemapPriority: 1.0
 {% include "components/divider-flow--default.njk" %}
 
 <div class="flex justify-center">
-    <lite-youtube videoid="eR0P40sxge8" style="background-image: url('images/thumbnail-nick-flowfuse.png'); width: 620px; height: 360px" class="absolute -mt-10 max-w-xs max-h-48 border-4 rounded-md sm:max-w-none sm:max-h-full z-[9999]"></lite-youtube>
+    <lite-youtube videoid="eR0P40sxge8" style="background-image: url('images/thumbnail-nick-flowfuse.png'); width: 620px; height: 360px" class="absolute -mt-10 max-w-xs max-h-48 border-4 rounded-md sm:max-w-none sm:max-h-full"></lite-youtube>
 </div>
 
 <!-- Secondary Content -->


### PR DESCRIPTION
## Description

While trying to get the snow effect behind the video, I added z-index property that is no longer needed, as a result it and can prevent the menu to display properly in some mobile devices.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
