### PR TITLE
Add promo banner to docs pages

### DIFF
--- a/src/_data/docs_banner.yaml
+++ b/src/_data/docs_banner.yaml
@@ -1,0 +1,7 @@
+- type: "Webinar"
+  title: "Operationalizing Node-RED for the Enterprise"
+  buttonText: "Register now"
+  link: "/webinars/2024/operationalizing-node-red-for-the-enterprise/"
+  expire: "2024-09-24T16:00:00Z"
+  eventTime: "17:00 CET (11:00am ET)"
+  secondaryText:

--- a/src/_includes/components/docs-banner.njk
+++ b/src/_includes/components/docs-banner.njk
@@ -1,0 +1,48 @@
+{% set hasExpireDate = false %}
+{% set hasContent = false %}
+
+{% for ad in docs_banner %}
+    {% if ad.expire %}
+        {% if ad.expire | isFutureDate %}
+            {% set hasExpireDate = true %}
+        {% endif %}
+    {% else %}
+        {% set hasContent = true %}
+    {% endif %}
+{% endfor %}
+
+{% if hasExpireDate or hasContent %}
+<div class="w-full bg-indigo-50 border-indigo-300 border-2 rounded-lg max-lg:hidden p-3">
+    {% set ad = docs_banner[0] %}
+        {% if ad.expire and ad.expire | isFutureDate or not ad.expire %}
+            <a href="{{ ad.link }}" class="text-sm justify-center hover:no-underline">
+                {% if ad.type %}
+                    <span class="font-medium text-white px-2 py-1 bg-red-600 rounded-sm">{{ ad.type }}</span>
+                {% endif %}
+                {% if ad.title %}
+                <h3 class="font-semibold text-2xl mb-2{% if ad.type %} mt-4{% endif %}">{{ ad.title }}</h3>
+                {% endif %}
+                {% if ad.expire %}
+                    <div class="text-lg text-gray-500">
+                        {{ ad.expire | shortDate }}
+                    </div>
+                {% endif %}
+                {% if ad.eventTime %}
+                    <div class="text-md text-gray-500 mb-3">
+                        {{ ad.eventTime }}
+                    </div>
+                {% endif %}
+                {% if ad.secondaryText %}
+                    <div class="text-lg text-gray-500 mb-3">
+                        {{ ad.secondaryText }}
+                    </div>
+                {% endif %}
+                {% if ad.buttonText %}
+                    <span class="ff-btn ff-btn--primary uppercase">
+                        {{ ad.buttonText }}
+                    </span>
+                {% endif %}
+            </a>
+        {% endif %}
+</div>
+{% endif %}

--- a/src/_includes/layouts/handbook.njk
+++ b/src/_includes/layouts/handbook.njk
@@ -67,6 +67,9 @@ date: git Last Modified
             {%- endfor -%}
             <div class="text-sm pb-1 text-right mb-4"><a href="{{ page | handbookEditLink }}">Edit this page</a></div>
             <div class="text-xs pb-1 text-right mb-4 italic">Updated: {% filter shortDate %}{{ updated if updated else page.date }}{% endfilter %}</div>
+            {% if nav == 'docs' %}
+                {% include "components/docs-banner.njk" %}
+            {% endif %}
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Description

Added a banner to the right column in every `/docs/*` page. The banner displays the type, title, date (based on the `expiration date`), event time, secondary text (in case we'd like to add a really short description when it's not a webinar), and button text of the first item in `src/_data/docs_banner.yaml`. The banner is only displayed if the expiration date is a future date or if no expiration date is provided. The information displayed in the banner is controlled from the file `src/_data/docs_banner.yaml`.

## Related Issue(s)

closes https://github.com/FlowFuse/customer/issues/255

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
