### PR TITLE
Fix: Install local docs references

### DIFF
--- a/src/blog/2022/02/flowforge-02-released.md
+++ b/src/blog/2022/02/flowforge-02-released.md
@@ -47,7 +47,7 @@ of the platform:
 ### Upgrading FlowFuse
 
 If you installed FlowFuse 0.1 and want to upgrade, our documentation provides a
-guide for [upgrading FlowFuse on a local server](/docs/install/introduction/).
+guide for [upgrading FlowFuse on a local server](/docs/upgrade/).
 
 ### Getting help
 

--- a/src/blog/2022/02/flowforge-02-released.md
+++ b/src/blog/2022/02/flowforge-02-released.md
@@ -47,7 +47,7 @@ of the platform:
 ### Upgrading FlowFuse
 
 If you installed FlowFuse 0.1 and want to upgrade, our documentation provides a
-guide for [upgrading FlowFuse on a local server](https://github.com/FlowFuse/flowfuse/tree/main/docs/install/local#upgrade).
+guide for [upgrading FlowFuse on a local server](/docs/install/introduction/).
 
 ### Getting help
 

--- a/src/blog/2022/03/flowforge-03-released.md
+++ b/src/blog/2022/03/flowforge-03-released.md
@@ -86,7 +86,7 @@ of the platform:
 ### Upgrading FlowFuse
 
 If you installed FlowFuse 0.1 or 0.2 and want to upgrade, our documentation provides a
-guide for [upgrading FlowFuse on a local server](https://github.com/FlowFuse/flowfuse/tree/main/docs/install/local#upgrade).
+guide for [upgrading FlowFuse on a local server](/docs/install/introduction/).
 
 ### Getting help
 

--- a/src/blog/2022/03/flowforge-03-released.md
+++ b/src/blog/2022/03/flowforge-03-released.md
@@ -86,7 +86,7 @@ of the platform:
 ### Upgrading FlowFuse
 
 If you installed FlowFuse 0.1 or 0.2 and want to upgrade, our documentation provides a
-guide for [upgrading FlowFuse on a local server](/docs/install/introduction/).
+guide for [upgrading FlowFuse on a local server](/docs/upgrade/).
 
 ### Getting help
 

--- a/src/blog/2023/01/flowforge-1-3-0-released.md
+++ b/src/blog/2023/01/flowforge-1-3-0-released.md
@@ -62,7 +62,7 @@ If you're interested in contributing, checkout our [guide in the docs](/docs/con
 ## Try it out
 
 We're confident you can have self managed FlowFuse running locally in under 30 minutes.
-You can install our [local build](/docs/contribute/local/), use [Docker](/docs/install/docker/), or [Kubernetes](/docs/install/kubernetes/).
+You can install FlowFuse yourself via a variety of install options. You can find out more details [here](/docs/install/introduction/).
 
 If you'd rather use our hosted offering: [Get started for free]({{ site.appURL }}/account/create) on FlowFuse Cloud.
 

--- a/src/blog/2023/02/flowforge-1-4-0-released.md
+++ b/src/blog/2023/02/flowforge-1-4-0-released.md
@@ -77,7 +77,7 @@ If you're interested in contributing, checkout our [guide in the docs](/docs/con
 ## Try it out
 
 We're confident you can have self managed FlowFuse running locally in under 30 minutes.
-You can install our [local build](/docs/contribute/local/), use [Docker](/docs/install/docker/), or [Kubernetes](/docs/install/kubernetes/).
+You can install FlowFuse yourself via a variety of install options. You can find out more details [here](/docs/install/introduction/).
 
 If you'd rather use our hosted offering: [Get started for free]({{ site.appURL }}/account/create) on FlowFuse Cloud.
 

--- a/src/blog/2023/03/flowforge-1-5-0-released.md
+++ b/src/blog/2023/03/flowforge-1-5-0-released.md
@@ -70,7 +70,7 @@ FlowFuse Cloud is a great place to try out the new Node-RED features, with FlowF
 ## Try it out
 
 We're confident you can have self managed FlowFuse running locally in under 30 minutes.
-You can install our [local build](/docs/contribute/local/), use [Docker](/docs/install/docker/), or [Kubernetes](/docs/install/kubernetes/).
+You can install FlowFuse yourself via a variety of install options. You can find out more details [here](/docs/install/introduction/).
 
 If you'd rather use our hosted offering: [Get started for free]({{ site.appURL }}/account/create) on FlowFuse Cloud.
 

--- a/src/blog/2023/04/flowforge-1-6-released.md
+++ b/src/blog/2023/04/flowforge-1-6-released.md
@@ -59,7 +59,7 @@ Application Overview: “Open Editor” shouldn’t show (or should be disabled)
 ## Try it out
 
 We're confident you can have self managed FlowFuse running locally in under 30 minutes.
-You can install our [local build](/docs/contribute/local/), use [Docker](/docs/install/docker/), or [Kubernetes](/docs/install/kubernetes/).
+You can install FlowFuse yourself via a variety of install options. You can find out more details [here](/docs/install/introduction/).
 
 If you'd rather use our hosted offering: [Get started for free]({{ site.appURL }}/account/create) on FlowFuse Cloud.
 

--- a/src/blog/2023/05/flowforge-1-7-released.md
+++ b/src/blog/2023/05/flowforge-1-7-released.md
@@ -88,7 +88,7 @@ Cannot select "Member" option when inviting a team member [#2084](https://github
 ## Try it out
 
 We're confident you can have self managed FlowFuse running locally in under 30 minutes.
-You can install our [local build](/docs/contribute/local/), use [Docker](/docs/install/docker/), or [Kubernetes](/docs/install/kubernetes/).
+You can install FlowFuse yourself via a variety of install options. You can find out more details [here](/docs/install/introduction/).
 
 If you'd rather use our hosted offering: [Get started for free]({{ site.appURL }}/account/create) on FlowFuse Cloud.
 

--- a/src/blog/2023/06/flowforge-1-8-released.md
+++ b/src/blog/2023/06/flowforge-1-8-released.md
@@ -81,7 +81,7 @@ HOME env var not set within Node-RED process [#117](https://github.com/FlowFuse/
 ## Try it out
 
 We're confident you can have self managed FlowFuse running locally in under 30 minutes.
-You can install our [local build](/docs/contribute/local/), use [Docker](/docs/install/docker/), or [Kubernetes](/docs/install/kubernetes/).
+You can install FlowFuse yourself via a variety of install options. You can find out more details [here](/docs/install/introduction/).
 
 If you'd rather use our hosted offering: [Get started for free]({{ site.appURL }}/account/create) on FlowFuse Cloud.
 

--- a/src/blog/2023/07/flowforge-1-9-3-release.md
+++ b/src/blog/2023/07/flowforge-1-9-3-release.md
@@ -44,7 +44,7 @@ Together, we can make FlowFuse better with each release!
 ## Try it out
 
 We're confident you can have self managed FlowFuse running locally in under 30 minutes.
-You can install our [local build](/docs/contribute/local/), use [Docker](/docs/install/docker/), or [Kubernetes](/docs/install/kubernetes/).
+You can install FlowFuse yourself via a variety of install options. You can find out more details [here](/docs/install/introduction/).
 
 If you'd rather use our hosted offering: [Get started for free]({{ site.appURL }}/account/create) on FlowFuse Cloud.
 

--- a/src/blog/2023/07/flowforge-1-9-release.md
+++ b/src/blog/2023/07/flowforge-1-9-release.md
@@ -70,7 +70,7 @@ Together, we can make FlowFuse better with each release!
 ## Try it out
 
 We're confident you can have self managed FlowFuse running locally in under 30 minutes.
-You can install our [local build](/docs/contribute/local/), use [Docker](/docs/install/docker/), or [Kubernetes](/docs/install/kubernetes/).
+You can install FlowFuse yourself via a variety of install options. You can find out more details [here](/docs/install/introduction/).
 
 If you'd rather use our hosted offering: [Get started for free]({{ site.appURL }}/account/create) on FlowFuse Cloud.
 

--- a/src/blog/2023/08/flowforge-1-10-release.md
+++ b/src/blog/2023/08/flowforge-1-10-release.md
@@ -59,7 +59,7 @@ Together, we can make FlowFuse better with each release!
 ## Try it out
 
 We're confident you can have self managed FlowFuse running locally in under 30 minutes.
-You can install our [local build](/docs/contribute/local/), use [Docker](/docs/install/docker/), or [Kubernetes](/docs/install/kubernetes/).
+You can install FlowFuse yourself via a variety of install options. You can find out more details [here](/docs/install/introduction/).
 
 If you'd rather use our hosted offering: [Get started for free]({{ site.appURL }}/account/create) on FlowFuse Cloud.
 

--- a/src/blog/2023/08/flowfuse-1-11-release.md
+++ b/src/blog/2023/08/flowfuse-1-11-release.md
@@ -60,7 +60,7 @@ Together, we can make FlowFuse better with each release!
 ## Try it out
 
 We're confident you can have self managed FlowFuse running locally in under 30 minutes.
-You can install our [local build](/docs/contribute/local/), use [Docker](/docs/install/docker/), or [Kubernetes](/docs/install/kubernetes/).
+You can install FlowFuse yourself via a variety of install options. You can find out more details [here](/docs/install/introduction/).
 
 If you'd rather use our hosted offering: [Get started for free]({{ site.appURL }}/account/create) on FlowFuse Cloud.
 

--- a/src/blog/2024/01/flowfuse-release-2-0.md
+++ b/src/blog/2024/01/flowfuse-release-2-0.md
@@ -39,7 +39,7 @@ At FlowFuse, our mission is to empower bottom-up innovation and enable organizat
 
 ## How to get started
 
-You can install our [local build](/docs/contribute/local/), use [Docker](/docs/install/docker/), or [Kubernetes](/docs/install/kubernetes/).
+You can install FlowFuse yourself via a variety of install options. You can find out more details [here](/docs/install/introduction/).
 
 If you'd rather use our hosted offering: [Get started for free]({{ site.appURL }}/account/create) on FlowFuse Cloud.
 

--- a/src/blog/2024/05/flowfuse-2-4-release.md
+++ b/src/blog/2024/05/flowfuse-2-4-release.md
@@ -57,7 +57,7 @@ Together, we can make FlowFuse better with each release!
 ## Try it out
 
 We're confident you can have self managed FlowFuse running locally in under 30 minutes.
-You can install our [local build](/docs/contribute/local/), use [Docker](/docs/install/docker/), or [Kubernetes](/docs/install/kubernetes/).
+You can install FlowFuse yourself via a variety of install options. You can find out more details [here](/docs/install/introduction/).
 
 If you'd rather use our hosted offering: [Get started for free]({{ site.appURL }}/account/create) on FlowFuse Cloud.
 

--- a/src/blog/2024/06/flowfuse-2-5-release.md
+++ b/src/blog/2024/06/flowfuse-2-5-release.md
@@ -60,7 +60,7 @@ Together, we can make FlowFuse better with each release!
 ## Try it out
 
 We're confident you can have self managed FlowFuse running locally in under 30 minutes.
-You can install our [local build](/docs/contribute/local/), use [Docker](/docs/install/docker/), or [Kubernetes](/docs/install/kubernetes/).
+You can install FlowFuse yourself via a variety of install options. You can find out more details [here](/docs/install/introduction/).
 
 If you'd rather use our hosted offering: [Get started for free]({{ site.appURL }}/account/create) on FlowFuse Cloud.
 

--- a/src/blog/2024/07/flowfuse-2-6-release.md
+++ b/src/blog/2024/07/flowfuse-2-6-release.md
@@ -109,7 +109,7 @@ Together, we can make FlowFuse better with each release!
 
 ### Self-Hosted
 
-We're confident you can have self managed FlowFuse running locally in under 30 minutes. You can install our [local build](/docs/contribute/local/), use [Docker](/docs/install/docker/), or [Kubernetes](/docs/install/kubernetes/).
+We're confident you can have self managed FlowFuse running locally in under 30 minutes. You can install FlowFuse yourself via a variety of install options. You can find out more details [here](/docs/install/introduction/).
 
 ### FlowFuse Cloud
 


### PR DESCRIPTION
## Description

Local installation documentation was removed, and whilst references inside the documentation were updated, we had many references in the blogs too.
