### PR TITLE
eBook: create new key/value for page image

### DIFF
--- a/src/_includes/layouts/ebook.njk
+++ b/src/_includes/layouts/ebook.njk
@@ -25,7 +25,11 @@ hubspot:
                     <div class="absolute top-0 right-0 transform translate-x-[-15%] md:translate-x-[-30%] rounded-b-md bg-white md:px-4 px-2 py-1">
                         <label class="text-red-600 max-md:text-sm">eBook</label>
                     </div>
-                    {% set imageSrc = ["./", image ] | join %}
+                    {% if coverImage %}
+                        {% set imageSrc = ["./", coverImage ] | join %}
+                    {% else %}
+                        {% set imageSrc = ["./", image ] | join %}
+                    {% endif %}
                     {% image imageSrc, "eBook cover image with title and FlowFuse logo", [302] %}
                 </div>
                 <div class="mb-4 hero-img prose ff-prose">

--- a/src/ebooks/ultimate-guide-to-building-applications-with-flowfuse-dashboard-for-node-red.md
+++ b/src/ebooks/ultimate-guide-to-building-applications-with-flowfuse-dashboard-for-node-red.md
@@ -1,11 +1,11 @@
 ---
 contentTitle: The Ultimate Guide to Building Applications with <span class="inline-block">FlowFuse Dashboard for Node-RED</span>
-image: /images/ebooks/ebook_dashboard.png
+coverImage: /images/ebooks/ebook_dashboard.png
+image: /images/ebooks/ebook-dashboard-render.png
 meta:
   title: The Ultimate Guide to Building Applications with FlowFuse Dashboard for Node-RED
   description: Discover the power of the FlowFuse Dashboard for Node-RED with our comprehensive eBook. Learn how to effortlessly create stunning UIs, from data charts to custom components, and enable collaborative full-stack application development. Ideal for developers of all levels, this guide unlocks the potential of your data in industrial IoT environments.
   Keywords: FlowFuse Dashboard, Node-RED Dashboard, Dashboard 2.0, IoT dashboard creation, Low-code platform, Data visualization, UI development, Industrial IoT, Dashboard design
-  image: /images/ebooks/ebook-dashboard-render.png
 hubspot:
   formId: 372e557c-9f90-48e8-81da-d7e462f8ef55
   cta: "download-ebook"


### PR DESCRIPTION
## Description

In order to support different images for the Open Graph (OG) image and the page image, I've introduced a new key-value pair and a conditional statement. This conditional checks for the existence of `coverImage` and uses it if available. If `coverImage` is not found, it falls back to using `image`.

The approach from the related PR wasn't working as expected because `image` is reserved for the OG image. With this change, we can now specify a different `coverImage` for the page, while `image` is used for the OG image.

## Related Issue(s)

https://github.com/FlowFuse/website/pull/2238

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
