### PR TITLE
Add meta properties to core-nodes template

### DIFF
--- a/src/_data/coreNodes.json
+++ b/src/_data/coreNodes.json
@@ -3,7 +3,9 @@
         {
             "xpath": "inject",
             "name": "Inject",
-            "file": "20-inject"
+            "file": "20-inject",
+            "description": "Guide on the Node-RED core node that injects a message into a flow",
+            "keywords": "inject, message, flow"
         },
         {
             "xpath": "debug",

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -17,8 +17,10 @@ meta:
 eleventyComputed:
   meta:
     url: "{{ page.url | url | toAbsoluteUrl }}"
+    title: "{{ meta.title }}"
     description: "{{ meta.description }}"
     modified: "{{ page.date }}"
+    keywords: "{{ meta.keywords }}"
 ---
 
 <!doctype html>
@@ -39,13 +41,15 @@ eleventyComputed:
     <meta name="theme-color" content="#ffffff">
     
     <!-- Meta Keywords -->
-    {% if tags %}
-    {% set filtered_tags = tags | reject('equalto', 'posts') | reject('equalto', 'node-red') | list %}
-    <meta name="keywords" content="{{ filtered_tags | join(', ') }}, {{ site.messaging.keywords }}">
-    {% elif meta.keywords %}
-    <meta name="keywords" content="{{ meta.keywords }}, {{ site.messaging.keywords }}">
+    {% if meta.keywords %}
+        <meta name="keywords" content="{{ meta.keywords }}, {{ site.messaging.keywords }}">
+    {% elif keywords %}
+        <meta name="keywords" content="{{ keywords }}, {{ site.messaging.keywords }}">
+    {% elif tags %}
+        {% set filtered_tags = tags | reject('equalto', 'posts') | reject('equalto', 'node-red') | list %}
+        <meta name="keywords" content="{{ filtered_tags | join(', ') }}, {{ site.messaging.keywords }}">
     {% else %}
-    <meta name="keywords" content="{{ site.messaging.keywords }}">
+        <meta name="keywords" content="{{ site.messaging.keywords }}">
     {% endif %}
 
     <!-- Browser Title -->

--- a/src/handbook/customer/marketing/website.md
+++ b/src/handbook/customer/marketing/website.md
@@ -75,13 +75,15 @@ By default, each webpage on the FlowFuse website includes a set of predefined ke
 
 ### Priority of Keywords
 
-When it comes to determining which keywords to include in the meta tags of a webpage, FlowFuse follows a specific priority order:
+When adding meta keywords to the website pages, a specific priority order is followed:
 
-1. [**Tags:**](/handbook/customer/marketing/blog/#tags) The tags assigned to the content take precedence and are included as meta keywords. These tags are used to categorize the content and provide relevant context.
+1. **Meta Keywords:** These are the keywords specified in the front matter of the webpage. They are specifically defined for each page and offer additional context.
 
-2. **Meta Keywords:** If no tags are available, the meta keywords specified in the front matter of the webpage are used. These meta keywords are specifically defined for each page and offer additional context.
+2. **Keywords:** If no `meta.keywords` are found, the `keywords` specified in the front matter of the webpage are used.
 
-3. **Default Keywords:** These keywords are always included and provide general information about the website's content. They can be appended to the keywords obtained from previous points. If neither tags nor meta keywords are present, the default keywords are used as a fallback option. 
+3. [**Tags:**](/handbook/customer/marketing/blog/#tags) If neither `meta.keywords` nor `keywords` are assigned, the `tags` assigned to the content are included as meta keywords. These tags are used to categorize the content and provide relevant context.
+
+4. **Default Keywords:** These are always included and provide general information about the website's content. They can be appended to the keywords obtained from previous points, or, if neither of the previous conditions are met, the default keywords are used as a fallback option.
 
 ### Adding Meta Keywords
 

--- a/src/node-red/core-nodes/common.njk
+++ b/src/node-red/core-nodes/common.njk
@@ -10,6 +10,9 @@ eleventyComputed:
   eleventyNavigation:
     key: "{{ node.name }}"
     parent: "{{ coreNodeCategory }}"
+  title: "Node-RED - {{ node.name }} Node"
+  description: "{{ node.description }}"
+  keywords: "{{ node.keywords }}"
 ---
 
 {% include "core-node-docs.njk" %}

--- a/src/node-red/core-nodes/function.njk
+++ b/src/node-red/core-nodes/function.njk
@@ -10,6 +10,9 @@ eleventyComputed:
   eleventyNavigation:
     key: "{{ node.name }}"
     parent: "{{ coreNodeCategory }}"
+  title: "Node-RED - {{ node.name }} Node"
+  description: "{{ node.description }}"
+  keywords: "{{ node.keywords }}"
 ---
 
 {% include "core-node-docs.njk" %}

--- a/src/node-red/core-nodes/network.njk
+++ b/src/node-red/core-nodes/network.njk
@@ -10,6 +10,9 @@ eleventyComputed:
   eleventyNavigation:
     key: "{{ node.name }}"
     parent: "{{ coreNodeCategory }}"
+  title: "Node-RED - {{ node.name }} Node"
+  description: "{{ node.description }}"
+  keywords: "{{ node.keywords }}"
 ---
 
 {% include "core-node-docs.njk" %}

--- a/src/node-red/core-nodes/parsers.njk
+++ b/src/node-red/core-nodes/parsers.njk
@@ -10,6 +10,9 @@ eleventyComputed:
   eleventyNavigation:
     key: "{{ node.name }}"
     parent: "{{ coreNodeCategory }}"
+  title: "Node-RED - {{ node.name }} Node"
+  description: "{{ node.description }}"
+  keywords: "{{ node.keywords }}"
 ---
 
 {% include "core-node-docs.njk" %}

--- a/src/node-red/core-nodes/sequence.njk
+++ b/src/node-red/core-nodes/sequence.njk
@@ -10,6 +10,9 @@ eleventyComputed:
   eleventyNavigation:
     key: "{{ node.name }}"
     parent: "{{ coreNodeCategory }}"
+  title: "Node-RED - {{ node.name }} Node"
+  description: "{{ node.description }}"
+  keywords: "{{ node.keywords }}"
 ---
 
 {% include "core-node-docs.njk" %}

--- a/src/node-red/core-nodes/storage.njk
+++ b/src/node-red/core-nodes/storage.njk
@@ -10,6 +10,9 @@ eleventyComputed:
   eleventyNavigation:
     key: "{{ node.name }}"
     parent: "{{ coreNodeCategory }}"
+  title: "Node-RED - {{ node.name }} Node"
+  description: "{{ node.description }}"
+  keywords: "{{ node.keywords }}"
 ---
 
 {% include "core-node-docs.njk" %}


### PR DESCRIPTION
## Description

I've added `meta` properties to the front matter of the templates that generate the core-nodes pages.

This required some updates to the base template, so it could recognise the `title` and `keywords` of each node instead of taking only the data of the last node of each category.

I've added the description and keywords field to the `inject` node in the `coreNodes.json` file to provide a guide, since this is the file where the data needs to be added.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
