### PR TITLE
Handbook: Add steps to uncomment events banner

### DIFF
--- a/src/handbook/customer/marketing/website.md
+++ b/src/handbook/customer/marketing/website.md
@@ -21,6 +21,11 @@ Once you have those, you can update the [following file](https://github.com/Flow
 
 Update the `href=""` value of the `<a>` tag to update the Event URL, and change the title inside the middle `<span>`
 
+You should also ensure that the banner is not disabled in [this file](https://github.com/FlowFuse/website/blob/main/src/_includes/layouts/base.njk). If it is, it would look like this: 
+`{% raw %}
+{# {% include "../components/events-banner.njk" %} #}
+{% endraw %}`. Please remove the comment symbols `{#` and `#}` to enable the banner.
+
 ## Images
 
 All images on the website, whether part of the blog or otherwise, are run though an [image pipeline](https://github.com/FlowFuse/website/blob/main/lib/image-handler.js), that compresses, resizes and converts the images to reduce file size and improve page loading speed.


### PR DESCRIPTION
## Description

The instructions for updating the events banner didn't contemplate the possibility of it being commented out. I added a step to check it and how to enable it.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
