### PR TITLE
Release post: replaces 'blueprints' tag with 'blueprint'

### DIFF
--- a/src/blog/2024/06/flowfuse-2-5-release.md
+++ b/src/blog/2024/06/flowfuse-2-5-release.md
@@ -11,7 +11,7 @@ tags:
    - releases
    - LDAP
    - snapshot
-   - blueprints
+   - blueprint
    - Node-RED
    
 


### PR DESCRIPTION
## Description

The tag `blueprints` adds the post to the `/blueprints` page, so in this case, I've changed it to 'blueprint' to exclude it from that collection.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
