### PR TITLE
fix: CTA download slides

### DIFF
--- a/src/_includes/hubspot/hs-form.njk
+++ b/src/_includes/hubspot/hs-form.njk
@@ -3,7 +3,7 @@
         hbspt.forms.create({
             region: "eu1",
             portalId: "26586079",
-            formId: "{{ hubspot.formId }}",
+            formId: "{{ formId or hubspot.formId }}",
             onFormSubmit: function ($form) {
                 capture('{{ cta or hubspot.cta }}', {
                     'page': '{{ hubspot.reference or title }}'


### PR DESCRIPTION
Currently the CTA to download slides reads "Register today".

The page wasn't showing the correct CTA, "Download Slides" on past webinars with slides attached. This was due to the code checking only one property, not the one the past webinars set.

## Related Issue(s)

Spotted by @Hasmin-AC in https://github.com/FlowFuse/website/pull/1759#issuecomment-1981709879

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
