### PR TITLE
team-discount-only

### DIFF
--- a/src/pricing/index.njk
+++ b/src/pricing/index.njk
@@ -10,7 +10,7 @@ meta:
     faq:
         - question: "Does FlowFuse offer annual discounts for FlowFuse Cloud?"
           answer: >
-            Yes, we offer a 20% discount for customers who move from monthly to annual subscriptions. Please <a href="/contact-us/">reach out</a> to request the discount.
+            Yes, we offer a 20% discount for Team customers who move from monthly to annual subscriptions. Please <a href="/contact-us/">reach out</a> to request the discount.
         - question: "Is there a minimum for purchase?"
           answer: >
             Yes, 5 instances on Team and 10 instances on Enterprise.


### PR DESCRIPTION
## Description

Specifying that the Cloud discount only applies to Team tier customers who move from monthly to annual. This is for 2 reasons:

1. Protects our pricing for Enterprise Cloud deals (where people have noticed and asked for this discount)
2. Prevents sales from having to manually process $192 annual Starter deals moving forward. We can still honor this yearly discount for existing Starter customers who are migrating to the new pricing, as has been communicated with them already.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
