### PR TITLE
Escape html entities in flow json

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -115,8 +115,8 @@ module.exports = function(eleventyConfig) {
         flowId++; // Increment the flowId to allow multiple flows on the same page
 
         return `<div id="nr-flow-${flowId}" style="height: ${height}px" data-grid-lines="true" data-zoom="true" data-images="true" data-link-lines="false" data-labels="true"></div>
-        <script type="module">const flow${flowId} = ${JSON.stringify(flow)};
-        new FlowRenderer().renderFlows(JSON.parse(flow${flowId}), { container: document.getElementById('nr-flow-${flowId}') })</script>`
+        <script type="module">const flow${flowId} = ${JSON.stringify(flow).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')};
+        new FlowRenderer().renderFlows(JSON.parse(flow${flowId}.replace(/&gt;/g,'>').replace(/&lt;/g,'<').replace(/&amp;/g,'&')), { container: document.getElementById('nr-flow-${flowId}') })</script>`
     });
 
     eleventyConfig.addGlobalData("coreNodesArray", () => {


### PR DESCRIPTION
The `{%renderFlow%}` short code was failing if the embedded flow included the text `</script>` - because that was being embedded in the page as-is and causing the browser to close the script block mid-flow json.

This PR fixes it by escaping `&`, `<` and `>` (in that order specifically) before embedding the JSON in the page. Then, the code that runs in the page reverses the escaping before passing to `JSON.parse`.

I have verified this fixes it for the flow I was trying to embed. Have also browsed through a random selection of previous blog posts that include embedded flows and they all appear okay.