### PR TITLE
Update ebook title source

### DIFF
--- a/src/_includes/layouts/ebook.njk
+++ b/src/_includes/layouts/ebook.njk
@@ -8,7 +8,7 @@ hubspot:
         <label class="text-red-600">eBook</label>
         <div class="md:flex md:flex-row gap-6">
             <div class="text-left md:w-1/2">
-                <h1>{{ title | safe }}</h1>
+                <h1>{{ contentTitle | safe }}</h1>
             </div>
             <div class="ff-prose md:w-1/2">
                 <div class="prose mt-3">

--- a/src/ebooks/beginner-guide-to-a-professional-nodered.md
+++ b/src/ebooks/beginner-guide-to-a-professional-nodered.md
@@ -1,5 +1,5 @@
 ---
-title: The Ultimate Beginner Guide to a Professional <span class="inline-block">Node-RED</span>
+contentTitle: The Ultimate Beginner Guide to a Professional <span class="inline-block">Node-RED</span>
 image: /images/ebooks/beginner-guide-node-red.png
 meta:
   title: The Ultimate Beginner guide to a Professional Node-RED


### PR DESCRIPTION
## Description

When the title is set, the meta.title isn't recognized as such; it's overwritten by the title property. I've changed the property to contentTitle to ensure that meta.title is recognized as both the Open Graph (og) and page title.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
