### PR TITLE
sales: License is added to Google Sheet automatically

### DIFF
--- a/src/handbook/customer/sales/meetings/poc.md
+++ b/src/handbook/customer/sales/meetings/poc.md
@@ -23,4 +23,4 @@ During the initial POC meeting, the [POC Criteria document](https://docs.google.
 For self-managed installs a license needs to be generated and installed to
 unlock paid-for features. Generate one by [filling out this form](https://energetic-sanderling-4472.flowfuse.cloud/dashboard/license){rel="nofollow"}.
 
-All licenses must be added [to this document](https://docs.google.com/spreadsheets/d/1wM_o8IWjjkwi-WMRueKfS-lrmkQYzV83xm4BIzZNAO0){rel="nofollow"}.
+All generated licenses are added [to this sheet](https://docs.google.com/spreadsheets/d/1wM_o8IWjjkwi-WMRueKfS-lrmkQYzV83xm4BIzZNAO0){rel="nofollow"} automatically.


### PR DESCRIPTION
## Description

Automatically adds licenses to the right Google Sheet, no manual intervention required.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
