### PR TITLE
relatedPosts: Sort first by most tags in common

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -297,7 +297,9 @@ module.exports = function(eleventyConfig) {
                 const commonTags = requiredTags?.reduce((count, tag) => count + (post.data.tags?.includes(tag) ? 1 : 0), 0);
                 return { ...post, commonTags };
             })
-            .filter(post => post.url !== page.url && post.commonTags >= requiredTags.length - 1);
+            .filter(post => post.url !== page.url && post.commonTags >= requiredTags.length - 1)
+            .sort((a, b) => b.commonTags - a.commonTags || b.date - a.date)
+            .slice(0, 5);
     });
     
     // Custom async filters

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -65,7 +65,7 @@
                     {% endfor %}
                     <p>Published on: <time value="{{ date | dateToRfc3339 }}">{{ date | shortDate }}</time>
                     </p>
-                    {%- set postsToShow = collections.posts | relatedPosts | reverse | limit(5) -%}
+                    {%- set postsToShow = collections.posts | relatedPosts -%}
                     {%- if postsToShow.length == 0 %}
                         {%- set postsToShow = collections.posts | reverse | limit(5) -%}
                         {%- set heading = "Recommended Articles:" %}


### PR DESCRIPTION
## Description

Updated the filter to display the list of related posts by most common tags in descending order

## Related Issue(s)

https://github.com/FlowFuse/website/pull/1544

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
