### PR TITLE
Exclude Main Branch from Algolia Crawl

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -71,7 +71,7 @@ publish = "_site"
 [[plugins]]
 package = "@algolia/netlify-plugin-crawler"
   [plugins.inputs]
-  branches = ['main', 'live']
+  branches = ['live']
   template = "hierarchical"
 
 [[plugins]]


### PR DESCRIPTION
## Description

This PR updates our Algolia search setup to exclude the `main` branch from the crawl process. 

Previously, we were crawling both the `main` and `live` branches, which was causing us to reach our Algolia record limit due to the creation of temporary indices. 

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
