### PR TITLE
Add capability to schedule blog posts

### DIFF
--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -74,7 +74,7 @@ eleventyComputed:
                     <p>Published on: <time value="{{ date | dateToRfc3339 }}">{{ date  | shortDate }}</time></p>
                     <h3 class="mb-3 pt-6 border-t-2">Recommended Articles:</h3>
                     <ul class="ml-6 list-disc">
-                    {% for post in collections.posts | reverse | limit(5) %}
+                    {% for post in collections.livePosts | reverse | limit(5) %}
                         {% if post.data.title != title %}
                             <li class="mb-3"><a href="{{ post.url }}">
                                 {{ post.data.title }}

--- a/src/feed.njk
+++ b/src/feed.njk
@@ -7,9 +7,9 @@ eleventyExcludeFromCollections: true
     <title>{{ site.title }}</title>
     <link href="https://flowfuse.com/blog/index.xml" rel="self"/>
     <link href="https://flowfuse.com/blog"/>
-    <updated>{{ collections.posts | getNewestCollectionItemDate | dateToRfc3339 }}</updated>
+    <updated>{{ collections.livePosts | getNewestCollectionItemDate | dateToRfc3339 }}</updated>
     <id>https://flowfuse.com/blog</id>
-    {%- for post in collections.posts | reverse %}
+    {%- for post in collections.livePosts | reverse %}
     {% set absolutePostUrl %}{{ post.url | url | absoluteUrl("https://flowfuse.com/blog/") }}{% endset %}
     <entry>
         <id>{{ absolutePostUrl }}</id>


### PR DESCRIPTION
## Description

Created a new posts collection.
Added filter to exclude posts with future dates (only in production, so the preview is available in dev_mode).
Added a warning message to scheduled posts.
Changed the cron function to build the site everyday at noon.

## Related Issue(s)

Fixes reverted https://github.com/FlowFuse/website/pull/1439

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
