### PR TITLE
/node-red: Add button to /professional-services in learning section

### DIFF
--- a/src/node-red/getting-started/index.md
+++ b/src/node-red/getting-started/index.md
@@ -1,6 +1,7 @@
 ---
 eleventyNavigation:
   key: Getting Started
+  order: 1
 meta:
   title: Getting Started with Node-RED
   description:  Learn the basics of Node-RED, a powerful tool for IoT integration and workflow automation.

--- a/src/node-red/index.njk
+++ b/src/node-red/index.njk
@@ -132,7 +132,7 @@ sitemapPriority: 0.8
         Node-RED <span class="text-indigo-600">Learning Resources</span>
     </h2>
 <div class="max-sm:text-center max-w-md sm:max-w-none mx-auto sm:grid justify-center items-center mt-10" style="grid-template-columns: 45% auto;">
-    <div class="max-h-[300px] md:max-h-[272px] ff-image-cover scale ff-image-rounded w-full h-full mb-4 sm:mb-0">
+    <div class="max-h-[400px] md:max-h-[350px] ff-image-cover scale ff-image-rounded w-full h-full mb-4 sm:mb-0">
         {% image "../images/learning_nr.png", "Node-RED pseudo UI", [406] %}
     </div>
         <div class="content-center justify-center sm:pl-8 flex-1">
@@ -146,7 +146,8 @@ sitemapPriority: 0.8
                 <span class="px-3">|</span>
                 <a href="/blog/2023/04/3-quick-node-red-tips-6/">Quick Tips</a>
             </p>
-            <a class="ff-btn ff-btn--primary-outlined min-h-[40px] md:inline" href="/blog/node-red/">SEE MORE</a>
+            <a class="ff-btn ff-btn--primary min-h-[40px] md:inline mb-2 md:mb-0 md:mr-2" href="/node-red/learn/">SEE MORE</a>
+            <a class="ff-btn ff-btn--primary-outlined min-h-[40px] md:inline" href="/professional-services/">GET PROFESSIONAL SUPPORT</a>
         </div>
     </div>   
 </div>

--- a/src/node-red/learn.md
+++ b/src/node-red/learn.md
@@ -1,7 +1,7 @@
 ---
 eleventyNavigation:
   key: Learning Resources
-  order: 1
+  order: 0
 meta:
    title: Node-RED Learning Resources
    description: Explore this comprehensive set of Node-RED learning resources, including how to set up Node-RED on various hardware platforms, its basic terminologies, integration of different databases, and more.

--- a/src/professional-services.njk
+++ b/src/professional-services.njk
@@ -2,7 +2,7 @@
 align: center
 layout: layouts/page.njk
 title: Professional Services
-description: <p>FlowFuse partners with our customers to ensure their successful deployment of FlowFuse and Node-RED. Discover our professional service offerings.</p>
+description: <p>At FlowFuse, we partner with our customers to ensure their successful deployment of FlowFuse and Node-RED. Our professional services are available to Enterprise tier customers, providing expert support for critical projects.</p>
 hubspot:
   script: "hubspot/hs-form.njk"
   formId: b8ae3144-7eb2-4f5a-a9f8-f99e5c7bb07f
@@ -24,7 +24,7 @@ hubspot:
               </div>
             </h3>
             <p class="mb-0">
-              FlowFuse employees are experts in Node-RED development. We can help your team create Node-RED flows that meet your requirements or we can conduct an architecture review of existing flows to align with Node-RED best practices. Flow engineering is available to Enterprise tier customers of FlowFuse.
+              FlowFuse employees are experts in Node-RED development. We can help your team create Node-RED flows that meet your requirements or conduct an architecture review of existing flows to align with Node-RED best practices.
             </p>
           </div>
         </div>  
@@ -39,7 +39,7 @@ hubspot:
               </div>
             </h3>
             <p class="mb-0">
-              FlowFuse offers Node-RED and FlowFuse in-person and online courses for engineers, architects and managers. Our structured approach to training can be customized to fit your unique requirements.
+              FlowFuse offers Node-RED and FlowFuse in-person and online courses for engineers, architects, and managers. Our structured approach to training can be customized to fit your unique requirements.
             </p>
           </div>
         </div>  


### PR DESCRIPTION
## Description

- Added a button to `/professional-services` in learning section
- Updated the `SEE MORE` button link to go to `/node-red/learn`
- Update left nav order to maintain its landing as the first item
- Updated the `/professional-services` copy to clarify in the page description that both services are available to enterprise tier customers

## Related Issue(s)

https://github.com/FlowFuse/customer/issues/225

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
