### PR TITLE
Nav bar main CTA A/B Test: Remove feature flag

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -253,14 +253,7 @@ eleventyComputed:
 			            <li class="flex"><a href="{{ site.appURL }}">Sign In</a></li>
 			            <li class="flex"><a href="{{ site.appURL }}/account/create" onclick="capture('cta-join', {'position': 'header'})">Free Trial</a></li>
                         <a class="ml-2 ff-btn ff-btn--primary uppercase text-sm inline-flex" href="/contact-us" onclick="capture('cta-talk-us', {'position': 'header'})">
-                            {% edge "liquid" %}
-                                {% abtesting "ab-talk-to-us", "control" %}
-                                    Talk to us
-                                {% endabtesting %}
-                                {% abtesting "ab-talk-to-us", "contact-us" %}
-                                    Contact us
-                                {% endabtesting %}
-                            {% endedge %}
+                            Contact us
                         </a>
                     </ul>
                 </nav>
@@ -270,7 +263,7 @@ eleventyComputed:
                         <a href="{{ site.appURL }}" class="ff-btn ff-btn--primary-outlined">Sign In</a>
                         <a href="{{ site.appURL }}/account/create" onclick="capture('cta-join', {'position': 'header'})" class="ff-btn ff-btn--primary-outlined">Free Trial</a>
                     </div>
-                    <a class="ff-btn ff-btn--primary" href="/contact-us" onclick="capture('cta-talk-to-sales', {'position': 'header'})">Talk to Sales</a>
+                    <a class="ff-btn ff-btn--primary" href="/contact-us" onclick="capture('cta-talk-to-sales', {'position': 'header'})">Contact Us</a>
                 </div>    
             </header>
             <!-- Main Content -->


### PR DESCRIPTION
## Description
The A/B test results indicate that `Contact Us `outperforms `Talk to Us` as the main CTA. Therefore, I’m removing the feature flag and setting `Contact Us` as the permanent CTA.

<img width="1014" alt="Screenshot 2024-08-20 at 15 17 20" src="https://github.com/user-attachments/assets/7defc7fb-0c92-4993-a28e-cc13e8366802">


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
