### PR TITLE
Optimize Google Fonts loading

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -31,7 +31,8 @@ eleventyComputed:
     <link href="/css/style.css" rel="stylesheet">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Heebo:wght@100..900&display=swap" rel="stylesheet">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Heebo:wght@100..900&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <noscript><link href="https://fonts.googleapis.com/css2?family=Heebo:wght@100..900&display=swap" rel="stylesheet"></noscript>
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -16,6 +16,7 @@
 
 html, body {
     font-size: 16px;
+    font-family: 'Helvetica Neue', sans-serif;
 }
 
 *{


### PR DESCRIPTION
## Description

This PR optimizes the loading of the Google Font 'Heebo' by using the 'preload' attribute. This helps to improve the page load speed by loading the font in the background without blocking the rendering of the page. Additionally, the default font has been set to 'Helvetica Neue' to provide a fallback while 'Heebo' is loading.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
