### PR TITLE
Content Fix - Mark content as raw & add syntax highlighting

### DIFF
--- a/src/blog/2024/04/displaying-logged-in-users-on-dashboard.md
+++ b/src/blog/2024/04/displaying-logged-in-users-on-dashboard.md
@@ -82,15 +82,15 @@ To display user information on the dashboard we will use Vue’s [Teleport](http
 2. Click on that node, and select type as “Widget (Ui-Scoped)”. ( this allows us to render this ui-template at ui scoped which means I will not required to add separate ui-templates for different pages )
 3. Copy the below vue snippet and paste that into the ui-template.
 
-```
+```html
 <template>
     <!-- Teleporting user info to #app-bar-actions, which is the ID of the action bars' right corners area -->
     <Teleport v-if="loaded" to="#app-bar-actions">
         <div class="user-info">
             <!-- Displaying user image -->
             <img :src="setup.socketio.auth.user.image" />
-            <!-- Greeting the user -->
-            <span>Hi, {{ setup.socketio.auth.user.name }}</span>
+            <!-- Greeting the user -->{% raw %}
+            <span>Hi, {{ setup.socketio.auth.user.name }}</span>{% endraw %}
         </div>
     </Teleport>
 </template>


### PR DESCRIPTION
## Description

Just had someone email me saying the example doesn't work in the latest Dashboard article, issue was nunjucks compiling the `{{ }}` and removing it from the resulting article. This marks that content as `raw` which tells Nunjucks not to process it.

### Before:

<img width="618" alt="Screenshot 2024-04-05 at 09 03 30" src="https://github.com/FlowFuse/website/assets/99246719/db98ada3-ddcb-438a-8d37-61d18bb4ce45">

### After:

<img width="646" alt="Screenshot 2024-04-05 at 09 03 57" src="https://github.com/FlowFuse/website/assets/99246719/fbe0efb8-487f-4ba7-8e99-c0f5b90d842c">

## Related Issue(s)

Fixes issues #1889 