### PR TITLE
Update script to copy blueprints folder names in small caps

### DIFF
--- a/scripts/copy_blueprints.js
+++ b/scripts/copy_blueprints.js
@@ -9,15 +9,15 @@ async function copyFiles(src, dest) {
     const files = await fs.readdir(src, { withFileTypes: true });
     for (const file of files) {
         if (!file.name.startsWith('.')) {
-            const lowerCaseFileName = file.name.toLowerCase();
             if (file.isDirectory()) {
+                const lowerCaseFileName = file.name.toLowerCase();
                 const newSrc = path.join(src, file.name);
                 const newDest = path.join(dest, lowerCaseFileName);
                 await fs.mkdir(newDest, { recursive: true });
                 await copyFiles(newSrc, newDest);
             } else {
                 const srcFile = path.join(src, file.name);
-                const destFile = path.join(dest, lowerCaseFileName.replace(/readme/, 'index'));
+                const destFile = path.join(dest, file.name.replace(/README/, 'index'));
 
                 if (!file.name.endsWith('.md')) {
                     await fs.copyFile(srcFile, destFile);

--- a/scripts/copy_blueprints.js
+++ b/scripts/copy_blueprints.js
@@ -9,14 +9,15 @@ async function copyFiles(src, dest) {
     const files = await fs.readdir(src, { withFileTypes: true });
     for (const file of files) {
         if (!file.name.startsWith('.')) {
+            const lowerCaseFileName = file.name.toLowerCase();
             if (file.isDirectory()) {
                 const newSrc = path.join(src, file.name);
-                const newDest = path.join(dest, file.name);
+                const newDest = path.join(dest, lowerCaseFileName);
                 await fs.mkdir(newDest, { recursive: true });
                 await copyFiles(newSrc, newDest);
             } else {
                 const srcFile = path.join(src, file.name);
-                const destFile = path.join(dest, file.name.replace(/README/, 'index'));
+                const destFile = path.join(dest, lowerCaseFileName.replace(/readme/, 'index'));
 
                 if (!file.name.endsWith('.md')) {
                     await fs.copyFile(srcFile, destFile);


### PR DESCRIPTION
## Description

To maintain the blueprints URLs in small caps, I've updated the script so it doesn't matter if the folders in the [blueprint-library](https://github.com/FlowFuse/blueprint-library) repository have capital letters in their names.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
