### PR TITLE
Fix blog articles only showing the default image

### DIFF
--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -48,7 +48,7 @@
                             allowfullscreen></iframe>
                         {% else %}
                             <div class="w-full h-auto">
-                                {% tileImage item, "./images/og-blog.jpg", "Image with logo and the slogan: Elevate Node-RED with Flowfuse", 560 %}
+                                {% tileImage null, image, "./images/og-blog.jpg", "Image with logo and the slogan: Elevate Node-RED with Flowfuse", 560 %}
                             </div>
                         {% endif %}
                     </div>


### PR DESCRIPTION
## Description

In the previous implementation, the tileImage shortcode was designed to work within a loop, extracting the item.data.image property from an item object. To make it work outside of a loop, such as in an individual blog post template where the image is passed directly, I've adjusted the shortcode. Now, if the item parameter is null, the shortcode will use the image parameter directly. This allows the tileImage shortcode to function properly in both scenarios.

## Related Issue(s)

https://github.com/FlowFuse/website/pull/1798

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
