### PR TITLE
Blueprints: Add prose class

### DIFF
--- a/src/_includes/layouts/blueprint.njk
+++ b/src/_includes/layouts/blueprint.njk
@@ -23,7 +23,7 @@ layout: layouts/base.njk
     {% endif %}
     <div class="blog nohero w-full pb-12 pt-20">
         <div class="container flex flex-col md:flex-row m-auto text-left max-lg:px-6 md:max-w-screen-lg gap-8 items-stretch">
-            <div class="ff-prose">
+            <div class="ff-prose prose max-w-none">
                 <a class="inline-flex align-center gap-1 mb-4" href="/blueprints">
                     {% include "components/icons/chevron-left.svg" %}
                     Back to Blueprints Library


### PR DESCRIPTION
## Description

Lists elements were not rendering properly, this PR introduces the `prose` class that aligns the style with the blog, handbook and docs sections

## Related Issue(s)

#2557

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
