### PR TITLE
Handbook - Project Mgmt (Milestones & Headline Features)

### DIFF
--- a/src/handbook/development/project-management.md
+++ b/src/handbook/development/project-management.md
@@ -22,6 +22,8 @@ Beneath the areas, we then utilize the standard GitHub hierarchy of Epics, Stori
 
 Our planning process is continuously evolving as we find the best way to accommodate both a growing team and an expanding set of requirements for how and what we deliver. We operate on a continuous delivery model, with iterations of two-weeks. 
 
+Whilst we deploy to FlowFuse Cloud on every merge to `main` branch, we conduct formal releases every four weeks. With this, we utilize GitHub milestones in order to track which items are planned for each release. The "Active Release" view provides a picture of all issues assigned to a given release, which is updated when a new release starts after our [retrospective](./releases/process.md#retrospective).
+
 ### Cadence
 
 FlowFuse is continuously released to FlowFuse Cloud, and every four weeks, on a Thursday, it is packaged for users who are self-hosting FlowFuse.
@@ -87,8 +89,12 @@ tasks/bugs related to work already in progress and that need to be addressed in
 the current milestone. They should be added to the Development Board and current
 milestone directly.
 
+#### Headline Features
+
 We label some items as `headline`. These are items we want to highlight in the changelog and further
 announcements and should clearly describe the value they bring to our users.
+
+We provide the ["Headlines" view](https://github.com/orgs/FlowFuse/projects/1/views/39) on our GitHub project boards to track these items on a release-by-release basis so that the customer team has a clearer view on what new content can be discussed in socials, etc.
 
 ### Sizing Issues
 

--- a/src/handbook/development/releases/process.md
+++ b/src/handbook/development/releases/process.md
@@ -197,3 +197,9 @@ All release activity should be highlighted in #dev so the team is aware.
 
 To celebrate the launch of a new version of FlowFuse, we organize a lunch on
 the release day. See also the [peopleops section](../../peopleops/compensation#launch-lunch).
+
+## Retrospective
+
+The day after each release, a one hour meeting is conducted which anyone from the company can join. The purpose of this meeting is to reflect on the past four weeks of development effort, the release process and any other thoughts or comments that can help us refine processes moving forward.
+
+In the retrospective, the CTO or Engineering Manager will also cover any new items that have been added to the [Development Board](../project-management#development-board) and any relevant plans for engineering resource to be assigned to that work.


### PR DESCRIPTION
## Description

Details two new project boards I've added, and the re-introduction of milestones as release markers in GitHub.

Key objective to process changes here is to make it easier for the customer-side of the organisation to see what "headline" features we're releasing into FlowFuse. The changelog will still detail features as they're added to FF Cloud, but this project management board helps us plan ahead, and provides a concise view of the "higlights" that went into particular versions of FF.