### PR TITLE
Add redirect for may webinar page

### DIFF
--- a/src/redirect.md
+++ b/src/redirect.md
@@ -46,6 +46,7 @@ redirects:
   - { "from": "/blog/2023/08/UNS-article/", "to": "/blog/2023/08/isa-95-automation-pyramid-to-unified-namespace/" }
   - { "from": "/product/", "to": "/product/why-flowfuse/" }
   - { "from": "/node-red/core-nodes/rbe/", "to": "/node-red/core-nodes/filter/" }
+  - { "from": "/webinars/2024/deploy-flowfuse-on-industrial-iiot-with-ncd-io/", "to": "/webinars/2024/deploy-flowfuse-on-industrial-iot-with-ncd-io/" }
 
 # The "permalink" attribute determines where the output page will be located.
 permalink: "{{ redirect.from }}"


### PR DESCRIPTION
## Description

Added a redirect for the May webinar page, since it was changed in the related PR today and a webinar had gone out with the old link.

## Related Issue(s)

https://github.com/FlowFuse/website/pull/2019

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
