### PR TITLE
Catch for /decide API call to PostHog & reduce edge function traffic

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -85,3 +85,4 @@ package = "netlify-plugin-cache"
 [[edge_functions]]
 function = "eleventy-edge"
 path = "/*"
+excludedPath = ["/*.css", "/*.png", "/*.jpg", "/*.svg", "/*.webmanifest", "/*.js", "/*.htm", "/*.html"]

--- a/netlify/edge-functions/eleventy-edge.js
+++ b/netlify/edge-functions/eleventy-edge.js
@@ -77,6 +77,9 @@ async function getPHFeatureFlags (distinctId) {
           return response.json()
       }).then((data) => {
           resolve(data.featureFlags)
+      }).catch((err) => {
+          console.error("Error getting feature flags > ", err)
+          resolve({})
       })
   })
 }
@@ -99,7 +102,7 @@ async function featureFlagCalled (distinctId, feature, value) {
       }).then((data) => {
           resolve(data)
       }).catch((err) => {
-          console.error(err)
+          console.error("Error capturing feature flag called event > ", err)
       })
   })
 }


### PR DESCRIPTION
## Description

- Ensure we have a `catch()` on all `fetch` requests
- Add a fallback of `{}` on `getPHFeatureFlags` to ensure we fallback to control if errors occur
- Uses Netlify's `excludedPath` to prevent edge functions running on _every_ resource (e.g. pngs, js, css) ([docs](https://docs.netlify.com/edge-functions/declarations/#declare-edge-functions-in-netlify-toml))