### PR TITLE
Add thank-you page template and pages

### DIFF
--- a/src/_includes/hubspot/hs-book-demo.njk
+++ b/src/_includes/hubspot/hs-book-demo.njk
@@ -1,2 +1,0 @@
-<div class="meetings-iframe-container -mb-20 md:-mb-6" data-src="https://meetings-eu1.hubspot.com/flowfuse/book-a-demo-call?embed=true"></div>
-<script type="text/javascript" src="https://static.hsappstatic.net/MeetingsEmbed/ex/MeetingsEmbedCode.js"></script>

--- a/src/_includes/hubspot/hs-book-meeting.njk
+++ b/src/_includes/hubspot/hs-book-meeting.njk
@@ -1,0 +1,2 @@
+<div class="meetings-iframe-container -mb-20 md:-mb-6" data-src="{{ hubspot.dataSrc }}"></div>
+<script type="text/javascript" src="https://static.hsappstatic.net/MeetingsEmbed/ex/MeetingsEmbedCode.js"></script>

--- a/src/_includes/layouts/thank-you.njk
+++ b/src/_includes/layouts/thank-you.njk
@@ -1,0 +1,53 @@
+---
+layout: layouts/page.njk
+---
+<div class="flex flex-col max-w-5xl mx-auto gap-x-10 px-6">
+  <div class="{% if downloadFollowUp %}md:grid md:grid-rows-4 md:grid-cols-2 md:grid-flow-rows md:gap-x-6{% else %}w-full{% endif %}">
+    {% if downloadFollowUp %}
+    <!-- Secondary title -->
+    <div class="max-md:mx-auto flex flex-col max-md:max-w-md md:col-start-1 md:col-end-2 max-md:text-center">
+      <h4 class="w-full font-light mb-2 md:mb-6 pt-2 text-gray-500">See how Flowfuse can help with your next project</h4>
+      <h4 class="w-full text-red-600 md:flex md:flex-row md:gap-2 md:items-center">
+        Book a call now <span class="max-md:hidden">{% include "components/icons/arrow-long-right.svg" %}</span>
+        </h4>
+    </div>
+    {% endif %}
+    <!-- Form section -->
+    <section class="text-center md:text-left md:row-span-full md:col-start-2 md:col-end-7 {% if not downloadFollowUp %}md:mb-10{% endif %}">
+      <div class="container m-auto text-left max-w-5xl">
+        <div class="flex flex-col justify-center items-center md:block mx-auto">
+            <!-- Form / Calendar Script -->
+            <div class="max-w-2xl mx-auto">
+              {% include hubspot.script %}
+            </div>
+        </div>
+      </div>
+    </section>
+    {% if downloadFollowUp %}
+    <!-- Latest blog posts -->
+    <div class="my-2 pb-4 md:row-span-3 md:col-start-1 md:col-end-2">
+      <section class="max-w-sm max-md:mx-auto rounded-lg border border-gray-300 bg-white px-8 py-6 md:mt-10">
+        <div class="pb-2 md:pb-8">
+          <h4 class="pb-3">Latest on the blog</h4>
+          {%- for item in collections.posts | sort(attribute='item.date') | reverse | limit(3) -%}
+          <a href="{{ item.url }}" class="w-full flex flex-col group {% if not loop.last %}border-b{% endif %}">
+            <h5 class="my-2 font-light">
+              <span class="text-gray-500 group-hover:text-blue-700">
+                {{ item.data.title }}
+              </span>
+            </h5>
+          </a>
+          {%- endfor -%}
+        </div>
+        <a href="/blog/" class="w-full items-center pt-6 md:mt-16">
+          See all
+        </a>
+      </section>
+    </div>
+    {% endif %}
+  </div>
+  <!-- Social proof logos -->
+  <div class="w-full social-proof-logos md:-mt-12 mt-6 px-6 border-t border-gray-200">
+    {% include "social-proof.njk" %}
+  </div>
+</div>

--- a/src/book-demo.njk
+++ b/src/book-demo.njk
@@ -8,7 +8,8 @@ image: /images/og-book-demo.jpeg
 meta:
   description: Book a demo to understand how FlowFuse helps you professionalise your Node-RED deployment.
 hubspot:
-    script: "hubspot/hs-book-demo.njk"
+    script: "hubspot/hs-book-meeting.njk"
+    dataSrc: https://meetings-eu1.hubspot.com/flowfuse/book-a-demo-call?embed=true
 otherChannels:
   - title: Just wanted to send us a message?
     description: Fill out the form in our contact page and we’ll get back to you as soon as possible.

--- a/src/thank-you/contact.njk
+++ b/src/thank-you/contact.njk
@@ -1,0 +1,12 @@
+---
+layout: layouts/thank-you.njk
+title: Thank you for contacting us
+subtitle: Schedule a call now, you can leave it empty if you don't want to display it.
+description: Optional description, you can leave it empty if you don't want to display it.
+downloadFollowUp: false
+meta:
+  description: Optional meta description, if you leave it empty, the page description will be used.
+hubspot:
+    script: "hubspot/hs-book-meeting.njk"
+    dataSrc: https://meetings-eu1.hubspot.com/flowfuse/sales?embed=true
+---

--- a/src/thank-you/download.njk
+++ b/src/thank-you/download.njk
@@ -1,0 +1,10 @@
+---
+layout: layouts/thank-you.njk
+title: Thank you for dowloading...
+downloadFollowUp: true
+meta:
+  description: Optional meta description, if you leave it empty, the page description will be used.
+hubspot:
+    script: "hubspot/hs-book-meeting.njk"
+    dataSrc: https://meetings-eu1.hubspot.com/flowfuse/sales?embed=true
+---


### PR DESCRIPTION
## Description

I've created a template for thank you pages.

In `src/thank-you` there are two pages, one for **content** download follow up and another one for **contact** follow up. The template is the same for both and the key `downloadFollowUp` controls if the recent blog posts are shown and the layout of the page.

## Related Issue(s)

#1939

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
