### PR TITLE
Add data-nosnippet to numbers in /pricing

### DIFF
--- a/src/pricing.njk
+++ b/src/pricing.njk
@@ -97,39 +97,41 @@ hubspot:
                             </div>
                             {% endmacro %}
                             {{ team() }}
-                            <!-- Slider -->
-                            <ul class="font-extralight text-sm leading-7 mt-6 w-full flex flex-row justify-between text-gray-400">
-                                <li>Instances</li>
-                                <li id="team-monthly-value" class="value">5</li>
-                            </ul>
-                            <div class="range contentMonthly">
-                                <input type="range" min="5" max="355" value="5" id="team-monthly-slider" class="transition duration-1000" step="5"/>
-                            </div>
-                            <!-- Price -->
-                            <div id="team-m-original-div" class="mt-3 mb-6 flex flex-row flex-wrap w-full gap-x-2">
-                                <div class="text-left flex flex-row">
-                                    <div class="w-16 mr-1">
-                                        <h2 class="self-end">
-                                            <span class="align-top text-sm leading-7">$</span><span
-                                                id="team-monthly-price-int" class="align-top">20</span><span
-                                                id="team-monthly-price-dec" class="align-top text-sm leading-7">83</span>
-                                        </h2>
-                                    </div>
-                                    <div class="pl-2 text-sm leading-4 text-left self-end pb-1">
-                                        <note id="team-monthly-price-note" class="note text-teal-100 text-xs">/instance a
-                                            month <br>Billed monthly at $300<br \></note>
+                            <div data-nosnippet>
+                                <!-- Slider -->
+                                <ul class="font-extralight text-sm leading-7 mt-6 w-full flex flex-row justify-between text-gray-400">
+                                    <li>Instances</li>
+                                    <li id="team-monthly-value" class="value">5</li>
+                                </ul>
+                                <div class="range contentMonthly">
+                                    <input type="range" min="5" max="355" value="5" id="team-monthly-slider" class="transition duration-1000" step="5"/>
+                                </div>
+                                <!-- Price -->
+                                <div id="team-m-original-div" class="mt-3 mb-6 flex flex-row flex-wrap w-full gap-x-2">
+                                    <div class="text-left flex flex-row">
+                                        <div class="w-16 mr-1">
+                                            <h2 class="self-end">
+                                                <span class="align-top text-sm leading-7">$</span><span
+                                                    id="team-monthly-price-int" class="align-top">20</span><span
+                                                    id="team-monthly-price-dec" class="align-top text-sm leading-7">83</span>
+                                            </h2>
+                                        </div>
+                                        <div class="pl-2 text-sm leading-4 text-left self-end pb-1">
+                                            <note id="team-monthly-price-note" class="note text-teal-100 text-xs">/instance a
+                                                month <br>Billed monthly at $300<br \></note>
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
-                            <div id="team-m-alternate-div" class="hidden mt-3 mb-6 flex flex-row flex-wrap w-full gap-x-2">
-                                <div class="text-left flex flex-row">
-                                    <div class="w-16 mr-1">
-                                        <h2 class="self-end">
-                                            <span id="team-monthly-price-int" class="align-top text-6xl leading-9">∞</span>
-                                        </h2>
-                                    </div>
-                                    <div class="pl-2 text-sm leading-4 text-left self-end pb-1">
-                                        <note id="team-monthly-price-note" class="note text-teal-100 text-xs">instances <br>Billed monthly at <span class="font-semibold">$3,200.00</span><br \></note>
+                                <div id="team-m-alternate-div" class="hidden mt-3 mb-6 flex flex-row flex-wrap w-full gap-x-2">
+                                    <div class="text-left flex flex-row">
+                                        <div class="w-16 mr-1">
+                                            <h2 class="self-end">
+                                                <span id="team-monthly-price-int" class="align-top text-6xl leading-9">∞</span>
+                                            </h2>
+                                        </div>
+                                        <div class="pl-2 text-sm leading-4 text-left self-end pb-1">
+                                            <note id="team-monthly-price-note" class="note text-teal-100 text-xs">instances <br>Billed monthly at <span class="font-semibold">$3,200.00</span><br \></note>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -164,35 +166,37 @@ hubspot:
                             </div>
                             {% endmacro %}
                             {{ enterprise() }}
-                            <!-- Slider -->
-                            <ul class="font-extralight text-sm leading-7 mt-6 w-full flex flex-row justify-between text-gray-400">
-                                <li>Instances</li>
-                                <li id="enterprise-monthly-value" class="value">10</li>
-                            </ul>
-                            <div class="range contentMonthly">
-                                <input type="range" min="10" max="510" value="10" id="enterprise-monthly-slider" class="transition duration-1000" step="10" />
-                            </div>
-                            <!-- Price -->
-                            <div id="enterprise-m-original-div" class="mt-3 mb-6 flex flex-row flex-wrap w-full gap-x-2">
-                                <div class="text-left flex flex-row">
-                                    <div class="w-16 mr-1">
-                                        <h2 class="self-end">
-                                            <span class="align-top text-sm leading-7">$</span><span
-                                                id="enterprise-monthly-price-int" class="align-top">20</span><span
-                                                id="enterprise-monthly-price-dec" class="align-top text-sm leading-7">83</span>
-                                        </h2>
-                                    </div>
-                                    <div class="pl-2 text-sm leading-4 text-left self-end pb-1">
-                                        <note id="enterprise-monthly-price-note" class="note text-teal-100 text-xs">/instance a
-                                            month <br>Billed monthly at $600<br \></note>
+                            <div data-nosnippet>
+                                <!-- Slider -->
+                                <ul class="font-extralight text-sm leading-7 mt-6 w-full flex flex-row justify-between text-gray-400">
+                                    <li>Instances</li>
+                                    <li id="enterprise-monthly-value" class="value">10</li>
+                                </ul>
+                                <div class="range contentMonthly">
+                                    <input type="range" min="10" max="510" value="10" id="enterprise-monthly-slider" class="transition duration-1000" step="10" />
+                                </div>
+                                <!-- Price -->
+                                <div id="enterprise-m-original-div" class="mt-3 mb-6 flex flex-row flex-wrap w-full gap-x-2">
+                                    <div class="text-left flex flex-row">
+                                        <div class="w-16 mr-1">
+                                            <h2 class="self-end">
+                                                <span class="align-top text-sm leading-7">$</span><span
+                                                    id="enterprise-monthly-price-int" class="align-top">20</span><span
+                                                    id="enterprise-monthly-price-dec" class="align-top text-sm leading-7">83</span>
+                                            </h2>
+                                        </div>
+                                        <div class="pl-2 text-sm leading-4 text-left self-end pb-1">
+                                            <note id="enterprise-monthly-price-note" class="note text-teal-100 text-xs">/instance a
+                                                month <br>Billed monthly at $600<br \></note>
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
-                            <div id="enterprise-m-alternate-div" class="hidden mt-3 mb-6 flex flex-row flex-wrap w-full gap-x-2">
-                                <div class="text-left">
-                                    <h2 class="self-end">
-                                        <span class="align-top">Let's talk</span>
-                                    </h2>
+                                <div id="enterprise-m-alternate-div" class="hidden mt-3 mb-6 flex flex-row flex-wrap w-full gap-x-2">
+                                    <div class="text-left">
+                                        <h2 class="self-end">
+                                            <span class="align-top">Let's talk</span>
+                                        </h2>
+                                    </div>
                                 </div>
                             </div>
                             <a class="md:self-end ff-btn ff-btn--primary uppercase align-baseline w-full"
@@ -210,39 +214,41 @@ hubspot:
                     <div class="pricing-tile md:h-full">
                         <div class="pricing-tile-background pb-6 md:grid flex-col">
                             {{ team() }}
-                            <!-- Slider -->
-                            <ul class="font-extralight text-sm leading-7 mt-6 w-full flex flex-row justify-between text-gray-400">
-                                <li>Instances</li>
-                                <li id="team-annual-value" class="value">5</li>
-                            </ul>
-                            <div class="range contentAnnual hide">
-                                <input type="range" min="5" max="355" value="5" id="team-annual-slider" class="transition duration-1000" step="5"/>
-                            </div>
-                            <!-- Price -->
-                            <div id="team-original-div" class="mt-3 mb-6 flex flex-row flex-wrap w-full gap-x-2">
-                                <div class="text-left flex flex-row">
-                                    <div class="w-16 mr-1">
-                                        <h2 class="self-end">
-                                            <span class="align-top text-sm leading-7">$</span><span
-                                                id="team-annual-price-int" class="align-top">20</span><span
-                                                id="team-annual-price-dec" class="align-top text-sm leading-7">83</span>
-                                        </h2>
-                                    </div>
-                                    <div class="pl-2 text-sm leading-4 text-left self-end pb-1">
-                                        <note id="team-annual-price-note" class="note text-teal-100 text-xs">/instance a
-                                            month <br>Billed annually at $250<br \></note>
+                            <div data-nosnippet>
+                                <!-- Slider -->
+                                <ul class="font-extralight text-sm leading-7 mt-6 w-full flex flex-row justify-between text-gray-400">
+                                    <li>Instances</li>
+                                    <li id="team-annual-value" class="value">5</li>
+                                </ul>
+                                <div class="range contentAnnual hide">
+                                    <input type="range" min="5" max="355" value="5" id="team-annual-slider" class="transition duration-1000" step="5"/>
+                                </div>
+                                <!-- Price -->
+                                <div id="team-original-div" class="mt-3 mb-6 flex flex-row flex-wrap w-full gap-x-2">
+                                    <div class="text-left flex flex-row">
+                                        <div class="w-16 mr-1">
+                                            <h2 class="self-end">
+                                                <span class="align-top text-sm leading-7">$</span><span
+                                                    id="team-annual-price-int" class="align-top">20</span><span
+                                                    id="team-annual-price-dec" class="align-top text-sm leading-7">83</span>
+                                            </h2>
+                                        </div>
+                                        <div class="pl-2 text-sm leading-4 text-left self-end pb-1">
+                                            <note id="team-annual-price-note" class="note text-teal-100 text-xs">/instance a
+                                                month <br>Billed annually at $250<br \></note>
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
-                            <div id="team-alternate-div" class="hidden mt-3 mb-6 flex flex-row flex-wrap w-full gap-x-2">
-                                <div class="text-left flex flex-row">
-                                    <div class="w-16 mr-1">
-                                        <h2 class="self-end">
-                                            <span id="team-annual-price-int" class="align-top text-6xl leading-9">∞</span>
-                                        </h2>
-                                    </div>
-                                    <div class="pl-2 text-sm leading-4 text-left self-end pb-1">
-                                        <note id="team-annual-price-note" class="note text-teal-100 text-xs">instances <br>Annual bill. <span class="font-semibold">$2,708.50</span>/month<br \></note>
+                                <div id="team-alternate-div" class="hidden mt-3 mb-6 flex flex-row flex-wrap w-full gap-x-2">
+                                    <div class="text-left flex flex-row">
+                                        <div class="w-16 mr-1">
+                                            <h2 class="self-end">
+                                                <span id="team-annual-price-int" class="align-top text-6xl leading-9">∞</span>
+                                            </h2>
+                                        </div>
+                                        <div class="pl-2 text-sm leading-4 text-left self-end pb-1">
+                                            <note id="team-annual-price-note" class="note text-teal-100 text-xs">instances <br>Annual bill. <span class="font-semibold">$2,708.50</span>/month<br \></note>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -256,35 +262,37 @@ hubspot:
                     <div class="pricing-tile md:h-full">
                         <div class="pricing-tile-background pb-6 md:grid flex-col">
                             {{ enterprise() }}
-                            <!-- Slider -->
-                            <ul class="font-extralight text-sm leading-7 mt-6 w-full flex flex-row justify-between text-gray-400">
-                                <li>Instances</li>
-                                <li id="enterprise-annual-value" class="value">10</li>
-                            </ul>
-                            <div class="range contentAnnual hide">
-                                <input type="range" min="10" max="510" value="10" id="enterprise-annual-slider" class="transition duration-1000" step="10"/>
-                            </div>
-                            <!-- Price -->
-                            <div id="enterprise-original-div" class="mt-3 mb-6 flex flex-row flex-wrap w-full gap-x-2">
-                                <div class="text-left flex flex-row">
-                                    <div class="w-16 mr-1">
-                                        <h2 class="self-end">
-                                            <span class="align-top text-sm leading-7">$</span><span
-                                                id="enterprise-annual-price-int" class="align-top">20</span><span
-                                                id="enterprise-annual-price-dec" class="align-top text-sm leading-7">83</span>
-                                        </h2>
-                                    </div>
-                                    <div class="pl-2 text-sm leading-4 text-left self-end pb-1">
-                                        <note id="enterprise-annual-price-note" class="note text-teal-100 text-xs">/instance a
-                                            month <br>Billed annually at $500<br \></note>
+                            <div data-nosnippet>
+                                <!-- Slider -->
+                                <ul class="font-extralight text-sm leading-7 mt-6 w-full flex flex-row justify-between text-gray-400">
+                                    <li>Instances</li>
+                                    <li id="enterprise-annual-value" class="value">10</li>
+                                </ul>
+                                <div class="range contentAnnual hide">
+                                    <input type="range" min="10" max="510" value="10" id="enterprise-annual-slider" class="transition duration-1000" step="10"/>
+                                </div>
+                                <!-- Price -->
+                                <div id="enterprise-original-div" class="mt-3 mb-6 flex flex-row flex-wrap w-full gap-x-2">
+                                    <div class="text-left flex flex-row">
+                                        <div class="w-16 mr-1">
+                                            <h2 class="self-end">
+                                                <span class="align-top text-sm leading-7">$</span><span
+                                                    id="enterprise-annual-price-int" class="align-top">20</span><span
+                                                    id="enterprise-annual-price-dec" class="align-top text-sm leading-7">83</span>
+                                            </h2>
+                                        </div>
+                                        <div class="pl-2 text-sm leading-4 text-left self-end pb-1">
+                                            <note id="enterprise-annual-price-note" class="note text-teal-100 text-xs">/instance a
+                                                month <br>Billed annually at $500<br \></note>
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
-                            <div id="enterprise-alternate-div" class="hidden mt-3 mb-6 flex flex-row flex-wrap w-full gap-x-2">
-                                <div class="text-left">
-                                    <h2 class="self-end">
-                                        <span class="align-top">Let's talk</span>
-                                    </h2>
+                                <div id="enterprise-alternate-div" class="hidden mt-3 mb-6 flex flex-row flex-wrap w-full gap-x-2">
+                                    <div class="text-left">
+                                        <h2 class="self-end">
+                                            <span class="align-top">Let's talk</span>
+                                        </h2>
+                                    </div>
                                 </div>
                             </div>
                             <a class="md:self-end ff-btn ff-btn--primary uppercase align-baseline w-full"


### PR DESCRIPTION
## Description

![image](https://github.com/FlowFuse/website/assets/129537638/e284ca99-79b9-4eda-a25e-675aad01f3ff)
Google is picking up the numbers as the description instead of the meta description. 
This should fix it according to https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
