### PR TITLE
Changelog - Fix relative link

### DIFF
--- a/src/changelog/2024/05/snapshot-upload.md
+++ b/src/changelog/2024/05/snapshot-upload.md
@@ -19,5 +19,5 @@ if you prefer, automate it via the APIs it is built on.
 
 We hope you like this nifty little feature. 
 
-Stay tuned as we expect the final peices in the overall [Snapshot Improvements](snapshot-improvements.md)
+Stay tuned as we expect the final peices in the overall [Snapshot Improvements](/changelog/2024/05/snapshot-improvements)
 to be delivered in the coming days.


### PR DESCRIPTION
## Description

Link got into `main` from the changelog that is failing the tests: https://github.com/FlowFuse/website/actions/runs/9127196753/job/25096984929

The PR didn't report this at all, which is odd, and the second time I've noticed this now.

## Related Issue(s)

Initial PR that introduced this: https://github.com/FlowFuse/website/pull/2072