### PR TITLE
Device Agent: Update Links to Direct to Landing Page Instead of Docs

### DIFF
--- a/src/_includes/core-nodes/write-file-use-case.md
+++ b/src/_includes/core-nodes/write-file-use-case.md
@@ -1,6 +1,6 @@
 ## What is the Write File Node in Node-RED?
 
-The "Write File" node in Node-RED is used to write data to a file on the filesystem. It's commonly employed in flows where you need to save data or logs for later analysis or storage. In FlowFuse Cloud, the Write File node interacts with a cloud-based storage solution, leveraging AWS S3 for file storage. However, in the Node-RED instance running on edge devices using the [ FlowFuse device agent](/docs/device-agent/introduction/), this node will interact with the local file system of that device. The content to be written is specified using `msg.payload`.
+The "Write File" node in Node-RED is used to write data to a file on the filesystem. It's commonly employed in flows where you need to save data or logs for later analysis or storage. In FlowFuse Cloud, the Write File node interacts with a cloud-based storage solution, leveraging AWS S3 for file storage. However, in the Node-RED instance running on edge devices using the [ FlowFuse device agent](/product/device-agent/), this node will interact with the local file system of that device. The content to be written is specified using `msg.payload`.
 
 # Configuring the Write File Node in Node-RED:
 

--- a/src/blog/2024/03/scaling-node-red-devices-vs-flowfuse-instance.md
+++ b/src/blog/2024/03/scaling-node-red-devices-vs-flowfuse-instance.md
@@ -26,7 +26,7 @@ FlowFuse functions as an orchestration tool that allows the deployment and manag
 
 ## Deploying Node-RED Next to Devices
 
-One common issue in IoT deployments is that device instances of Node-RED often communicate with unsecure devices or networks. To mitigate security risks and ensure data protection, it's common to deploy Node-RED in close proximity to these devices. The FlowFuse platform uses [device agents](/docs/device-agent/introduction/) that communicate back to the platform via a reverse tunnel over port 443. This setup requires only one firewall rule: allowing outbound connections from the [device agent](/docs/device-agent/introduction/) running Node-RED to the FlowFuse platform, significantly minimizing security risks while enabling remote monitoring, flow editing, and configuration deployment at scale.
+One common issue in IoT deployments is that device instances of Node-RED often communicate with unsecure devices or networks. To mitigate security risks and ensure data protection, it's common to deploy Node-RED in close proximity to these devices. The FlowFuse platform uses [device agents](/product/device-agent/) that communicate back to the platform via a reverse tunnel over port 443. This setup requires only one firewall rule: allowing outbound connections from the [device agent](/product/device-agent/) running Node-RED to the FlowFuse platform, significantly minimizing security risks while enabling remote monitoring, flow editing, and configuration deployment at scale.
 
 ## Deploying Node-Red Instances Within the FlowFuse Platform
 

--- a/src/blog/2024/05/mapping-location-on-dashboard-2.md
+++ b/src/blog/2024/05/mapping-location-on-dashboard-2.md
@@ -109,7 +109,7 @@ To render worlmap webpage on dashboard 2.0 we will use **iframe** custom widget 
 1. With your flow updated to include the above, click the **Deploy** button in the top-right of the Node-RED Editor.
 2. Locate the **Open Dashboard** button at the top-right corner of the Dashboard 2.0 sidebar and click on it to navigate to the dashboard.
 
-Now you can view the live location of Edinburgh public transport vehicles on the dashboard. Additionally, clicking on each vehicle reveals further details such as its name, speed, and other properties you've included. Moreover, if you wish to track the live locations of your own vehicles instead of Edinburgh's public transport vehicles, you can connect your devices and access GPS and sensor data using the [Flowfuse device agent](/docs/device-agent/introduction/).
+Now you can view the live location of Edinburgh public transport vehicles on the dashboard. Additionally, clicking on each vehicle reveals further details such as its name, speed, and other properties you've included. Moreover, if you wish to track the live locations of your own vehicles instead of Edinburgh's public transport vehicles, you can connect your devices and access GPS and sensor data using the [Flowfuse device agent](/product/device-agent/).
 
 ## Conclusion 
 

--- a/src/blog/2024/05/node-red-mind-stack-with-flowfuse.md
+++ b/src/blog/2024/05/node-red-mind-stack-with-flowfuse.md
@@ -29,7 +29,7 @@ It often makes sense to deploy a full MING stack, but in some deployments, it mi
 
 FlowFuse has a built-in feature called [project link nodes](/docs/user/projectnodes/), which leverages MQTT, that allows the communication of data between FlowFuse runtimes of Node-RED. One caveat is that this MQTT broker is only available within the FlowFuse platform. What this means is there needs to be some form of translation to be done within Node-RED.  This isn’t a big deal for small deployments, because often Node-RED runtimes at the edger are collecting data from various sources that aren’t MQTT. The flow of data is as follows: 
 
-Sensor > Node-RED([FlowFuse Device Agent](https://flowfuse.com/docs/device-agent/introduction/)) > [MQTT Encapsulated by FlowFuse](/docs/user/projectnodes/) > Node-RED(FlowFuse Platform) > InfluxDB
+Sensor > Node-RED([FlowFuse Device Agent](/product/device-agent/)) > [MQTT Encapsulated by FlowFuse](/docs/user/projectnodes/) > Node-RED(FlowFuse Platform) > InfluxDB
 
 !["Screenshot showing the flow of data: Sensor > Node-RED(FlowFuse Device Agent) > MQTT Encapsulated by FlowFuse > Node-RED(FlowFuse Platform) > InfluxDB"](./images/sensor-data-mqtt-node-red-dashboard-influxdb.png ""){data-zoomable}
 

--- a/src/solutions/manufacturing.njk
+++ b/src/solutions/manufacturing.njk
@@ -243,7 +243,7 @@ description:
                             Run Node-RED where the data is generated. Manage thousands of edge devices through the FlowFuse Device Agent.
                         </p>
                     </div>
-                    <a class="md:self-end ff-btn ff-btn--primary-outlined uppercase align-baseline w-full mt-3" href="/docs/device-agent/introduction/">MORE INFO</a>
+                    <a class="md:self-end ff-btn ff-btn--primary-outlined uppercase align-baseline w-full mt-3" href="/product/device-agent/">MORE INFO</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Description

Since we now have a landing page dedicated to the Device Agent, I've updated the links that previously directed to the documentation to now point to the landing page, which also includes a link to the documentation.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
