### PR TITLE
billing: Revert to manual for contracted customers

### DIFF
--- a/src/handbook/customer/sales/engagements.md
+++ b/src/handbook/customer/sales/engagements.md
@@ -26,11 +26,10 @@ countersignature.
 
 ### Steps
 
-1. Move the deal to `Closed Won` in HubSpots Deal overview.
 1. Provide access to the bought resources
    * *Cloud*
-      * Ensure a team on FlowFuse Cloud has been set up by the customer including billing.
-      * Apply the discounts on the stripe customer through Coupons
+      * Ensure a team on FlowFuse Cloud has been set up by the customer
+      * Request the customer team to [enter manual billing mode](/handbook/operations/accounts/#internal-teams-and-contracted-revenue)
       * Have a FlowFuse Admin upgrade the customer to the correct tier
    * *Self-Managed*
       * Generate a [license key](../sales/meetings/poc.md#generating-a-license)
@@ -39,4 +38,5 @@ countersignature.
    * Email the billing (billing@) department with the signed fully
 quote. Also include customer details like their email and if applicable their stripe customer details.
    * Update the Stripe customer to set `CommittedRevenue` to `true` in the Metadata
+1. Move the deal to `Closed Won` in HubSpots Deal overview.
 1. Once all parties have signed, download the completed Order Form and Subscription Agreement, and upload them to the Legal folder in Google Drive.

--- a/src/handbook/operations/accounts.md
+++ b/src/handbook/operations/accounts.md
@@ -14,10 +14,13 @@ All employees of FlowFuse should have a user account on FlowFuse Cloud and be ad
 
 The email address for this account should be their normal @flowfuse.com address and will make use of single-sign on.
 
-### Internal Teams
+### Internal Teams and Contracted revenue
 
-Any teams created by employees must have billing disabled to avoid polluting our revenue tracking. This is achieved by placing
-the team into 'manual' billing mode.
+Any teams created by employees must have billing disabled to avoid polluting our
+revenue tracking. This is achieved by placing the team into 'manual' billing mode.
+
+For customers on contracted revenue, e.g. an annual deal made by an account
+executive, the team too is put into manual billing mode. 
 
 1. Raise a [Change Request](./change.md) with the name of the team and a request to move it to manual billing mode
 2. The request can be actioned by anyone with admin access to the platform. They will have access to admin-only


### PR DESCRIPTION
## Description

Two points:
1. Customers enter manual billing mode
2. A deal is closed only when it's fully processed from the AE side

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
