### PR TITLE
Cookies: Implement Country-Based PostHog Opt-Out

### DIFF
--- a/netlify/edge-functions/country.js
+++ b/netlify/edge-functions/country.js
@@ -1,0 +1,11 @@
+export default async (request, context) => {
+    const countryCode = context.geo?.country?.code || "UNKNOWN";
+
+    return new Response(countryCode, {
+        headers: { "content-type": "text/plain" },
+    });
+};
+
+export const config = {
+    path: "/country",
+};

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -392,12 +392,31 @@ eleventyComputed:
     }
 
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    posthog.init('{{ POSTHOG_APIKEY }}', {
-        api_host:'https://eu.posthog.com',
-        bootstrap: phBootstrap,
-        capture_pageleave: false,
-        opt_out_capturing_by_default: true
-    })
+    let optOutByDefault = false;
+
+    fetch('/country')
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('Failed to fetch country code from edge function');
+            }
+            return response.text();
+        })
+        .then(countryCode => {
+            const optOutCountries = ['AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'ES', 'FI', 'FR', 'DE', 'GR', 'HU', 'IE', 'IT', 'LV', 'LT', 'LU', 'MT', 'NL', 'PL', 'PT', 'RO', 'SK', 'SI', 'SE', 'GB', 'US-CA', 'BR', 'CA', 'AU'];
+            optOutByDefault = optOutCountries.includes(countryCode);
+        })
+        .catch(error => {
+            console.error('Initializing PostHog with opt_out_capturing_by_default set to true due to Fetch failed by:', error);
+            optOutByDefault = true;
+        })
+        .finally(() => {
+            posthog.init('{{ POSTHOG_APIKEY }}', {
+                api_host:'https://eu.posthog.com',
+                bootstrap: phBootstrap,
+                capture_pageleave: false,
+                opt_out_capturing_by_default: optOutByDefault
+            });
+        });
     /*
         Custom pageleave handler to track scroll
     */


### PR DESCRIPTION
## Description

With the reinstallation of the Edge plugin and the inspiration gained from [this documentation](https://edge-functions-examples.netlify.app/example/localized-content), I decided to leverage it to localize the default cookie consent. This change uses the functionality of Edge Functions to determine the user's location and adjust the cookie consent accordingly. I based this implementation on [this example](https://github.com/netlify/examples/blob/main/examples/edge-functions/netlify/edge-functions/localized-content.js).

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
