### PR TITLE
Fix /node-red/hardware/raspberry-pi-4/ image path

### DIFF
--- a/src/node-red/hardware/raspberry-pi-4.md
+++ b/src/node-red/hardware/raspberry-pi-4.md
@@ -6,7 +6,7 @@ meta:
    title: Setting Node-RED on Raspberry Pi 4
    description: Learn how to set up Node-RED on a Raspberry Pi 4, including installation, configuration, and integration with sensors and actuators.
    keywords: node-red, raspberry pi, raspberry pi 4
-image: "./images/how-to-setup-node-red-on-raspberry-pi.png"
+image: /node-red/hardware/images/how-to-setup-node-red-on-raspberry-pi.png
 ---
 
 # Setting Node-RED on Raspberry Pi 4


### PR DESCRIPTION
## Description

Fixed the path to the image. Now it's adding it as the OG image

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
