### PR TITLE
Apply round corners to content images

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -682,6 +682,10 @@ h4:hover .header-anchor {
         aspect-ratio: 1.78;
         margin-bottom: 0.7rem;
     }
+    .ff-blog-tile img,
+    .prose img {
+        @apply rounded-lg;
+    }
 }
 
 .ff-full-bg {


### PR DESCRIPTION
## Description

Matching the style of pages' images and the company logo, I've added the `border-radius` class to the images in content sections, such as `/docs` `/handbook` `/node-red/*`

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
