### PR TITLE
Blueprint pages: Add contact us link

### DIFF
--- a/src/_includes/blueprints/template.njk
+++ b/src/_includes/blueprints/template.njk
@@ -1,8 +1,8 @@
-<div class="ff-blog container m-auto text-left max-w-lg md:max-w-5xl pt-8 pb-24 w-full ff-full-bg px-4">
+<div class="ff-blog container m-auto text-left max-w-lg md:max-w-5xl pt-8 pb-12 w-full ff-full-bg px-4">
     <div class="px-2 flex items-center gap-12">
         <h1 class="mb-0">Blueprint Library</h1>
     </div>
-    <div class="px-2 mt-4 flex text-lg">   
+    <div class="px-2 mt-4 text-lg">   
             <p>Explore FlowFuse Blueprints, choose templates for quick setups, perfect for learning and fast solution-building. Customizable for unique needs. Simplify your Node-RED projects with FlowFuse Blueprints!</p> 
     </div>
 
@@ -12,4 +12,5 @@
         {%- endeach -%}
     </ul>
     {% include "blog/pagination.njk" %}
+    {% include "contact-us-cta-line.njk" %}
 </div>

--- a/src/_includes/contact-us-cta-line.njk
+++ b/src/_includes/contact-us-cta-line.njk
@@ -1,0 +1,3 @@
+<div class="bg-indigo-50 py-1 px-4 rounded-md w-full mx-auto text-center mt-12">
+    <p>Looking for help with your project? <a href="/contact-us/">Contact us</a>; our experts will be happy to provide a solution for your needs.  </p>
+</div>

--- a/src/_includes/layouts/blueprint.njk
+++ b/src/_includes/layouts/blueprint.njk
@@ -21,7 +21,7 @@ layout: layouts/base.njk
             </div>
         </div> -->
     {% endif %}
-    <div class="blog nohero w-full pb-24 pt-20">
+    <div class="blog nohero w-full pb-12 pt-20">
         <div class="container flex flex-col md:flex-row m-auto text-left max-lg:px-6 md:max-w-screen-lg gap-8 items-stretch">
             <div class="ff-prose">
                 <a class="inline-flex align-center gap-1 mb-4" href="/blueprints">
@@ -29,6 +29,7 @@ layout: layouts/base.njk
                     Back to Blueprints Library
                 </a>
                 {{ content | safe }}
+                {% include "contact-us-cta-line.njk" %}
             </div>
         </div>
     </div>

--- a/src/blueprints.njk
+++ b/src/blueprints.njk
@@ -3,7 +3,7 @@ layout: nohero
 sitemapPriority: 0.9
 pagination:
   data: collections.blueprints
-  size: 18
+  size: 12
   alias: blueprints
   reverse: true
 meta:

--- a/src/product/dashboard.njk
+++ b/src/product/dashboard.njk
@@ -124,13 +124,11 @@ meta:
                 {% endfor %}
             </ul>
             <div class="flex justify-end">
-                <a href="/blog/dashboard/" class="font-light hover:underline pt-3 flex flex-row items-center gap-1 cursor-pointer flex-wrap max-md:max-w-md mb-10">
+                <a href="/blog/dashboard/" class="font-light hover:underline pt-3 flex flex-row items-center gap-1 cursor-pointer flex-wrap max-md:max-w-md">
                     Learn more {% include "components/icons/arrow-long-right.svg" %}
                 </a>
             </div>
-            <div class="bg-indigo-50 py-1 px-4 rounded-md w-full mx-auto">
-                <p>Looking for help with your project? <a href="/contact-us/">Contact us</a>; our experts will be happy to provide a solution for your needs.  </p>
-            </div>
+            {% include "contact-us-cta-line.njk" %}
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Description

Added a contact us CTA at the bottom of the blueprint pages. There's no netlify preview for these pages, they work like the docs pages, so I'm attaching screenshots for reference.

`/blueprints`
![image](https://github.com/user-attachments/assets/d2443fc0-778d-405c-8818-f740cb0eb3a9)

`/blueprints/*`
![image](https://github.com/user-attachments/assets/7138ecb8-aef5-4757-bd28-4807aec13035)


## Related Issue(s)

https://github.com/FlowFuse/customer/issues/225

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
