### PR TITLE
Handbook and docs: Adjust max-width for pre elements

### DIFF
--- a/src/css/style.handbook.css
+++ b/src/css/style.handbook.css
@@ -9,7 +9,7 @@
     }
 
     .handbook .prose {
-        max-width: none;
+        @apply max-w-full;
     }
 
     .handbook-nav {
@@ -132,8 +132,10 @@
         @apply lg:max-w-[calc(100vw-610px)];
     }
 
+    .handbook div[style="position: relative"],
     .handbook pre {
-        max-width: max-content;
+        width: max-content;
+        @apply max-w-full lg:max-w-[calc(100vw-580px)] xl:max-w-[calc(100vw-630px)]  2xl:max-w-[calc(100vw-690px)];
     }
 
     /* Define animation transitions for all child UL elements */

--- a/src/css/style.nohero.css
+++ b/src/css/style.nohero.css
@@ -42,10 +42,6 @@
     line-height: 2.9rem;
 }
 
-.prose code::after {
-    content: '' !important;
-}
-
 .prose code::before {
     content: '' !important;
 }


### PR DESCRIPTION
## Description

This PR addresses an issue with the max-width of the parent element of `<pre>` elements in our handbook and docs pages. Previously, when the content inside the `<pre>` tag was too long, it would stretch the parent element beyond the max-width of the grandparent element, pushing the nav bars off the screen if they were too small.

This change adjusts the max-width property of the parent of `<pre>` elements to prevent this issue and removes extra space at the bottom of the code blocks.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
