### PR TITLE
Handbook and docs: Remove ' at the end of inline code blocks

### DIFF
--- a/src/css/style.nohero.css
+++ b/src/css/style.nohero.css
@@ -42,6 +42,10 @@
     line-height: 2.9rem;
 }
 
+.prose code::after {
+    content: '' !important;
+}
+
 .prose code::before {
     content: '' !important;
 }


### PR DESCRIPTION
## Description

Bring back the `after` class that removes the  ` at the end of the inline code blocks.

I'll follow up on this one because it's adding extra space at the bottom of some code blocks.
i.e.
<img width="537" alt="Screenshot 2024-07-29 at 17 02 59" src="https://github.com/user-attachments/assets/a4168804-f79b-42f3-8d42-86b3035d9370">
`/handbook/development/packaging/`

## Related Issue(s)

#2400 and https://github.com/FlowFuse/website/pull/2399#discussion_r1695383656

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
