### PR TITLE
Add CSP to prevent embedding in an iframe

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,9 @@
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    Content-Security-Policy = "frame-ancestors 'none';"
+
 [[redirects]]
 from = "http://flowforge.com/*"
 to = "http://flowfuse.com/:splat"


### PR DESCRIPTION
This sets a Content-Security-Policy header that prevents the site from being embedded in an iframe - one measure to prevent click-jacking on the site.

There are further policies to add to CSP, but starting with this.

This is a work-in-progress - need to review the preview site generated by netlify before pushing for full review.