### PR TITLE
Make main nav sticky

### DIFF
--- a/src/_includes/feature_lists/features-table-base.njk
+++ b/src/_includes/feature_lists/features-table-base.njk
@@ -1,5 +1,5 @@
 <div class="ff-feature-table m-auto">
-    <ul class="{{ hosting }} ff-feature-table-section sticky top-0 z-10">
+    <ul class="{{ hosting }} ff-feature-table-section sticky top-0 md:top-14 z-10">
         <li class="ff-feature--column-header">
             <span class="sticky left-0 h-full"></span>
             {% if hosting == "cloud" %}

--- a/src/_includes/layouts/handbook.njk
+++ b/src/_includes/layouts/handbook.njk
@@ -55,7 +55,7 @@ date: git Last Modified
             </div>
         </div>
         <!-- Right side bar -->
-        <div class="sticky top-6 w-full mt-4 md:mt-6 px-8">
+        <div class="sticky top-20 w-full mt-4 md:mt-6 px-8">
             <h3 class="font-medium border-b pb-1 mb-4">On this page</h3>
             <ul id="toc" class="text-sm border-b mb-4"></ul>
             {%- for maintainer in page | pageOwners | ghUsersToTeamMembers(team) -%}

--- a/src/_includes/layouts/learning-resources.njk
+++ b/src/_includes/layouts/learning-resources.njk
@@ -37,7 +37,7 @@ date: git Last Modified
             </div>
         </div>
         <!-- Right side bar -->
-        <div class="sticky top-6 w-full md:w-64 mt-4 md:mt-6 px-8">
+        <div class="sticky top-20 w-full md:w-64 mt-4 md:mt-6 px-8">
             <h3 class="font-medium border-b pb-1 mb-4">On this page</h3>
             <ul id="toc" class="text-sm border-b mb-4"></ul>
             <div class="text-sm pb-1 text-right mb-4"><a href="{{ page | handbookEditLink }}">Edit this page</a></div>

--- a/src/_includes/layouts/post-changelog.njk
+++ b/src/_includes/layouts/post-changelog.njk
@@ -31,7 +31,7 @@ hubspot:
                 </div>
             </div>
             <div class="w-72 max-w-full flex-shrink-0">
-                <div class="sticky top-4 mt-6 flex flex-col">
+                <div class="sticky top-20 mt-6 flex flex-col">
                     <h3 class="mb-3">Written By:</h3>
                     {% for author in authors %}
                         {% if people[author] %}

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -56,7 +56,7 @@
                 </div>
             </div>
             <div class="w-72 max-w-full flex-shrink-0">
-                <div class="sticky top-4 mt-6 flex flex-col">
+                <div class="sticky top-20 mt-6 flex flex-col">
                     <h3 class="mb-3">Written By:</h3>
                     {% for author in authors %}
                         {% renderTeamMember people[author] %}

--- a/src/_includes/layouts/whitepaper.njk
+++ b/src/_includes/layouts/whitepaper.njk
@@ -18,7 +18,7 @@ layout: layouts/base.njk
                 {{ content | safe }}
             </div>
             <div class="w-72 flex-shrink-0 flex flex-col">
-                <div class="sticky top-4">
+                <div class="sticky top-20">
                     <h5 class="font-medium pb-1 mb-4">Table of Contents</h5>
                     <ul id="toc" class="text-sm border-b mb-10"></ul>
                     <h5 class="font-medium pb-1 mb-4">Download Whitepaper</h5>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -512,7 +512,7 @@ h4:hover .header-anchor {
 */
 @layer components {
     .ff-website .ff-header {
-        @apply bg-white w-full px-6 py-4 sm:py-6 md:py-0 top-0 z-10 relative md:sticky;
+        @apply bg-white w-full px-6 py-4 sm:py-6 md:py-0 top-0 z-50 relative md:sticky;
     }
 
     .ff-website header .ff-wordmark path,

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -512,7 +512,7 @@ h4:hover .header-anchor {
 */
 @layer components {
     .ff-website .ff-header {
-        @apply bg-white w-full px-6 py-4 sm:py-6 md:py-0 top-0 z-10 relative;
+        @apply bg-white w-full px-6 py-4 sm:py-6 md:py-0 top-0 z-10 relative md:sticky;
     }
 
     .ff-website header .ff-wordmark path,

--- a/src/css/style.eleventy.nav.css
+++ b/src/css/style.eleventy.nav.css
@@ -17,7 +17,7 @@
         padding-top: 0.25rem;
         max-height: calc(100vh - 1.5rem);
         overflow-y: auto;
-        @apply sticky top-12 pl-2 sm:pl-6 xl:pl-0;
+        @apply sticky top-14 pl-2 sm:pl-6 xl:pl-0;
     }
 
     .has-children > ul > li:not(.has-children) {

--- a/src/index.njk
+++ b/src/index.njk
@@ -15,11 +15,11 @@ hubspot:
                 <h1 class="font-medium max-w-xl m-auto lg:m-0 text-center lg:text-left text-indigo-800 max-sm:text-4xl">
                     {{ site.messaging.tagLine }}
                 </h1>
-                <p class="mt-6 text-center lg:text-left pb-5">
+                <p class="mt-6 text-center lg:text-left lg:pb-5">
                     {{ site.messaging.subtitle }}
                 </p>
                 <div class="flex flex-col">
-                    <div class="m-auto mt-7 flex gap-4 items-center justify-center lg:items-start lg:justify-start lg:m-0 flex-row">
+                    <div class="m-auto lg:mt-7 flex gap-4 items-center justify-center lg:items-start lg:justify-start lg:m-0 flex-row">
                         <a class="ff-btn ff-btn--highlight flex flex-col mb-6" href="{{ site.appURL }}/account/create"
                             onclick="capture('cta-try-it-now', {'position': 'hero'})">
                             <span class="text-base uppercase items-center">
@@ -101,7 +101,7 @@ hubspot:
             <div class="w-full sm:grid sm:grid-cols-2 gap-6 sm:gap-8">
                 <div class="w-full mt-4 md:mt-0 flex flex-col justify-between">
                     <div>
-                        <div class="flex justify-center sm:justify-start mt-3 mb-2 w-6 h-6">
+                        <div class="flex justify-center sm:justify-start mt-3 mb-2 mx-auto md:mx-0 w-6 h-6">
                             {% include "components/icons/building-office-2.svg" %}
                         </div>
                         <h4 class="flex justify-center sm:justify-start font-semibold">On Premise</h4>
@@ -125,10 +125,13 @@ hubspot:
             </div>
         </div>
         <!-- FF Content -->
-        <div class="w-full px-6">
-            <div class="max-w-md sm:max-w-screen-lg m-auto max-w-5xl pt-12 mt-10 pb-12">
+        <div class="max-w-md sm:max-w-screen-lg m-auto max-w-5xl px-6">
+            <div class="pt-12 mt-10 pb-12">
             <h2 class="text-center w-full md:text-left col-span-full font-medium"><span class="text-indigo-600">Explore more</span> about FlowFuse and Node-RED</h2>
                 {% include "explore-more-content.njk" %}
+            </div>
+            <div class="md:hidden bg-indigo-50 py-1 px-4 rounded-md w-full mx-auto max-md:text-center">
+                <p>Need assistance with your project? <a href="/contact-us/">Contact us</a>, and our experts will gladly provide a solution tailored to your needs.</p>
             </div>
         </div>
     </div>

--- a/src/pricing/index.njk
+++ b/src/pricing/index.njk
@@ -350,7 +350,7 @@ hubspot:
                     <h2><span class="text-indigo-600">Feature</span> Comparison</h2>
                 </div>
                 <!-- Feature List -->
-                <div class="sticky">{{ featuresHtml | safe }}
+                <div>{{ featuresHtml | safe }}
                     {% set hosting = "cloud" %}
                     <div class="contentCloud transition duration-1000 max-w-full overflow-x-scroll sm:overflow-x-visible h-[60vh] sm:h-full">
                         {% include "feature_lists/features-table-base.njk" %}


### PR DESCRIPTION
## Description

- Aiming to make the `Talk to Us` button visible at all times, I've made the main navigation sticky.
- I've also updated the top property of the elements that were already sticky.
- Since the navigation isn't sticky on mobile and the button is only visible if the main navigation is expanded, I've added a "Contact Us" section at the bottom of the homepage

## Related Issue(s)

https://github.com/FlowFuse/customer/issues/225

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
