### PR TITLE
Fix blog sticky position

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -15,7 +15,6 @@
 
 html, body {
     font-size: 16px;
-    overflow-x: hidden;
 }
 
 *{
@@ -672,7 +671,7 @@ h4:hover .header-anchor {
     opacity: 0;
     visibility: hidden;
     position: absolute;
-    width: 100%;
+    width: 0%;
     transform: translateX(20px);
 }
 
@@ -681,6 +680,7 @@ h4:hover .header-anchor {
     opacity: 1;
     visibility: visible;
     position: relative;
+    width: 100%;
     transform: translateX(0);
 }
 /*


### PR DESCRIPTION
## Description

The reason the sticky class wasn't working is that an `overflow-x: hidden` class was added to the `body` to prevent extra space from being created on the right. Initially, I thought this was related to the gradient applied to the background, which affects all pages. However, it was actually related to the animated section on the `/home` and `/features` pages. This issue has been fixed in this PR.

## Related Issue(s)

closes [#1830](https://github.com/FlowFuse/website/issues/1830)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
