### PR TITLE
Update Grafana link in observability.md

### DIFF
--- a/src/handbook/development/ops/observability.md
+++ b/src/handbook/development/ops/observability.md
@@ -27,7 +27,7 @@ Grafana is a popular open-source platform for creating, sharing, and managing da
 * Customizable Dashboards: Grafana offers extensive customization options, enabling you to build tailored dashboards that provide the insights you need.
 * Alerting: You can set up alerting rules in Grafana to proactively monitor your systems based on your metrics and logs data.
 
-[Link](https://grafana.flowfuse.com)
+[Link](https://insights.flowfuse.com)
 
 ### AWS CloudWatch
 
@@ -43,6 +43,6 @@ and emailed to the CTO.
 
 ## Alerting
 
-Any [alerts](https://grafana.flowfuse.com/alerting/list) that have been configured
+Any [alerts](https://insights.flowfuse.com/alerting/list) that have been configured
 in Grafana will post to the `#ops-alerts` channel in slack. The alert, where appropriate,
 will include a link to the relevant section of the [Incident Playbook](https://docs.google.com/document/d/1NMPWEFgHkVNN7RqHXUgijEGdNwZH-SlaAspOQr9Vg9k/edit#heading=h.a7jq4bkz66hv).


### PR DESCRIPTION
## Description

This pull request updates the Grafana link in the observability.md file from "https://grafana.flowfuse.com" to "https://insights.flowfuse.com". This change ensures that the link points to the correct Grafana instance.

## Related Issue(s)

https://github.com/FlowFuse/CloudProject/pull/347

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated