### PR TITLE
netlify: For deploy previews skip the minification

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -21,7 +21,8 @@ const imageHandler = require('./lib/image-handler.js')
 const site = require("./src/_data/site");
 const coreNodeDoc = require("./lib/core-node-docs.js");
 
-const DEV_MODE = process.env.ELEVENTY_RUN_MODE !== "build" // i.e. serve/watch
+// Skip slow optimizations when developing i.e. serve/watch or Netlify deploy preview
+const DEV_MODE = process.env.ELEVENTY_RUN_MODE !== "build" || process.env.CONTEXT === "deploy-preview" 
 
 module.exports = function(eleventyConfig) {
     eleventyConfig.setUseGitIgnore(false); // Otherwise docs are ignored


### PR DESCRIPTION
The minification is _by far_ the slowest part of the build. This change makes a preview available in a minute, instead of 20.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
