### PR TITLE
Remove first line padding in code blocks

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -148,7 +148,6 @@ pre code {
 
 .prose code {
     font-weight: 500;
-    padding-left: 0.25rem;
     padding-right: 0.25rem;
 }
 


### PR DESCRIPTION
## Description

Removed padding from the `.prose code` class to align the first line with subsequent lines in code blocks.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
