### PR TITLE
Update meta description value

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -17,7 +17,7 @@ meta:
 eleventyComputed:
   meta:
     url: "{{ page.url | url | toAbsoluteUrl }}"
-    description: "{{ description }}"
+    description: "{{ meta.description }}"
     modified: "{{ page.date }}"
 ---
 


### PR DESCRIPTION
## Description

Currently, in the Eleventy configuration, the meta description is incorrectly prioritizing the `description` over the `meta.description`. When it doesn't find a `description`, it defaults to the `site.messaging.subtitle`, ignoring the `meta.description` even when it's set. This PR fixes that issue by adjusting the priority order. Now, it first looks for `meta.description`, then `description`, and lastly falls back to `site.messaging.subtitle` if neither are provided.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
