### PR TITLE
Add missing space on about page

### DIFF
--- a/src/about.njk
+++ b/src/about.njk
@@ -84,7 +84,7 @@ eleventyComputed:
                 </div>
                 <div class="md:w-[72%] text-justify">
                     <p>We believe strongly that <span class="font-medium">Open Source is the heart of everything we
-                        do</span>influencing not just our contributions to Node-RED but also the development of FlowFuse. We
+                        do</span> influencing not just our contributions to Node-RED but also the development of FlowFuse. We
                         strive to be good Open Source citizens and to empower the community to get involved.</p>
                 </div>
             </div>


### PR DESCRIPTION
## Description

Spotted a missing space on the about page.
<img width="313" alt="image" src="https://github.com/FlowFuse/website/assets/51083/22eae115-a333-481d-9923-957bc068d887">
