### PR TITLE
Features: Replace book a demo with contact us

### DIFF
--- a/src/_includes/common-cta.njk
+++ b/src/_includes/common-cta.njk
@@ -35,15 +35,15 @@
         </div>
         <div class="features-card">
             <div>
-                <label class="flex items-center text-center justify-center font-medium text-2xl text-gray-800 mt-5">Contact Sales</label>
+                <label class="flex items-center text-center justify-center font-medium text-2xl text-gray-800 mt-5">Contact Us</label>
                 <p>
                     <div class="text-sm leading-6 mb-6 mt-6">
-                        FlowFuse was built to help companies at the enterprise level, and we’d love to help yours.
+                        FlowFuse was built to help companies at the enterprise level, and we’d love to help yours. If you have questions or need more information, please reach out to us.
                     </div>
                 </p>
             </div>
             <div class="flex flex-col items-center">
-                <a class="ff-btn ff-btn--primary-outlined uppercase align-baseline w-full" href='/book-demo/'>Book a demo</a> 
+                <a class="ff-btn ff-btn--primary-outlined uppercase align-baseline w-full" href='/contact-us/'>Contact Us</a> 
             </div>
         </div>                       
     </div>


### PR DESCRIPTION
## Description

At the bottom of `/features` we have this section:

<img width="1025" alt="Screenshot 2024-07-15 at 14 05 47" src="https://github.com/user-attachments/assets/14c9dcf0-8107-4cc4-a0c5-957519d4cc33">

Those numbers represent the amount of clicks from the past 90 days (according to PostHog after the cookie banner was set up properly).

This changes the copy and the link from `book a demo` to the `contact us` page to see if we can improve that number since filling out a form can seem less intimidating than scheduling a call.

## Related Issue(s)

https://github.com/FlowFuse/customer/issues/225

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
