### PR TITLE
Fix Register Today color in webinar banner

### DIFF
--- a/src/_includes/components/events-banner.njk
+++ b/src/_includes/components/events-banner.njk
@@ -9,7 +9,7 @@
         Building Unified Namespace using Node-RED and MQTT
     </span>
     <span class="hidden sm:block">-</span>
-    <span class="flex items-center gap-1 font-medium underline text-blue-600 hover:text-blue-900 hover:stroke-blue-900" >
+    <span class="flex items-center gap-1 font-medium underline" >
         Register Today {% include "components/icons/chevron-right-sm.svg" %}
     </span>
 </a>


### PR DESCRIPTION
Quick fix for #1762 

Removes the separate colours used for the 'Register Today' text - the whole banner is already clickable.

<img width="658" alt="image" src="https://github.com/FlowFuse/website/assets/51083/88a15f5e-429b-4194-a9bf-790c7f17e52b">
