### PR TITLE
Pricing page/features table: Include team clients in the MQTT description

### DIFF
--- a/src/_data/pricingFeatures.yaml
+++ b/src/_data/pricingFeatures.yaml
@@ -38,7 +38,7 @@ sections:
         label: MQTT Broker
         cloudValues: [ null, 'check', 'check' ]    
         tags: [ 'cloud' ]
-        info: "<p>Effortlessly manage and create MQTT clients to transport data for efficient messaging and communication for your applications. Up to 20 clients included at no extra cost, with the option to purchase additional clients in the future.</p>"
+        info: "<p>Easily manage and create MQTT clients to transport data for efficient messaging and communication within your applications. The Team Tier includes 5 clients at no extra cost, while the Enterprise Tier includes 20 clients for free as part of your existing plan, with purchase additional clients as needed in the future.</p>"
       - id: device-groups
         label: Device Group Management
         cloudValues: [ null, null, 'check' ]


### PR DESCRIPTION
## Description

The features table now has a check for the MQTT broker for the team tier, but the description only refers to the enterprise tier

## Related Issue(s)

https://github.com/FlowFuse/website/pull/2730

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
