### PR TITLE
Release post: move some tags to meta.keywords

### DIFF
--- a/src/blog/2024/06/flowfuse-2-5-release.md
+++ b/src/blog/2024/06/flowfuse-2-5-release.md
@@ -5,16 +5,12 @@ description: Discover the new features in FlowFuse 2.5, including LDAP integrati
 date: 2024-06-06
 authors: ["grey-dziuba"]
 image: /blog/2024/06/images/release-2-5-graphic.png
+meta:
+   keywords: LDAP, snapshot, blueprints, Node-RED
 tags:
    - posts
    - flowfuse
    - releases
-   - LDAP
-   - snapshot
-   - blueprints
-   - Node-RED
-   
-
 ---
 
 FlowFuse 2.5 introduces LDAP integration, snapshot comparison, extends the ability to preview flow to Blueprints, rounds out the management for snapshots, and allows you to point your own domain names at your FlowFuse instances.


### PR DESCRIPTION
## Description

The tag `blueprints` adds the post to the `/blueprints` page, I moved some of the tags into the `meta.keywords` values to fix that.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
