### PR TITLE
fix: Core nodes missing use-case

### DIFF
--- a/src/_includes/core-node-docs.njk
+++ b/src/_includes/core-node-docs.njk
@@ -1,4 +1,4 @@
-{% set templateFile = "src/_includes/core-nodes/" + node.name + "-use-case.md" %}
+{% set templateFile = "src/_includes/core-nodes/" + node.name | lower + "-use-case.md" %}
 <h1>{{ node.name }}</h1>
 
 {% if templateFile | templateExists %}


### PR DESCRIPTION
When this change is deployed the use cases for each core nodes will be deployed both on filesystems with capital letter sensitivity for filenames and the ones without.

This change is required as my laptop doesn't care about capital letters and the node.name includes them. As such the use case files were found and rendered. GitHub actions runs a filesystem that's not capital letter 'friendly' and thus didn't include the docs.


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
