### PR TITLE
Adjust Anchor Position to Prevent Hidden Headers

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -353,6 +353,19 @@ eleventyComputed:
             </div>
         </div>
     </footer>
+    <script>
+        // Adjust anchors so they don't get hidden behind the sticky header
+        function adjustAnchor() {
+            window.scrollBy(0, -70);
+        }
+
+        window.addEventListener('hashchange', adjustAnchor);
+
+        // Run adjustAnchor on page load if there's a hash
+        if (window.location.hash) {
+            window.addEventListener('load', adjustAnchor);
+        }
+    </script>
 </body>
 <script>
     document.getElementById('nav-toggle').onclick = function(){
@@ -363,7 +376,6 @@ eleventyComputed:
         classes.toggle("mobile-open");
     }
 </script>
-
 <!-- Youtube Facade -->
 <script async src="https://cdn.jsdelivr.net/npm/lite-youtube-embed@0.2.0/src/lite-yt-embed.min.js"></script>
 <link rel="preload" href="https://cdn.jsdelivr.net/npm/lite-youtube-embed@0.2.0/src/lite-yt-embed.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'" crossorigin="anonymous" referrerpolicy="no-referrer" />


### PR DESCRIPTION
## Description

This PR introduces a script that adjusts the position of anchors to prevent headers from being hidden behind the sticky navigation bar. 

The script works by scrolling the page up by the height of the navigation bar whenever a hashchange event occurs or the page loads with a hash in the URL. This ensures that the header associated with the anchor is not hidden behind the navigation bar.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
