### PR TITLE
Restore prose max-with except on handbook template

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -294,10 +294,6 @@ dl.message-properties {
     margin-top: 1rem;
 }
 
-.blog .ff-prose {
-    @apply md:flex-grow md:max-w-[calc(100%-18rem)];
-}
-
 /*
     prevent top margin on first/hero img of a blog post
 */

--- a/src/css/style.handbook.css
+++ b/src/css/style.handbook.css
@@ -8,6 +8,10 @@
         @apply flex flex-col-reverse lg:grid lg:max-w-screen-xl 2xl:max-w-[1920px] 2xl:grid-cols-[300px,auto,270px];
     }
 
+    .handbook .prose {
+        max-width: none;
+    }
+
     .handbook-nav {
         border-right: 1px solid right;
         text-transform: capitalize;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,7 +36,7 @@ module.exports = {
                         strong: {
                             color: theme('colors.gray.500'),
                         },
-                        maxWidth: 'none',
+                        maxWidth: '80ch',
                     },
                 },
             }),


### PR DESCRIPTION
## Description

The changes introduced in this PR: https://github.com/FlowFuse/website/pull/2246/files were affecting other templates, this change restores the style in all pages other than `/docs` or `/handbook`

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
