### PR TITLE
Pricing page: Remove cloud/enterprise slider and update trial license text

### DIFF
--- a/src/_data/pricingFeatures.yaml
+++ b/src/_data/pricingFeatures.yaml
@@ -159,9 +159,9 @@ buttons:
     - cta: TRY FOR FREE
       url: https://app.flowfuse.com/account/create
       onclick: "capture('cta-join', {'position': 'secondary'}, {'plan': 'cloud-starter'})"
-    - cta: BOOK A DEMO
-      url: /book-demo/
-      onclick: "capture('cta-book-demo', {'position': 'secondary'}, {'plan': 'cloud-team'})"
+    - cta: CONTACT US
+      url: "#contact-us"
+      onclick: "scrollToAnchor(event, 'contact-us'), capture('cta-contact-us', {'position': 'secondary'}, {'plan': 'team'})"
     - cta: Request a Quote
       url: /pricing/request-quote/
       onclick: "capture('cta-request-quote', {'position': 'secondary'}, {'plan': 'sh-enterprise'})"

--- a/src/pricing/index.njk
+++ b/src/pricing/index.njk
@@ -86,7 +86,7 @@ hubspot:
                                     </ul>
                                 </div>
                             </div>
-                            <div class="mt-9 md:text-left items-left w-full mb-11 md:mt-11 md:mb-0 flex flex-row">
+                            <div class="mt-9 md:text-left items-left w-full mb-11 md:mt-20 md:mb-0 flex flex-row">
                                 <h2 class="self-end">$15</h2>
                                 <div class="pl-1 text-sm leading-4 text-left self-end pb-1">
                                     <note class="note ">/month</note>
@@ -128,7 +128,7 @@ hubspot:
                                     <li id="team-monthly-value" class="value">5</li>
                                 </ul>
                                 <div class="range contentMonthly">
-                                    <input type="range" min="5" max="355" value="5" id="team-monthly-slider" class="transition duration-1000" step="5" />
+                                    <input type="range" min="5" max="105" value="5" id="team-monthly-slider" class="transition duration-1000" step="5" />
                                 </div>
                                 <!-- Price -->
                                 <div id="team-m-original-div" class="mt-3 mb-6 flex flex-row flex-wrap w-full gap-x-2">
@@ -148,30 +148,23 @@ hubspot:
                                         </div>
                                     </div>
                                 </div>
-                                <div id="team-m-alternate-div"
-                                    class="hidden mt-3 mb-6 flex flex-row flex-wrap w-full gap-x-2">
+                                <div id="team-m-alternate-div" class="hidden mt-3 mb-6 flex flex-row flex-wrap w-full gap-x-2">
                                     <div class="text-left flex flex-row">
-                                        <div class="w-16 mr-1">
+                                        <div class="text-left">
                                             <h2 class="self-end">
-                                                <span id="team-monthly-price-int"
-                                                    class="align-top text-6xl leading-9">∞</span>
+                                                <span class="align-top">Let's talk</span>
                                             </h2>
-                                        </div>
-                                        <div class="pl-2 text-sm leading-4 text-left self-end pb-1">
-                                            <note id="team-monthly-price-note" class="note  text-xs">
-                                                instances <br>Billed monthly at <span class="font-semibold">$3,200.00</span><br \></note>
                                         </div>
                                     </div>
                                 </div>
                             </div>
                             <a class="md:self-end ff-btn ff-btn--primary uppercase align-baseline w-full"
-                                href="/book-demo/"
-                                onclick="capture('cta-book-demo', {'position': 'primary'}, {'plan': 'team'})">BOOK A
-                                DEMO</a>
+                                href='#contact-us'
+                                onclick="scrollToAnchor(event, 'contact-us'), capture('cta-contact-us', {'position': 'primary'}, {'plan': 'team'})">Contact Us</a>
                         </div>
                     </div>
                     <!-- Enterprise -->
-                    {% macro enterprise(show_sla=true, show_slider=true) %}
+                    {% macro enterprise(show_sla=true, cloud=true) %}
                     <div class="pricing-tile md:h-full">
                         <div class="pricing-tile-background pb-6 md:grid flex-col">
                             <div>
@@ -197,54 +190,11 @@ hubspot:
                                     </ul>
                                 </div>
                             </div>
-                            {% if show_slider %}
-                            <div data-nosnippet>
-                                <!-- Slider -->
-                                <ul class="font-extralight text-sm leading-7 mt-6 w-full flex flex-row justify-between text-gray-600">
-                                    <li>Instances</li>
-                                    <li id="enterprise-monthly-value" class="value">10</li>
-                                </ul>
-                                <div class="range contentMonthly">
-                                    <input type="range" min="10" max="510" value="10" id="enterprise-monthly-slider"
-                                        class="transition duration-1000" step="10" />
-                                </div>
-                                <!-- Price -->
-                                <div id="enterprise-m-original-div"
-                                    class="mt-3 mb-6 flex flex-row flex-wrap w-full gap-x-2">
-                                    <div class="text-left flex flex-row">
-                                        <div class="w-16 mr-1">
-                                            <h2 class="self-end">
-                                                <span class="align-top text-sm leading-7">$</span><span
-                                                    id="enterprise-monthly-price-int" class="align-top">20</span><span
-                                                    id="enterprise-monthly-price-dec"
-                                                    class="align-top text-sm leading-7">83</span>
-                                            </h2>
-                                        </div>
-                                        <div class="pl-2 text-sm leading-4 text-left self-end pb-1">
-                                            <note id="enterprise-monthly-price-note" class="note text-xs">
-                                            </note>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div id="enterprise-m-alternate-div"
-                                    class="hidden mt-3 mb-6 flex flex-row flex-wrap w-full gap-x-2">
-                                    <div class="text-left">
-                                        <h2 class="self-end">
-                                            <span class="align-top">Let's talk</span>
-                                        </h2>
-                                    </div>
-                                </div>
-                            </div>
-                            <a class="md:self-end ff-btn ff-btn--primary uppercase align-baseline w-full"
-                                href='#contact-us'
-                                onclick="scrollToAnchor(event, 'contact-us'), capture('cta-contact-us', {'position': 'primary'}, {'plan': 'enterprise'})">Contact Us</a>
-                            {% else %}
-                            <div class="mt-9 md:text-left items-left w-full mb-11 md:mt-11 md:mb-3 flex flex-row">
+                            <div class="mt-9 md:text-left items-left w-full mb-11 {% if cloud %}md:mt-20 {% endif %}md:mb-3 flex flex-row">
                                 <h2 class="self-end">Let's Talk</h2>
                             </div>
                             <a class="md:self-end ff-btn ff-btn--primary uppercase align-baseline w-full"
                             href="/book-demo/" onclick="capture('cta-lets-talk', {'position': 'primary'}, {'plan': 'sh-enterprise'})">book a demo</a>
-                            {% endif %}
                         </div>
                     </div>
                     {% endmacro %}
@@ -252,7 +202,7 @@ hubspot:
                 </div>
             </div>
             <!-- Self-hosted -->
-            <div class="contentSelfHosted hide m-auto transition duration-1000 md:min-h-[547px]">
+            <div class="contentSelfHosted hide m-auto transition duration-1000 md:min-h-[500px]">
                 <div class="pricing-tiles flex flex-col md:grid md:flex-row md:max-w-screen-sm mt-4 md:mt-0">
                     <!-- Starter -->
                     <div class="pricing-tile md:h-full">
@@ -274,7 +224,7 @@ hubspot:
                                     </ul>
                                 </div>
                             </div>
-                            <div class="mt-9 md:text-left items-left w-full mb-11 md:mt-11 md:mb-3 flex flex-row">
+                            <div class="mt-9 md:text-left items-left w-full mb-11 md:mb-3 flex flex-row">
                                 <h2 class="self-end">Free</h2>
                             </div>
                             <a class="md:self-end ff-btn ff-btn--primary uppercase align-baseline w-full"
@@ -288,7 +238,7 @@ hubspot:
                 </div>
             </div>
             <!-- Dedicated -->
-            <div class="contentDedicated hide m-auto transition duration-1000 md:min-h-[547px] w-full mb-12">
+            <div class="contentDedicated hide m-auto transition duration-1000 md:min-h-[500px] w-full mb-12">
                 <div class="pricing-tiles flex flex-col md:grid md:flex-row md:max-w-screen-lg mt-4 md:mt-0">
                     <!-- Card -->
                     <div class="pricing-tile md:h-full">
@@ -401,9 +351,7 @@ hubspot:
                     Request a trial license
                 </h3>
                 <p>
-                    Unlock the complete potential of FlowFuse with a complimentary 30-day Enterprise license. This trial
-                    gives you the chance to explore all the features and functionalities of FlowFuse in your own
-                    environment. To start your trial, just fill out the form.
+                    Unlock the complete potential of FlowFuse with a complimentary 30-day Enterprise license. This trial gives you the chance to explore all the features and functionalities of FlowFuse in your own environment. To start your trial, simply fill out the form. Our sales team will reach out to you to discuss your needs and provide the license.
                 </p>
             </div>
             {% hubspotForm hubspot.selfHosted.formId, hubspot.selfHosted.cta, hubspot.reference, 'trialLicenseForm' %}
@@ -523,8 +471,7 @@ hubspot:
 
             // Map slider IDs to div IDs
             const divIds = {
-                "#team-monthly-slider": ["#team-m-original-div", "#team-m-alternate-div", 350],
-                "#enterprise-monthly-slider": ["#enterprise-m-original-div", "#enterprise-m-alternate-div", 500]
+                "#team-monthly-slider": ["#team-m-original-div", "#team-m-alternate-div", 100],
             };
 
             // Check if the slider ID is in the divIds map
@@ -549,19 +496,14 @@ hubspot:
             const progress = (tempSliderValue / sliderEl.max) * 100;
             sliderEl.style.background = `linear-gradient(to right, #4F46E5 ${progress}%, #A5B4FC ${progress}%)`;
 
-            let discountedPriceMonthly;
-            if (tempSliderValue > 250 && sliderId === "#team-monthly-slider") {
-                discountedPriceMonthly = 3200 / tempSliderValue;
-            } else {
-                const discount = ((tempSliderValue - stepSize) / stepSize) * 0.01;
-                discountedPriceMonthly = (basePrice * (1 - discount)) / 12;
-            }
+            const discount = ((tempSliderValue - stepSize) / stepSize) * 0.01;
+            let discountedPriceMonthly = (basePrice * (1 - discount)) / 12;
 
             const [intValue, decValue] = discountedPriceMonthly.toFixed(2).split(".");
             priceIntElement.textContent = intValue;
             priceDecElement.textContent = decValue;
 
-            const totalMonthlyPrice = sliderId === "#team-monthly-slider" && tempSliderValue > 250 ? 3200 : discountedPriceMonthly * tempSliderValue;
+            const totalMonthlyPrice = discountedPriceMonthly * tempSliderValue;
 
             priceNoteElement.innerHTML = `/instance a month <br>Billed monthly at <span class="font-semibold">$${totalMonthlyPrice.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span><br \\>`;
         })
@@ -571,7 +513,6 @@ hubspot:
 
     // Setup the sliders
     setupPricingSlider("#team-monthly-slider", 300, 5, "#team-monthly-price-int", "#team-monthly-price-dec", "#team-monthly-value", "#team-monthly-price-note");
-    setupPricingSlider("#enterprise-monthly-slider", 600, 10, "#enterprise-monthly-price-int", "#enterprise-monthly-price-dec", "#enterprise-monthly-value", "#enterprise-monthly-price-note");
 </script>
 
 <!-- Features info -->


### PR DESCRIPTION
## Description

- Removed the cloud/enterprise slider
- Updated the trial license text to make it clear that they will talk to sales to get the license
- Swapped CTAs, now `Book a Demo` is always the CTA for the entreprise tier and contact us for team.

## Related Issue(s)

https://github.com/FlowFuse/website/issues/2392

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
