### PR TITLE
docs: Allow `dev-env` to host the docs

### DIFF
--- a/scripts/copy_docs.js
+++ b/scripts/copy_docs.js
@@ -49,21 +49,19 @@ async function copyFiles (src, dest, version) {
 }
 
 (async () => {
-
     // Check we are in the root of the website repo
     if (!existsSync('src')) {
         console.log('Run this from the top of the website repository')
         process.exit(-1)
     }
 
-    // Go find the FF docs folder. It could be ../flowforge/docs or ../flowfuse/docs
-    let ffRepo = '../flowfuse'
-    if (!existsSync(ffRepo)) {
-        ffRepo = '../flowforge'
-        if (!existsSync(ffRepo)) {
-            console.log('FlowFuse repository not found (../flowfuse or ../flowforge) - skipping')
-            process.exit(-1)
-        }
+    const repoPaths = ['../dev-env/packages/flowfuse', '../flowfuse', '../flowforge'];
+
+    // For the first repoPath to exist, we will use that one
+    const ffRepo = repoPaths.find(p => existsSync(path.join(p, 'docs')))
+    if (!ffRepo) {
+        console.log(`FlowFuse repository not found (${repoPaths}) - skipping`)
+        process.exit(-1)
     }
 
     const docsDir = path.join(ffRepo, 'docs')
@@ -101,8 +99,6 @@ async function copyFiles (src, dest, version) {
         })
         setInterval(() => {}, 1 << 30);
     }
-
-
 })()
 
 


### PR DESCRIPTION
Before this change the location for docs didn't support what I suspect is the recommended path structure. That is, a dev-env, with as sibling a website repo in the same directory.

This change includes that directory to be supported.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
