### PR TITLE
Docs template: Increase columns width on large screens

### DIFF
--- a/src/_includes/layouts/handbook.njk
+++ b/src/_includes/layouts/handbook.njk
@@ -55,7 +55,7 @@ date: git Last Modified
             </div>
         </div>
         <!-- Right side bar -->
-        <div class="sticky top-6 w-full md:w-64 mt-4 md:mt-6 px-8">
+        <div class="sticky top-6 w-full mt-4 md:mt-6 px-8">
             <h3 class="font-medium border-b pb-1 mb-4">On this page</h3>
             <ul id="toc" class="text-sm border-b mb-4"></ul>
             {%- for maintainer in page | pageOwners | ghUsersToTeamMembers(team) -%}

--- a/src/css/style.handbook.css
+++ b/src/css/style.handbook.css
@@ -3,9 +3,9 @@
 
 @layer components {
     .handbook {
-        grid-template-columns: 220px auto 260px;
+        grid-template-columns: 230px auto 260px;
         margin-top: -3rem;
-        @apply flex flex-col-reverse lg:grid lg:max-w-screen-xl 2xl:max-w-[1920px] ;
+        @apply flex flex-col-reverse lg:grid lg:max-w-screen-xl 2xl:max-w-[1920px] 2xl:grid-cols-[300px,auto,270px];
     }
 
     .handbook-nav {
@@ -125,7 +125,7 @@
     .handbook .table-wrapper {
         overflow-x: auto;
         max-width: 100%;
-        @apply lg:max-w-[calc(100vw-590px)];
+        @apply lg:max-w-[calc(100vw-610px)];
     }
 
     .handbook pre {


### PR DESCRIPTION
## Description

On the template used in the `handbook` and `docs`, I've increased the width of the navigation columns in large screens.

## Related Issue(s)

#2259

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
