### PR TITLE
Add Google tag container

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -125,15 +125,32 @@ eleventyComputed:
     <script>{{ js | jsmin | safe }}</script>
     {% jsonLdScript meta, type, tags %}
 
-    {# {%- if not DEV_MODE -%} #}
+    {%- if not DEV_MODE -%}
+    <!-- Google Consent -->
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+
+        // Set cookies to denied by default in EU countries, California, Brazil, Canada and Australia
+        gtag('consent', 'default', {
+            'ad_storage': 'denied',
+            'analytics_storage': 'denied',
+            'ad_user_data': 'denied',
+            'ad_personalization': 'denied',
+            'region': ['AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'ES', 'FI', 'FR', 'DE', 'GR', 'HU', 'IE', 'IT', 'LV', 'LT', 'LU', 'MT', 'NL', 'PL', 'PT', 'RO', 'SK', 'SI', 'SE', 'GB', 'US-CA', 'BR', 'CA', 'AU']
+        });
+    </script>
     <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-55L36797');</script>
+    <script>(function (w, d, s, l, i) {
+            w[l] = w[l] || []; w[l].push({
+                'gtm.start':
+                    new Date().getTime(), event: 'gtm.js'
+            }); var f = d.getElementsByTagName(s)[0],
+                j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
+                    'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
+        })(window, document, 'script', 'dataLayer', 'GTM-55L36797');</script>
     <!-- End Google Tag Manager -->
-    {# {%- endif -%} #}
+    {%- endif -%}
 </head>
 <body class="font-sans ff-website leading-normal tracking-normal gradient text-gray-500 min-h-screen flex flex-col">
     <!-- Google Tag Manager (noscript) -->
@@ -480,5 +497,5 @@ eleventyComputed:
     });
 </script>
 
-{%- endif -%} 
+{%- endif -%}
 </html>

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -125,32 +125,21 @@ eleventyComputed:
     <script>{{ js | jsmin | safe }}</script>
     {% jsonLdScript meta, type, tags %}
 
-    {%- if not DEV_MODE -%}
-    <!-- Google tag (gtag.js) -->
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-
-        // Set cookies to denied by default in EU countries, California, Brazil, Canada and Australia
-        gtag('consent', 'default', {
-            'ad_storage': 'denied',
-            'analytics_storage': 'denied',
-            'ad_user_data': 'denied',
-            'ad_personalization': 'denied',
-            'region': ['AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'ES', 'FI', 'FR', 'DE', 'GR', 'HU', 'IE', 'IT', 'LV', 'LT', 'LU', 'MT', 'NL', 'PL', 'PT', 'RO', 'SK', 'SI', 'SE', 'GB', 'US-CA', 'BR', 'CA', 'AU']
-        });
-
-        gtag('js', new Date());
-        gtag('config', 'G-2ZH9W82QL8');
-        gtag('config', 'AW-16456599728');
-    </script>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2ZH9W82QL8"></script>
-
-    <!-- Google Ads Tag -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-16456599728"></script>
-    {%- endif -%} 
+    {# {%- if not DEV_MODE -%} #}
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-55L36797');</script>
+    <!-- End Google Tag Manager -->
+    {# {%- endif -%} #}
 </head>
 <body class="font-sans ff-website leading-normal tracking-normal gradient text-gray-500 min-h-screen flex flex-col">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-55L36797"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <div class="flex-grow base">
         <div class="w-full">
             <!-- Events Banner Comment out line below to remove banner-->

--- a/src/_includes/layouts/thank-you.njk
+++ b/src/_includes/layouts/thank-you.njk
@@ -1,5 +1,6 @@
 ---
 layout: layouts/page.njk
+skipIndex: true
 ---
 <div class="flex flex-col max-w-5xl mx-auto gap-x-10 px-6">
   <div class="{% if downloadFollowUp %}md:grid md:grid-rows-4 md:grid-cols-2 md:grid-flow-rows md:gap-x-6{% else %}w-full{% endif %}">

--- a/src/thank-you/contact.njk
+++ b/src/thank-you/contact.njk
@@ -1,11 +1,8 @@
 ---
-layout: layouts/thank-you.njk
 title: Thank you for contacting us
 subtitle: Schedule a call now, you can leave it empty if you don't want to display it.
 description: Optional description, you can leave it empty if you don't want to display it.
 downloadFollowUp: false
-meta:
-  description: Optional meta description, if you leave it empty, the page description will be used.
 hubspot:
     script: "hubspot/hs-book-meeting.njk"
     dataSrc: https://meetings-eu1.hubspot.com/flowfuse/sales?embed=true

--- a/src/thank-you/download.njk
+++ b/src/thank-you/download.njk
@@ -1,9 +1,6 @@
 ---
-layout: layouts/thank-you.njk
 title: Thank you for dowloading...
 downloadFollowUp: true
-meta:
-  description: Optional meta description, if you leave it empty, the page description will be used.
 hubspot:
     script: "hubspot/hs-book-meeting.njk"
     dataSrc: https://meetings-eu1.hubspot.com/flowfuse/sales?embed=true

--- a/src/thank-you/thank-you.json
+++ b/src/thank-you/thank-you.json
@@ -1,0 +1,3 @@
+{
+    "layout": "layouts/thank-you.njk"
+}


### PR DESCRIPTION
## Description

I've set up a Tag Manager account for FlowFuse. @Hasmin-AC @ZJvandeWeg, I've sent you an invitation to manage the account.

I've already added our Google Analytics Tag, and additionally, a tracking one from Google Ads to test it. 

I've replaced our Google tags with the Google Tag container in our base template, allowing all tags to be managed from https://tagmanager.google.com/

The Google Ads tag tracks e-book downloads, but it's incomplete as we currently lack a specific thank you page for that event. As a temporary measure, it's now triggered by any of the thank you pages. Feel free to remove or modify it as necessary in the Tag Manager.

Additionally, I've added 'skipIndex' to the thank-you pages template to prevent them from appearing on search browsers and triggering conversions based on unrelated events.

@Hasmin-AC, once this is merged, either you or the company we've hired to manage our ads should be able to set up [all this](https://docs.google.com/document/d/1M48K49b-hUK1krE805e_B3rbqK_aDkGj7Hz0jRbabNU/edit#heading=h.n2raj4juwacj) in the Tag Manager. Just provide them with access to the account if you want them to handle it.

Please note that I'm unable to update the app's Google Tag in this PR. You'll need to request this from the product team. I'm unsure if they'll use the same container or if we'll need to create a new one. This can also be done through the Tag Manager platform, which provides the necessary code for each container we create.

## Related Issue(s)

https://github.com/FlowFuse/customer/issues/192

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
