### PR TITLE
Added staging environment url

### DIFF
--- a/src/handbook/development/ops/staging.md
+++ b/src/handbook/development/ops/staging.md
@@ -38,6 +38,10 @@ of short-lived testing of sign-up and user management.
 The inboxes for these email addresses are publicly accessible if known, so the list
 is available on [this private issue](https://github.com/FlowFuse/CloudProject/issues/135).
 
+### Accessing Staging
+
+To access the staging environment, log in with your @flowfuse.com account through Google SSO. The url for the staging environment is https://forge.flowfuse.dev.
+
 ## Using staging
 
 When setting up a team you'll need to enter billing details. For credit card


### PR DESCRIPTION
This edit adds the url for the staging environment and specifies that logging into staging uses Google SSO.

## Description

I added a section to describe how to log into the staging environment.

## Related Issue(s)

n/a

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
