### PR TITLE
ci: Use `main` branch for publishing documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'FlowFuse/flowfuse'
-          ref: maintenance
+          ref: main
           path: 'flowfuse'
       - name: Generate a token
         id: generate_token

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It is built using [Tailwind CSS](https://tailwindcss.com/) and [Eleventy](https:
 
 It is hosted on Netlify with each commit to the `main` branch being automatically deployed to the live site.
 
-This works by a GitHub action automatically updating the `live` branch to includes documentation pulled from the `maintenance` branch of the [FlowFuse/flowfuse](https://github.com/FlowFuse/flowfuse)
+This works by a GitHub action automatically updating the `live` branch to includes documentation pulled from the `main` branch of the [FlowFuse/flowfuse](https://github.com/FlowFuse/flowfuse)
 repository, when changes are pushed to `main`.
 
 Netlify is then configured to watch the `live` branch for any changes, once detected, it will automatically pull the contents of this branch (docs included) and deploy to our production site.
@@ -94,17 +94,14 @@ The `authors` list should correspond to an entry under `src/_data/team`.
 ## Updating the FlowFuse Documentation
 
 When the website is built it will include the documentation
-from the `maintenance` branch of the [FlowFuse/flowfuse](https://github.com/FlowFuse/flowfuse)
+from the `main` branch of the [FlowFuse/flowfuse](https://github.com/FlowFuse/flowfuse)
 repository.
 
 To make a documentation update *and* make it live on the website:
 
 1. PR the documentation update to the `main` branch of [FlowFuse/flowfuse](https://github.com/FlowFuse/flowfuse)
-2. Attach the `backport` label to the PR
-3. Get the PR reviewed and merged in the normal manner.
-4. A new PR will get automatically raised that backports the change to the `maintenance` branch
-5. Review and merge the PR to that branch.
-6. Manually kick-off a website rebuild by clicking 'Run workflow' on [this page](https://github.com/FlowFuse/website/actions/workflows/build.yml).
+2. Get the PR reviewed and merged in the normal manner.
+3. Manually kick-off a website rebuild by clicking 'Run workflow' on [this page](https://github.com/FlowFuse/website/actions/workflows/build.yml).
 
 ## Acknowledgements
 


### PR DESCRIPTION
## Description

This pull request updates the reference to the branch used for the documentation from `maintenance` to `main`. This simplifies the flow and ensures that the website is build with the latest documentation available.

## Related Issue(s)

https://github.com/FlowFuse/website/issues/2018

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
