### PR TITLE
Add image pipeline output to cache

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -77,4 +77,7 @@ package = "@algolia/netlify-plugin-crawler"
 [[plugins]]
 package = "netlify-plugin-cache"
   [plugins.inputs]
-  paths = [ ".cache" ]
+  paths = [
+    "_site/img", # Eleventy Image Disk Cache
+    ".cache" # Remote asset cache
+  ]


### PR DESCRIPTION
The image pipeline output was not being cached by netlify. This meant each build required a complete run of the pipeline.

This PR adds the pipeline output directory to the list of directories that netlify will cache between builds.

Reference: https://github.com/11ty/demo-eleventy-img-netlify-cache