### PR TITLE
leave: Canada cannot have unlimited PTO

### DIFF
--- a/src/handbook/peopleops/leave.md
+++ b/src/handbook/peopleops/leave.md
@@ -25,6 +25,9 @@ team members. To prevent an undefined number of vacation days to start a race to
 the bottom, we recommend each team member to take a minimum of 25 days a year,
 and at least 5 days a quarter.
 
+Due to legal limitations, Canadian employees can not be offered unlimited PTO and
+will have the aforementioned 25 days instead.
+
 ## Sick leave
 
 Sick leave, or having limited availability is not recorded currently. Keep your


### PR DESCRIPTION
## Description

Due to Canadian law, Canadian employees cannot have unlimited PTO.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
