### PR TITLE
Homepage: Add CTA to testimonials

### DIFF
--- a/src/_includes/testimonials.njk
+++ b/src/_includes/testimonials.njk
@@ -4,20 +4,21 @@
     <div class="m-auto max-w-screen-lg">
       <div class="max-w-none mx-auto sm:grid justify-center items-center" style="grid-template-columns: 35% auto;">
         <div class="w-full h-full aspect-[331/239] ff-image-cover scale rounded-md mb-4 sm:mb-0">
-            {% set imageSrc = t.imageFile %}
-            {% set imageDescription = ["Image depicting", t.imageAlt] | join %}
-            {% image imageSrc, imageDescription, [360] %}
+          {% set imageSrc = t.imageFile %}
+          {% set imageDescription = ["Image depicting", t.imageAlt] | join %}
+          {% image imageSrc, imageDescription, [360] %}
         </div>
-        <div class="items-end justify-end sm:pl-12 flex-1 flex flex-col h-full w-full justify-items-end">
+        <div class="items-end justify-between sm:pl-12 flex-1 flex flex-col h-full w-full justify-items-end">
+          <span class="text-right pb-5 flex gap-1 hover:underline">Read the full story {% include "components/icons/arrow-long-right.svg" %}</span>
           <p class="font-normal italic text-2xl">
             "{{ t.quote }}"
           </p>
           <p class="text-lg mt-4 flex flex-row gap-3 text-right items-center self-end mb-0 mr-0 ">
             <span>{{ t.author }}, <span class="font-medium">{{ t.company }}</span></span>
             <span class="w-16 h-16 min-w-16 rounded-full mx-1 bg-black p-1">
-            {% set imageSrc = t.companyLogo %}
-            {% set imageDescription = [ t.company, "logo"] | join %}
-            {% image imageSrc, imageDescription, [56] %}
+              {% set imageSrc = t.companyLogo %}
+              {% set imageDescription = [ t.company, "logo"] | join %}
+              {% image imageSrc, imageDescription, [56] %}
             </span>
           </p>
         </div>


### PR DESCRIPTION
## Description

The testimonials on our homepage link to the corresponding customer story. People are clicking on the slider controls but not on the cards to view the full story. Although it has a hover effect and the cursor changes when hovering, it seems like it's not obvious enough. Therefore, I’m adding a CTA in the top-right corner to encourage more clicks.

Here are the number of clicks in the last 30 days according to PostHog:

<img width="1104" alt="Screenshot 2024-10-03 at 18 15 15" src="https://github.com/user-attachments/assets/d044fb5b-5a3c-41b5-8c70-f36ea236824a">

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
