### PR TITLE
Support both redirect frontmatter formats

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -398,7 +398,7 @@ module.exports = function(eleventyConfig) {
                     if (!accumulator[currentValue]) {
                         accumulator[currentValue] = {
                             'name': currentValue,
-                            'url': page.data.redirect || page.url,
+                            'url': page.data.redirect?.to || page.data.redirect || page.url,
                             'order': page.data.navOrder || Number.MAX_SAFE_INTEGER,
                             'children': {}
                         }


### PR DESCRIPTION
_Warning:_ this explanation uses the word `redirect` so many times it will lose all meaning by the time you've read it.

We have two formats for specifying page redirects in frontmatter.

For redirects within the website repo, we use the `redirect.md` file to contain a list of redirects with `from` and `to` properties - these are rendered with the `redirect` layout using the `redirect.to` property - so for those pages, the `redirect` property is an object.

For some docs pages, we have `redirect` as a string, providing the url to redirect to - such as the community support page directing to the forum.

We need to introduce some redirects within the docs pages that use the `redirect` layout - so need to provide `redirect.to`. For this to work, and not break the toc, the toc needs to handle both `redirect.to` and `redirect` properties - which is what this PR does.

Once this is merged, we can reapply the changes reverted here: https://github.com/FlowFuse/flowfuse/pull/2881 and finally fix the redirects in the docs pages.