### PR TITLE
Training clarification on pricing page tooltip

### DIFF
--- a/src/_includes/feature_lists/cloud.njk
+++ b/src/_includes/feature_lists/cloud.njk
@@ -138,7 +138,7 @@
         {
             label: "Training",
             values: [null, 'check', 'check'],
-            info: "<p>Expert training session in both Node-RED and FlowFuse to ensure your whole team gets the most out of it.</p>"
+            info: "<p>Expert training on FlowFuse and Node-RED migration to ensure your whole team is able to hit the ground running.</p>"
         }]
     }, {
         label: "Subscription",

--- a/src/_includes/feature_lists/self-hosted.njk
+++ b/src/_includes/feature_lists/self-hosted.njk
@@ -125,7 +125,7 @@
         {
             label: "Training",
             values: [null, 'check', 'check'],
-            info: "<p>Expert training session in both Node-RED and FlowFuse to ensure your whole team gets the most out of it.</p>"
+            info: "<p>Expert training on FlowFuse and Node-RED migration to ensure your whole team is able to hit the ground running.</p>"
         }]
     }, {
         label: "Subscription",


### PR DESCRIPTION
## Description

Our pricing today reads that training on Node-RED and FlowFuse is included in the Team and Enterprise tier, when this is not the case. Suggesting updates to clarify what is included (flow migration and onboarding to the FlowFuse platform), rather than flow development/review.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [x] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
