### PR TITLE
Add flowfuse.io redirect handling

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -52,6 +52,12 @@ to = "https://flowfuse.com/:splat"
 status = 301
 force = true
 
+[[redirects]]
+from = "https://flowfuse.io/*"
+to = "https://flowfuse.com/:splat"
+status = 301
+force = true
+
 [dev]
 port = 8080
 framework = "#static"


### PR DESCRIPTION
With `flowfuse.io` registered as our TLD for FF Dedicated, this change will mean (once other DNS changes have been made) anyone accessing `flowfuse.io` directly will get redirected to the website.