### PR TITLE
Add CSS for any image captions

### DIFF
--- a/src/css/style.handbook.css
+++ b/src/css/style.handbook.css
@@ -115,6 +115,13 @@
         display: block;
     }
 
+    .handbook picture+em {
+        font-size: 0.825rem;
+        display: block;
+        width: 100%;
+        text-align: center;
+    }
+
     /* Define animation transitions for all child UL elements */
     .handbook-nav ul {
         max-height: 0;


### PR DESCRIPTION
## Description

Describe your changes in detail -->Adds CSS for when a developer includes a caption on an image in our documentation. In the markdown, you can follow an image with emphasised text, like so:

```md
![Screenshot to show the available "Actions" for a given Snapshot](./images/snapshots-actions.png)
_Screenshot to show the available "Actions" for a given Snapshot_
```

Which, now with the added CSS, results in:

<img width="615" alt="Screenshot 2024-05-10 at 08 33 31" src="https://github.com/FlowFuse/website/assets/99246719/537e7f25-d207-4489-96f2-120e4162ed8c">
