### PR TITLE
Fix broken link in changelog

### DIFF
--- a/src/changelog/2024/05/snapshot-improvements.md
+++ b/src/changelog/2024/05/snapshot-improvements.md
@@ -15,7 +15,7 @@ updates to share that are available today.
 
 ### Viewing snapshot contents
 
-Following the work done to [enable viewing flows in the Team Library](./library-flowviewer.md), we've added
+Following the work done to [enable viewing flows in the Team Library](/changelog/2024/05/library-flowviewer), we've added
 the same capability to snapshots.
 
 Each snapshot now has a 'View Snapshot' option that will display the flows without having to open up


### PR DESCRIPTION
## Description

A few new PRs were having their builds fail due to a broken link. The link looked fine, but for some reason, I think in the way that Eleventy builds the changelo into two places, the relative link was failing. Not sure why it wasn't picked up in the original CL PR.