### PR TITLE
Add build task that skips image pipeline for CI to use

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -24,7 +24,7 @@ const yaml = require("js-yaml");
 const eleventyNavigationPlugin = require("@11ty/eleventy-navigation");
 
 // Skip slow optimizations when developing i.e. serve/watch or Netlify deploy preview
-const DEV_MODE = process.env.ELEVENTY_RUN_MODE !== "build" || process.env.CONTEXT === "deploy-preview" 
+const DEV_MODE = process.env.ELEVENTY_RUN_MODE !== "build" || process.env.CONTEXT === "deploy-preview" || process.env.SKIP_IMAGES === 'true'
 
 module.exports = function(eleventyConfig) {
     eleventyConfig.addDataExtension("yaml", contents => yaml.load(contents)); // Add support for YAML data files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         run: npm install
         working-directory: 'website'
       - name: Build the forge
-        run: npm run build
+        run: npm run build:skip-images
         working-directory: 'website'
       - uses: untitaker/hyperlink@0.1.32
         with:

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "test": "mocha",
         "build:js": "terser -c -m -o _site/js/cc.min.js node_modules/vanilla-cookieconsent/dist/cookieconsent.umd.js src/js/cookieconsent-config.js && cp node_modules/@flowfuse/flow-renderer/index.min.js _site/js/flowrenderer.min.js",
         "build": "cross-env NODE_ENV=production npm-run-all clean build:js --parallel prod:*",
+        "build:skip-images": "cross-env SKIP_IMAGES=true npm run build",
         "clean:dev": "cross-env npx del-cli '_site/!(img)' 'src/docs/**/*.md' 'src/blueprints/**/*' && cross-env npx mkdirp '_site/js/flows'",
         "clean": "cross-env npx del-cli '_site/!(img)' && cross-env mkdir -p '_site/js'",
         "dev:docs": "node scripts/copy_docs.js --watch",


### PR DESCRIPTION
## Description

There's no need to run the full image pipeline when running the website tests. This PR adds the ability to run a 'full' build, but with the image pipeline disabled.

This should speed things along.