### PR TITLE
Call out when changelog entries are expected

### DIFF
--- a/src/handbook/development/project-management.md
+++ b/src/handbook/development/project-management.md
@@ -100,6 +100,8 @@ We provide the ["Headlines" view](https://github.com/orgs/FlowFuse/projects/1/vi
 
 We produce changelog entries for new features and changes that are of interest to users. These are typically short highlight articles that let users know what we have added or improved in the product and can be found at https://flowfuse.com/changelog/
 
+ChangeLog entries are created via PR to the [website](https://github.com/FlowFuse/website/tree/main/src/changelog) repository.
+
 ### Sizing Issues
 
 To more accurately understand which tasks can be scheduled without overloading our team, everyone conducts an initial, high-level analysis when creating an issue to assign weight estimates. We recognize that these estimates might not be precise. If the person who creates an issue cannot provide an estimate, any FlowFuse team member is welcome to contribute one.

--- a/src/handbook/development/project-management.md
+++ b/src/handbook/development/project-management.md
@@ -91,10 +91,14 @@ milestone directly.
 
 #### Headline Features
 
-We label some items as `headline`. These are items we want to highlight in the changelog and further
+We label some items as `headline`. These are items we want to highlight in the ["changelog"](#changelog) and further
 announcements and should clearly describe the value they bring to our users.
 
 We provide the ["Headlines" view](https://github.com/orgs/FlowFuse/projects/1/views/39) on our GitHub project boards to track these items on a release-by-release basis so that the customer team has a clearer view on what new content can be discussed in socials, etc.
+
+#### Changelog
+
+We produce changelog entries for new features and changes that are of interest to users. These are typically short highlight articles that let users know what we have added or improved in the product and can be found at https://flowfuse.com/changelog/
 
 ### Sizing Issues
 


### PR DESCRIPTION
closes #2297

## Description

Current handbook implies changelog entries are for issues tagged **headline**

This update adds changelog as its own section and aims to clarify when and why changelog entries are required.

## Related Issue(s)

#2297

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
