### PR TITLE
Deny cookies by default only in some regions

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -112,6 +112,27 @@ eleventyComputed:
     {% set js %}{% include "base.js" %}{% endset %}
     <script>{{ js | jsmin | safe }}</script>
     {% jsonLdScript meta, type, tags %}
+
+    {%- if not DEV_MODE -%}
+    <!-- Google tag (gtag.js) -->
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+
+        // Set cookies to denied by default in EU countries, California, Brazil, Canada and Australia
+        gtag('consent', 'default', {
+            'ad_storage': 'denied',
+            'analytics_storage': 'denied',
+            'ad_user_data': 'denied',
+            'ad_personalization': 'denied',
+            'region': ['AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR', 'DE', 'GR', 'HU', 'IE', 'IT', 'LV', 'LT', 'LU', 'MT', 'NL', 'PL', 'PT', 'RO', 'SK', 'SI', 'SE', 'GB', 'US-CA', 'BR', 'CA', 'AU']
+        });
+
+        gtag('js', new Date());
+        gtag('config', 'G-2ZH9W82QL8');
+    </script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2ZH9W82QL8"></script>
+    {%- endif -%}
 </head>
 <body class="ff-website leading-normal tracking-normal gradient text-gray-500 min-h-screen flex flex-col" style="">
     <div class="flex-grow base">
@@ -394,22 +415,17 @@ eleventyComputed:
     }
 </script>
 
-<!-- Google tag (gtag.js) -->
-<script async type="text/plain" data-category="analytics" src="https://www.googletagmanager.com/gtag/js?id=G-2ZH9W82QL8"></script>
+<!-- gtag - cookie banner update -->
 <script type="text/plain" data-category="analytics">
-window.dataLayer = window.dataLayer || [];
-function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
-gtag('config', 'G-2ZH9W82QL8');
-gtag('consent', 'update', {
-    'analytics_storage': 'granted'
-});
+    gtag('consent', 'update', {
+        'analytics_storage': 'granted'
+    });
 </script>
 
 <script type="text/plain" data-category="!analytics">
-gtag('consent', 'update', {
-    'analytics_storage': 'denied'
-});
+    gtag('consent', 'update', {
+        'analytics_storage': 'denied'
+    });
 </script>
 
 <script type="text/plain" data-category="ads">

--- a/src/js/cookieconsent-config.js
+++ b/src/js/cookieconsent-config.js
@@ -14,6 +14,54 @@ CookieConsent.run({
         }
     },
 
+    onConsent: function(){
+        if(CookieConsent.acceptedCategory('analytics')){
+            // Enable Google Analytics
+            gtag('consent', 'update', {
+                'analytics_storage': 'granted'
+            });
+            // Send event to Google Analytics
+            gtag('event', 'cookie_consent', {
+                'event_category': 'analytics',
+                'event_label': 'accepted'
+            });
+        }else{
+            // Disable Google Analytics
+            gtag('consent', 'update', {
+                'analytics_storage': 'denied'
+            });
+            // Send event to Google Analytics
+            gtag('event', 'cookie_consent', {
+                'event_category': 'analytics',
+                'event_label': 'denied'
+            });
+        }
+
+        if(CookieConsent.acceptedCategory('ads')){
+            gtag('consent', 'update', {
+                'ad_storage': 'granted',
+                'ad_user_data': 'granted',
+                'ad_personalization': 'granted'
+            });
+            // Send event to Google Analytics
+            gtag('event', 'cookie_consent', {
+                'event_category': 'ads',
+                'event_label': 'accepted'
+            });
+        }else{
+            gtag('consent', 'update', {
+                'ad_storage': 'denied',
+                'ad_user_data': 'denied',
+                'ad_personalization': 'denied'
+            });
+            // Send event to Google Analytics
+            gtag('event', 'cookie_consent', {
+                'event_category': 'ads',
+                'event_label': 'denied'
+            });
+        }
+    },
+    
     onChange: function({changedCategories}){
         if(changedCategories.includes('analytics')){
             if(CookieConsent.acceptedCategory('analytics')){
@@ -21,10 +69,20 @@ CookieConsent.run({
                 gtag('consent', 'update', {
                     'analytics_storage': 'granted'
                 });
+                // Send event to Google Analytics
+                gtag('event', 'cookie_consent', {
+                    'event_category': 'analytics',
+                    'event_label': 'accepted'
+                });
             }else{
                 // Disable Google Analytics
                 gtag('consent', 'update', {
                     'analytics_storage': 'denied'
+                });
+                // Send event to Google Analytics
+                gtag('event', 'cookie_consent', {
+                    'event_category': 'analytics',
+                    'event_label': 'denied'
                 });
             }
         }
@@ -36,11 +94,21 @@ CookieConsent.run({
                     'ad_user_data': 'granted',
                     'ad_personalization': 'granted'
                 });
+                // Send event to Google Analytics
+                gtag('event', 'cookie_consent', {
+                    'event_category': 'ads',
+                    'event_label': 'accepted'
+                });
             }else{
                 gtag('consent', 'update', {
                     'ad_storage': 'denied',
                     'ad_user_data': 'denied',
                     'ad_personalization': 'denied'
+                });
+                // Send event to Google Analytics
+                gtag('event', 'cookie_consent', {
+                    'event_category': 'ads',
+                    'event_label': 'denied'
                 });
             }
         }
@@ -53,6 +121,7 @@ CookieConsent.run({
         analytics: {},
         ads: {}
     },
+    
     language: {
         default: "en",
         autoDetect: "browser",


### PR DESCRIPTION
## Description

Set conset default by region according to https://developers.google.com/tag-platform/security/guides/consent#region-specific-behavior

I used this tool to check if it was working: https://chromewebstore.google.com/detail/tag-assistant-companion/jmekfmbnaedfebfnmakmokmlfpblbfdm

The tool showed an error at first because the default behaviour must be set before the script loads anything else, and looking at one of their [examples](https://github.com/googleanalytics/ga4-tutorials/blob/main/src/public/layouts/layout.eta) I realised that it had to be in the header. That solved it.

Also, the region led behaviour only works for google cookies, the cookie banner will still pop up for everyone, but for the regions included in the script, nothing will be tracked until they grant their consent, and for the rest, since no default value is set, google considers it granted, although they will still have the option to deny it.

I also added a `cookie_consent` event to see how many users are denying the consent, I've seen it in the tag assistant tool, but it isn't showing yet in GA, it might take up to 24h.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
