### PR TITLE
Improve /pricing meta description

### DIFF
--- a/src/pricing.njk
+++ b/src/pricing.njk
@@ -3,7 +3,7 @@ align: center
 layout: layouts/page.njk
 sitemapPriority: 0.90
 meta:
-    description: Find out how much it costs to use FlowFuse.
+    description: Discover the pricing options for FlowFuse, featuring Starter, Team, and Enterprise plans. Benefit from volume discounts on Team and Enterprise plans. Get started with a 14-day trial period for the Starter plan.
     keywords: FlowFuse pricing, Cost, Plans, Features, Cloud, Self-hosted
 hubspot:
     script: "hubspot/hs-form.njk"


### PR DESCRIPTION
## Description

- Google isn't rendering the meta description as the description for the page in the search results:

<img width="616" alt="Screenshot 2024-02-29 at 10 56 05" src="https://github.com/FlowFuse/website/assets/129537638/8f89e8f9-6502-463c-a0bb-1ed6c8c6899f">

- Apparently, if Google considers that the meta description is not good enough, it'll pick something else from the page as the description.

- I've looked for an online tool to check it, found https://seositecheckup.com/analysis ad it says:
<img width="992" alt="Screenshot 2024-02-29 at 10 56 15" src="https://github.com/FlowFuse/website/assets/129537638/266aba1c-e2aa-4959-a752-398d6a0d24b8">

- I made it longer, but open to suggestions to make it more inviting maybe?

## Related Issue(s)

https://github.com/FlowFuse/website/pull/1717

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
