### PR TITLE
Docs: Add support for image zoom in the documentation

### DIFF
--- a/src/_includes/layouts/documentation.njk
+++ b/src/_includes/layouts/documentation.njk
@@ -72,3 +72,6 @@ date: git Last Modified
 </div>
 
 {% include "./common-js.njk" %}
+
+<!-- medium-zoom 1.1.0 | MIT License | https://github.com/francoischalifour/medium-zoom -->
+{% include "medium-zoom.min.njk" %}

--- a/src/_includes/medium-zoom.min.njk
+++ b/src/_includes/medium-zoom.min.njk
@@ -12,6 +12,8 @@
             wrapper.appendChild(img.parentNode);
         });
 
-        mediumZoom('[data-zoomable]');
+        mediumZoom('[data-zoomable]', {
+            margin: 48
+        });
     });
 </script>


### PR DESCRIPTION
## Description

Docs didn't support the use of `{data-zoomable}`, this adds it in.