### PR TITLE
Add CSP headers to 11ty edge function response

### DIFF
--- a/netlify/edge-functions/eleventy-edge.js
+++ b/netlify/edge-functions/eleventy-edge.js
@@ -178,7 +178,10 @@ export default async (request, context) => {
         });
         const distinctId = getDistinctId(context)
         setCookie(context, "ff-distinctid", distinctId, 1);
-        return await edge.handleResponse();
+        const response = await edge.handleResponse();
+        response.headers.set('X-Frame-Options', 'DENY')
+        response.headers.set('Content-Security-Policy', "frame-ancestors 'none';")    
+        return response
     } catch (e) {
         console.error("ERROR", { e });
         return context.next(e);


### PR DESCRIPTION
## Description

This is a second attempt to get custom headers set on the website.

The first attempt #1523 didn't work because we have an edge-function serving the content. This is a documented limitation of setting headers via the `netlify.toml` file.

The workaround is to set the headers explicitly in the edge function - which this PR does.