### PR TITLE
Generic subscription agreement URL

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -100,6 +100,26 @@ module.exports = function(eleventyConfig) {
     // make global accessible in src/_includes/layouts/base.njk for loading of PH scripts
     eleventyConfig.addGlobalData('POSTHOG_APIKEY', () => process.env.POSTHOG_APIKEY || '' )
     eleventyConfig.addGlobalData('DEV_MODE', () => DEV_MODE || DEV_MODE_POSTS)
+    eleventyConfig.addGlobalData('latestAgreementVersion', async () => {
+        const directoryPath = path.join(__dirname, 'src/handbook/customer/sales/subscription-agreements');
+    
+        const files = await fs.promises.readdir(directoryPath);
+    
+        const versionPattern = /^subscription-agreement-(\d+\.\d+)\.njk$/;
+    
+        const versions = files
+            .map(file => {
+                const match = file.match(versionPattern);
+                return match ? match[1] : null;
+            })
+            .filter(Boolean);
+    
+        versions.sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
+    
+        const latestVersion = versions[0];
+    
+        return latestVersion;
+    });
 
     // Custom Tooltip "Component"
     eleventyConfig.addPairedShortcode("tooltip", function (content, text) {

--- a/src/handbook/customer/sales/subscription-agreements/subscription-agreement-1.4.njk
+++ b/src/handbook/customer/sales/subscription-agreements/subscription-agreement-1.4.njk
@@ -1,44 +1,38 @@
 ---
 # Note: Do not delete this file. It's still referenced in contracts and quotes.
-navTitle: Subscription Agreement 1.5
+navTitle: Subscription Agreement 1.4
 navGroup: Customer Department
-hubspot:
-  script: "hubspot/hs-form.njk"
-  formId: "f5a6441c-63a5-4a4a-b676-87aab37df998"
-  cta: "subscription-agreement"
-  reference: "subscription-agreement"
+skipIndex: true
+permalink: /handbook/customer/sales/subscription-agreement-1.4/
 ---
 
-<p>Below if the FlowFuse subscription agreement that applies to all self-hosted
-  installations. If you'd like to make alterations for your organisation, please
-  download the .docx file in the following form and initiate the legal part of
-  the negotiation through your account executive.</p>
-  
-<p class="pb-4">Note alterations to the following agreement are only accepted on the Enterprise tier.</p>
+<h2>This subscription has been superseded by <a href="./subscription-agreement-1.5/">Subscription Agreement 1.5</a>.</h2>
 
-{% include hubspot.script %}
+<br />
 
 <h2><strong>Subscription Agreement</strong></h2>
 
-<p>
-This Subscription Agreement (“Agreement”) is between FlowFuse Inc. DBA FlowFuse with offices at 548 Market St
-</p>
-<p>
-PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate entity is listed as “FlowFuse” on an Quote [as defined below], (“FlowFuse”), and the individual or entity signing or electronically accepting this Agreement, or any Quote that references this Agreement (“Customer”). This Agreement is entered into on the earlier of, (a) Customer clicking “Agree” or “Yes” to the terms of this Agreement to gain initial access to, or use of, the Software, (b) FlowFuse and Customer agreeing to an Quote referencing this Agreement, or (c) Customer is given access to the Software (“Effective Date”).
-</p>
 
+<p>
+This Subscription Agreement (“Agreement”) is between FlowFuse Inc. with offices at 548 Market St
+</p>
+<p>
+PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate entity is listed as “FlowFuse” on an Order Form [as defined below], (“FlowFuse”), and the individual or entity signing or electronically accepting this Agreement, or any Order Form that references this Agreement (“Customer”). This Agreement is entered into on the earlier of, (a) Customer clicking “Agree” or “Yes” to the terms of this Agreement to gain initial access to, or use of, the Software, (b) FlowFuse and Customer agreeing to an Order Form referencing this Agreement, or (c) Customer is given access to the Software (“Effective Date”).
+</p>
 <ul>
-<li>Individual Signing on Behalf of Company. IF THE INDIVIDUAL ACCEPTING THIS AGREEMENT IS ACCEPTING ON BEHALF OF AN ENTERPRISE OR OTHER LEGAL ENTITY, SUCH INDIVIDUAL REPRESENTS THAT THEY HAVE THE AUTHORITY TO BIND SUCH ENTERPRISE AND ITS AFFILIATES TO THESE TERMS AND CONDITIONS, IN WHICH CASE THE TERM “CUSTOMER” SHALL REFER TO SUCH ENTERPRISE AND ITS AFFILIATES.</li>
 
-<li>Individual Not Authorized to Sign on Behalf of Company. IF THE INDIVIDUAL ACCEPTING THIS AGREEMENT DOES NOT HAVE SUCH AUTHORITY, OR DOES NOT AGREE WITH THESE TERMS AND CONDITIONS, SUCH INDIVIDUAL MUST NOT ACCEPT THIS AGREEMENT AND MAY NOT USE THE SERVICES OR SOFTWARE.</li>
+<li>Individual Signing on Behalf of Company. IF THE INDIVIDUAL ACCEPTING THIS AGREEMENT IS ACCEPTING ON BEHALF OF AN ENTERPRISE OR OTHER LEGAL ENTITY, SUCH INDIVIDUAL REPRESENTS THAT THEY HAVE THE AUTHORITY TO BIND SUCH ENTERPRISE AND ITS AFFILIATES TO THESE TERMS AND CONDITIONS, IN WHICH CASE THE TERM “CUSTOMER” SHALL REFER TO SUCH ENTERPRISE AND ITS AFFILIATES.
 
-<li>Individual Signing on Behalf of Individual But Using Company Email. IF THE INDIVIDUAL ACCEPTING THIS AGREEMENT IS ACCEPTING THIS AGREEMENT ON HIS OR HER OWN BEHALF BUT USING AN ENTERPRISE EMAIL ADDRESS TO DO SO, SUCH INDIVIDUAL ACKNOWLEDGES AND AGREES THAT USE OF SUCH ENTERPRISE EMAIL ADDRESS WILL ESTABLISH A FLOWFUSE ACCOUNT THAT WILL BE ASSOCIATED WITH THE APPLICABLE ENTERPRISE, AND CAN AND WILL BE TRANSFERRED ENTIRELY (BOTH CONTROL AND DATA/INFORMATION WITHIN THE ACCOUNT) TO SUCH ENTERPRISE UPON SUCH COMPANY’S REQUEST WITHOUT NOTICE OR LIABILITY TO THE INDIVIDUAL. AS SUCH, TO ENSURE NO LOSS OF PERSONAL CONTENT, FLOWFUSE STRONGLY RECOMMENDS ESTABLISHING A FLOWFUSE ACCOUNT TIED TO A PERSONAL EMAIL ADDRESS.</li>
+<li>Individual Not Authorized to Sign on Behalf of Company. IF THE INDIVIDUAL ACCEPTING THIS AGREEMENT DOES NOT HAVE SUCH AUTHORITY, OR DOES NOT AGREE WITH THESE TERMS AND CONDITIONS, SUCH INDIVIDUAL MUST NOT ACCEPT THIS AGREEMENT AND MAY NOT USE THE SERVICES OR SOFTWARE.
+
+<li>Individual Signing on Behalf of Individual But Using Company Email. IF THE INDIVIDUAL ACCEPTING THIS AGREEMENT IS ACCEPTING THIS AGREEMENT ON HIS OR HER OWN BEHALF BUT USING AN ENTERPRISE EMAIL ADDRESS TO DO SO, SUCH INDIVIDUAL ACKNOWLEDGES AND AGREES THAT USE OF SUCH ENTERPRISE EMAIL ADDRESS WILL ESTABLISH A FLOWFUSE ACCOUNT THAT WILL BE ASSOCIATED WITH THE APPLICABLE ENTERPRISE, AND CAN AND WILL BE TRANSFERRED ENTIRELY (BOTH CONTROL AND DATA/INFORMATION WITHIN THE ACCOUNT) TO SUCH ENTERPRISE UPON SUCH COMPANY’S REQUEST WITHOUT NOTICE OR LIABILITY TO THE INDIVIDUAL. AS SUCH, TO ENSURE NO LOSS OF PERSONAL CONTENT, FLOWFUSE STRONGLY RECOMMENDS ESTABLISHING A FLOWFUSE ACCOUNT TIED TO A PERSONAL EMAIL ADDRESS.
+</li>
 </ul>
 <h3><strong>1. DEFINITIONS</strong></h3>
 
 
 <p>
-“Acceptance” of a Quote shall occur at the earliest of the following: (a) execution of a Quote, (b) reference to an Quote Quote No. within a purchase order or similar document, or (c) the use of Software.
+“Acceptance” of an Order Form shall occur at the earliest of the following: (a) execution of an Order Form, (b) reference to an Order Form Quote No. within a purchase order or similar document, or (c) the use of Software.
 </p>
 <p>
 “Affiliate” means any entity(ies) controlling, controlled by, and/or under common control with a party hereto, where “control” means the ownership of more than 50% of the voting securities in such an entity.
@@ -71,7 +65,7 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 “Designated National” is any person or entity on the U.S. Department of Treasury’s List of Specially Designated Nationals or the U.S. Department of Commerce’s Table of Denial Orders.
 </p>
 <p>
-"Effective Price" means the actual price paid by Customer (List Price minus any applicable discount(s)) as set forth on a Quote or as purchased via the Website.
+"Effective Price" means the actual price paid by Customer (List Price minus any applicable discount(s)) as set forth on an Order Form or as purchased via the Website.
 </p>
 <p>
 “Embargoed Countries” refers collectively to countries to which the United States maintains an embargo.
@@ -80,7 +74,7 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 “Enterprise” means the organization, company, corporation and/or other type of entity which procures the Software to be used on its behalf pursuant to the terms of this Agreement.
 </p>
 <p>
-“Fees” are those fees set forth within the Quote, or, fees due immediately when purchasing via the web-portal.
+“Fees” are those fees set forth within the Order Form, or, fees due immediately when purchasing via the web-portal.
 </p>
 <p>
 “Free Software” means a feature-limited version of Software provided to a Customer, User, end user, partner, or any other third party at no (or a greatly reduced cost) including but not limited to, the lowest tier offering of Software as made available by FlowFuse.
@@ -89,7 +83,7 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 “Individual” means a person who uses the Software on their own behalf, and not an Enterprise. An Individual must be over the age of thirteen (13) years old.
 </p>
 <p>
-"List Price" means the list price of the FlowFuse Software excluding (if applicable) any discount(s) set forth in a Quote or as purchased via the Website.
+"List Price" means the list price of the FlowFuse Software excluding (if applicable) any discount(s) set forth in an Order Form or as purchased via the Website.
 </p>
 <p>
 “Node-RED instance” means a runtime, editor, or other part of the Node-RED software offering.
@@ -98,7 +92,7 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 “Open-Source Edition Software” means the publicly available, community-developed open-source software and components which may be provided with the Software. Open-Source Edition Software is provided as Free Software (as defined herein).
 </p>
 <p>
-“Quote” is a transactional document agreed to between the parties which states the Software and/or Supplemental Services being purchased, term of use, price, subscription duration, and other applicable transaction details. For the avoidance of doubt, the parties acknowledge and agree the terms and conditions stated within this Agreement and an executed Quote shall govern with respect to all matters contemplated herein.
+“Order Form” is a transactional document agreed to between the parties which states the Software and/or Supplemental Services being purchased, term of use, price, subscription duration, and other applicable transaction details. For the avoidance of doubt, the parties acknowledge and agree the terms and conditions stated within this Agreement and an executed Order Form shall govern with respect to all matters contemplated herein.
 </p>
 <p>
 “Purchase Order” is a Customer’s processing document, or similar record, which is used by Customer to demonstrate internal approval and /or record of a purchase. Any terms stated within a Purchase Order shall be null and void and are expressly rejected by the parties.
@@ -107,22 +101,22 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 “Software” means software, and other branded offerings made available by FlowFuse or its Affiliate(s), including but not limited to, FlowFuse’s Application Platform.
 </p>
 <p>
-“Subscription” refers to the applicable services, support and function(s) of the Software as provided. Subscriptions are provided in tiers / levels as described in Appendix 1 and are based on the number of Node-RED instances and Users.
+“Subscription” refers to the applicable services, support and function(s) of the Software as provided. Subscriptions are provided in tiers / levels as described in Appendix 1 and are based on the number of Users.
 </p>
 <p>
-“Subscription Start Date” is, unless otherwise agreed to in writing, the start date, (i) stated on an Quote, or, the date in which Customer is given access to the Software (whichever is later), or (ii) as indicated via a Website transaction, regardless if such purchase is direct with FlowFuse or via an Authorized Partner.
+“Subscription Start Date” is, unless otherwise agreed to in writing, the start date, (i) stated on an Order Form, or, the date in which Customer is given access to the Software (whichever is later), or (ii) as indicated via a Website transaction, regardless if such purchase is direct with FlowFuse or via an Authorized Partner.
 </p>
 <p>
-“Subscription Term” shall begin on the Subscription Start Date and continue for twelve (12) months, unless the term length is otherwise agreed to in an Quote or web-portal purchase.
+“Subscription Term” shall begin on the Subscription Start Date and continue for twelve (12) months, unless the term length is otherwise agreed to in an Order Form or web-portal purchase.
 </p>
 <p>
-“Supplemental Services” means additional capacity, functionality, storage and/or other elements that Customer may procure in addition to the Software. Such Supplemental Services may be purchased by Quote or web-portal. Supplemental Services purchased will be: (i) provided as a separate line item in an Quote or web-portal purchase, and (ii) co-termed to the underlying Subscription Term if not purchased on the Subscription Start Date. For the avoidance of doubt, Supplemental Services are not part of the Software, but rather, are provided in addition to the Software and Supplemental Services shall be subject to the terms and conditions of this Agreement.
+“Supplemental Services” means additional capacity, functionality, storage and/or other elements that Customer may procure in addition to the Software. Such Supplemental Services may be purchased by Order Form or web-portal. Supplemental Services purchased will be: (i) provided as a separate line item in an Order Form or web-portal purchase, and (ii) co-termed to the underlying Subscription Term if not purchased on the Subscription Start Date. For the avoidance of doubt, Supplemental Services are not part of the Software, but rather, are provided in addition to the Software and Supplemental Services shall be subject to the terms and conditions of this Agreement.
 </p>
 <p>
 “User(s)” is defined as the unique and single Individual, employee, Contractor, or other third party individual or machine authorized by Customer (in accordance with this Agreement) that requires the provision of a seat within the admin platform, who are able to access the Software purchased under a Subscription, regardless of whether the User actually accesses or the frequency with which they access the Software. A User must be over the age of thirteen (13) years old.
 </p>
 <p>
-“Website” means FlowFuse’s website located at <a href="http://www.flowfuse.com">www.flowfuse.com</a>, <a href="http://www.flowforge.cloud">www.FlowFuse.cloud</a>,<a href="http://www.flowfuse.cloud">www.flowfuse.cloud</a> and all subdomains, and all content, services, documentation provided on the Website.
+“Website” means FlowFuse’s website located at 'flowfuse.com', 'flowforge.cloud', 'flowfuse.cloud' and all subdomains, and all content, services, documentation provided on the Website.
 </p>
 <h3><strong>2. SCOPE OF AGREEMENT</strong></h3>
 
@@ -143,19 +137,13 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 (i) purchasing via the FlowFuse Website;
 </p>
 <p>
-(ii) executing a Quote with FlowFuse or an Affiliate of FlowFuse; 
+(ii) executing an Order Form with FlowFuse or an Affiliate of FlowFuse; or
 </p>
 <p>
-(iii) upgrading a license via FlowFuse Cloud or, if Customer is self-hosted, by requesting generation of a new license (either method, a “License Upgrade”)  or
+(iii) purchase from an Authorized Partner.
 </p>
 <p>
-(iv) purchase from an Authorized Partner.
-</p>
-<p>
-3.3 License Upgrades will be invoiced quarterly if accessed via FlowFuse Cloud, or immediately if Customer is self-hosted and requests a License Upgrade. License Upgrades will be payable in accordance with Section 6 (six) of this Agreement.
-</p>
-<p>
-3.4 FlowFuse and Customer acknowledge and agree that Free Software may be: (i) modified and/or updated, without notice, and (ii) limited in functionality, features, maintenance, support and contain other limitations not present in Software purchased. NOTWITHSTANDING THE “WARRANTY” AND “INDEMNIFICATION” SECTIONS BELOW, FREE SOFTWARE AND SOFTWARE OFFERED ON A TRIAL BASIS (AS STATED IN AN QUOTE OR WEB-PORTAL PURCHASE) ARE PROVIDED “AS-IS” WITHOUT ANY WARRANTY AND FLOWFUSE SHALL HAVE NO INDEMNIFICATION OBLIGATIONS NOR LIABILITY OF ANY TYPE WITH RESPECT TO SUCH FREE SOFTWARE UNLESS SUCH EXCLUSION OF LIABILITY IS NOT ENFORCEABLE UNDER APPLICABLE LAW, IN WHICH CASE FLOWFUSE’S LIABILITY WITH RESPECT TO SUCH FREE SOFTWARE SHALL NOT EXCEED $1,000.00USD.
+3.3 FlowFuse and Customer acknowledge and agree that Free Software may be: (i) modified and/or updated, without notice, and (ii) limited in functionality, features, maintenance, support and contain other limitations not present in Software purchased. NOTWITHSTANDING THE “WARRANTY” AND “INDEMNIFICATION” SECTIONS BELOW, FREE SOFTWARE AND SOFTWARE OFFERED ON A TRIAL BASIS (AS STATED IN AN ORDER FORM OR WEB-PORTAL PURCHASE) ARE PROVIDED “AS-IS” WITHOUT ANY WARRANTY AND FLOWFUSE SHALL HAVE NO INDEMNIFICATION OBLIGATIONS NOR LIABILITY OF ANY TYPE WITH RESPECT TO SUCH FREE SOFTWARE UNLESS SUCH EXCLUSION OF LIABILITY IS NOT ENFORCEABLE UNDER APPLICABLE LAW, IN WHICH CASE FLOWFUSE’S LIABILITY WITH RESPECT TO SUCH FREE SOFTWARE SHALL NOT EXCEED $1,000.00USD.
 </p>
 <h3><strong>4. TERM AND TERMINATION</strong></h3>
 
@@ -164,10 +152,10 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 4.1 The Agreement commences on the Effective Date and continues until it is terminated in accordance with this Section 4.
 </p>
 <p>
-4.2 A Subscription Term shall begin as of the Subscription Start Date and remain in effect for the term length indicated on the Quote (the "Initial Term") and automatically renew for successive twelve (12) month terms (each a "Renewal Term") unless either party gives notice of its intention not to renew thirty (30) days prior to the expiration of the current Subscription Term. Customer shall have the right to opt-out of such renewal, from within the Software, commencing upon the Subscription Start Date until thirty (30) days prior to the expiration of the Subscription Term. Subscriptions must be used during the Subscription Term and any unused Subscriptions will expire.
+4.2 A Subscription Term shall begin as of the Subscription Start Date and remain in effect for the term length indicated on the Order Form (the "Initial Term") and automatically renew for successive twelve (12) month terms (each a "Renewal Term") unless either party gives notice of its intention not to renew thirty (30) days prior to the expiration of the current Subscription Term. Customer shall have the right to opt-out of such renewal, from within the Software, commencing upon the Subscription Start Date until thirty (30) days prior to the expiration of the Subscription Term. Subscriptions must be used during the Subscription Term and any unused Subscriptions will expire.
 </p>
 <p>
-4.3 Either party may terminate this Agreement and any Quote executed between the parties if:
+4.3 Either party may terminate this Agreement and any Order Form executed between the parties if:
 </p>
 <p>
 (a) the other party materially breaches this Agreement and does not cure the breach within thirty (30) days after written notice; or
@@ -179,7 +167,7 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 4.4 FlowFuse may (at its sole discretion) suspend delivering Subscriptions if Customer breaches the terms of Section 6 (Payment of Fees) until the breach is remedied.
 </p>
 <p>
-4.5 Unless otherwise stated herein, termination of this Agreement shall not affect any Subscriptions currently being delivered and this Agreement shall remain in full force and effect until the expiration of the then-current Subscription Term. In the event this Agreement is terminated by Customer in accordance with Section 4.3, FlowFuse will refund Customer any prepaid Fees for the prorated portion of unused Subscription Term. If this Agreement is terminated by FlowFuse in accordance with this Section 4, Customer will pay (if applicable) any unpaid Fees covering the remainder of the Subscription Term of all Quotes, to the extent permitted by applicable law. For the avoidance of doubt, in no event will termination relieve Customer of its obligation to pay any Fees payable to FlowFuse for the period prior to the effective date of termination. The terms and conditions of this Agreement will apply to any Renewal Term(s) provided that, absent an Effective Price as set forth in an Quote, Website purchase or other written agreement between the Parties, FlowFuse’s then-current List Price will apply with regard to any such Renewal Term(s). FlowFuse reserves the right to increase fees for any Renewal Term(s) with respect to its products and services, including the Software and Supplemental Services.
+4.5 Unless otherwise stated herein, termination of this Agreement shall not affect any Subscriptions currently being delivered and this Agreement shall remain in full force and effect until the expiration of the then-current Subscription Term. In the event this Agreement is terminated by Customer in accordance with Section 4.3, FlowFuse will refund Customer any prepaid Fees for the prorated portion of unused Subscription Term. If this Agreement is terminated by FlowFuse in accordance with this Section 4, Customer will pay (if applicable) any unpaid Fees covering the remainder of the Subscription Term of all Order Forms, to the extent permitted by applicable law. For the avoidance of doubt, in no event will termination relieve Customer of its obligation to pay any Fees payable to FlowFuse for the period prior to the effective date of termination. The terms and conditions of this Agreement will apply to any Renewal Term(s) provided that, absent an Effective Price as set forth in an Order Form, Website purchase or other written agreement between the Parties, FlowFuse’s then-current List Price will apply with regard to any such Renewal Term(s). FlowFuse reserves the right to increase fees for any Renewal Term(s) with respect to its products and services, including the Software and Supplemental Services.
 </p>
 <h3><strong>5. RESTRICTIONS AND RESPONSIBILITIES</strong></h3>
 
@@ -191,13 +179,13 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 (i) use the Software for any purpose other than as specifically authorized in this Agreement;
 </p>
 <p>
-(ii) use the Software in such a manner that would enable any unauthorized third party to access the Software;
+(ii) use the Software in such a manner that would enable any third party to access the Software;
 </p>
 <p>
 (iii) use the Software for time sharing or service bureau purposes (including without limitation, sublicensing, distributing, selling, reselling any Software);
 </p>
 <p>
-(iv) for any purpose other than its and its Affiliates’ own internal use, except as specifically set forth in a Reseller Agreement for authorized Sublicense Referrals;
+(iv) for any purpose other than its and its Affiliates’ own internal use;
 </p>
 <p>
 (v) use the Software other than in compliance with all applicable laws and regulations;
@@ -227,13 +215,7 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 (ii) any acts or omissions carried out by Contractors on Customer’s behalf. Customer shall ensure that Contractors are subject to terms no less stringent than those stated herein.
 </p>
 <p>
-(iii) ensuring no firewalls or any other technical device prevent the Software from sending periodic pings to FlowFuse to enable it to monitor Customer’s  license compliance, or for any other reason.
-</p>
-<p>
-(iv) ensuring that Sublicense Referrals execute a Subscription Agreement with terms at least as restrictive as those set forth herein; for sake of clarity, Customer will be liable for Sublicense Referrals’ breach of this Agreement as though it were a Customer breach.
-</p>
-<p>
-5.6 Subject to this Agreement and the applicable Quote, FlowFuse will provide Customer Support to Customer for the Subscriptions, during the Subscription Term, at no additional cost. Details regarding Customer Support can be found in Appendix 1.
+5.6 Subject to this Agreement and the applicable Order Form, FlowFuse will provide Customer Support to Customer for the Subscriptions, during the Subscription Term, at no additional cost. Details regarding Customer Support can be found in Appendix 1.
 </p>
 <p>
 5.7 Portions of the Software are governed by underlying open source licenses. This Agreement and applicable Appendix(eces) establish the rights and obligations associated with Subscriptions and Software and are not intended to limit Customer’s right to software code under the terms of an open source license.
@@ -257,13 +239,13 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 6.1 With respect to purchases direct from FlowFuse, all web-portal purchase Fees shall be due and payable immediately.
 </p>
 <p>
-6.2 With respect to purchases direct from FlowFuse, the Quote shall: (i) reference this Agreement; (ii) state the Subscription Term(s) and Subscription(s) that are being purchased; and (iii) state the Fees due for the applicable Subscription(s).
+6.2 With respect to purchases direct from FlowFuse, the Order Form shall: (i) reference this Agreement; (ii) state the Subscription Term(s) and Subscription(s) that are being purchased; and (iii) state the Fees due for the applicable Subscription(s).
 </p>
 <p>
-6.3 With respect to purchases direct from FlowFuse, such Quote is hereby incorporated into this Agreement by reference. The parties hereby agree to the terms and conditions stated within this Agreement and those found within an Quote to the exclusion of all other terms. The parties agree that all terms stated within a Purchase Order, or other similar document, shall be null and void and are expressly rejected.
+6.3 With respect to purchases direct from FlowFuse, such Order Form is hereby incorporated into this Agreement by reference. The parties hereby agree to the terms and conditions stated within this Agreement and those found within an Order Form to the exclusion of all other terms. The parties agree that all terms stated within a Purchase Order, or other similar document, shall be null and void and are expressly rejected.
 </p>
 <p>
-6.4 With respect to purchases direct from FlowFuse, Customer will pay FlowFuse the applicable Fees, including those for Supplemental Services, without any right of set-off or deduction. All payments will be made in accordance with the payment details stated within the applicable Quote. If not otherwise specified: (i) FlowFuse (or applicable FlowFuse Affiliate) will invoice Customer for the Fees upon the Acceptance of an Quote; and (ii) all Fees will be due and payable within thirty (30) days of Customer’s receipt of an invoice. Except as expressly set forth in this Agreement, all Fees paid or due hereunder (including prepaid amounts) are non-refundable, and no credit will be due, including without limitation if this Agreement is terminated in accordance with Section 4 herein.
+6.4 With respect to purchases direct from FlowFuse, Customer will pay FlowFuse the applicable Fees, including those for Supplemental Services, without any right of set-off or deduction. All payments will be made in accordance with the payment details stated within the applicable Order Form. If not otherwise specified: (i) FlowFuse (or applicable FlowFuse Affiliate) will invoice Customer for the Fees upon the Acceptance of an Order Form; and (ii) all Fees will be due and payable within thirty (30) days of Customer’s receipt of an invoice. Except as expressly set forth in this Agreement, all Fees paid or due hereunder (including prepaid amounts) are non-refundable, and no credit will be due, including without limitation if this Agreement is terminated in accordance with Section 4 herein.
 </p>
 <p>
 6.5 Any unpaid Fees are subject to a finance charge of one percent (1.0%) per month, or the maximum permitted by law, whichever is lower, plus all expenses of collection, including reasonable attorneys’ fees. Fees under this Agreement are exclusive of any and all taxes or duties, now or hereafter imposed by any governmental authority, including, but not limited to any national, state or provincial tax, sales tax, value-added tax, property and similar taxes, if any. Fees under this Agreement shall be paid without any withholding or deduction. In the case of any deduction or withholding requirements, Customer will pay any required withholding itself and will not reduce the amount to be paid to FlowFuse on account thereof.
@@ -299,7 +281,7 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 
 
 <p>
-8.1 Subject to the terms and conditions of this Agreement, FlowFuse hereby grants to Customer and its Affiliates a limited, non-exclusive, non-transferable, non-sublicensable license for Customer’s and its Affiliates’ Users to use, reproduce, modify, prepare derivative works based upon, and display the code of Software at the tier level selected by Customer, or as set forth in an Quote, solely for: (i) its internal use in connection with the development of Customer’s and/or its Affiliates’ own software; and (ii) the number of Users for which Customer has paid FlowFuse. Notwithstanding anything to the contrary, Customer agrees that FlowFuse and/or its licensors (as applicable) retain all right, title and interest in and to all Software incorporated in such modifications and/or patches, and all such Software may only be used, copied, modified, displayed, distributed, or otherwise exploited in full compliance with this Agreement, and with a valid Subscription for the correct number of Users.
+8.1 Subject to the terms and conditions of this Agreement, FlowFuse hereby grants to Customer and its Affiliates a limited, non-exclusive, non-transferable, non-sublicensable license for Customer’s and its Affiliates’ Users to use, reproduce, modify, prepare derivative works based upon, and display the code of Software at the tier level selected by Customer, or as set forth in an Order Form, solely for: (i) its internal use in connection with the development of Customer’s and/or its Affiliates’ own software; and (ii) the number of Users for which Customer has paid FlowFuse. Notwithstanding anything to the contrary, Customer agrees that FlowFuse and/or its licensors (as applicable) retain all right, title and interest in and to all Software incorporated in such modifications and/or patches, and all such Software may only be used, copied, modified, displayed, distributed, or otherwise exploited in full compliance with this Agreement, and with a valid Subscription for the correct number of Users.
 </p>
 <p>
 8.2 Except as expressly set forth herein, FlowFuse (and its licensors, where applicable) will retain all intellectual property rights relating to the Software and any suggestions, ideas, enhancement requests, feedback, or other recommendations provided by Customer, its Affiliates, Users or any third party relating to the Software (herein referred to as “Feedback Materials”), which are hereby assigned to FlowFuse. For the avoidance of doubt, Feedback Materials shall not include Customer Confidential Information or intellectual property owned by Customer. This Agreement does not constitute a sale of the Software and does not convey to Customer any rights of ownership in or related to the Software or any other intellectual property rights.
@@ -329,10 +311,10 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 
 
 <p>
-10.1 FlowFuse will defend Customer from any claim, demand, suit or proceeding made or brought against Customer by a third party alleging the Software (excluding Free Software as set forth in Section 3.3) provided by FlowFuse infringes or misappropriates such third party’s patent or copyright (a “Customer Claim”). FlowFuse will indemnify and hold Customer harmless from any damages, reasonable attorneys’ fees and costs finally awarded against Customer as a result of a Customer Claim, or for amounts paid by Customer under a settlement approved (in writing) by FlowFuse, provided Customer: (i) promptly notifies FlowFuse in writing of the Customer Claim; (ii) gives FlowFuse all reasonable assistance at FlowFuse’s expense; and (iii) gives FlowFuse sole control over defense and settlement thereof except that FlowFuse may not settle any Customer Claim unless it unconditionally releases Customer of all liability. The foregoing obligations do not apply if: (v) the Customer Claim arises from Software or any part thereof that is modified by Customer, or at Customer’s direction, after delivery by FlowFuse; (w) the Customer Claim arises from the use or combination of the Software or any part thereof with other products, processes or materials not provided by FlowFuse where the alleged infringement relates to such combination; (x) Customer continues allegedly infringing activity after being notified thereof or after being informed of modifications that would have avoided the alleged infringement; (y) the Customer Claim arises from software not created by FlowFuse, or (z) the Customer Claim results from Customer’s breach of this Agreement and/or applicable Quotes. Notwithstanding the foregoing, in the event of a Customer Claim, FlowFuse, at its discretion, option and expense, reserves the rights to: (a) modify the Software to make it non-infringing provided there is no material loss of functionality; (b) settle such claim by procuring the right for Customer to continue using the Software; or (c) if in FlowFuse’s reasonable opinion neither (a) or (b) are commercially feasible, terminate the license to the Software and refund a pro-rata portion of the amount paid by Customer for such Software for the unused portion of the Subscription Term.
+10.1 FlowFuse will defend Customer from any claim, demand, suit or proceeding made or brought against Customer by a third party alleging the Software (excluding Free Software as set forth in Section 3.3) provided by FlowFuse infringes or misappropriates such third party’s patent or copyright (a “Customer Claim”). FlowFuse will indemnify and hold Customer harmless from any damages, reasonable attorneys’ fees and costs finally awarded against Customer as a result of a Customer Claim, or for amounts paid by Customer under a settlement approved (in writing) by FlowFuse, provided Customer: (i) promptly notifies FlowFuse in writing of the Customer Claim; (ii) gives FlowFuse all reasonable assistance at FlowFuse’s expense; and (iii) gives FlowFuse sole control over defense and settlement thereof except that FlowFuse may not settle any Customer Claim unless it unconditionally releases Customer of all liability. The foregoing obligations do not apply if: (v) the Customer Claim arises from Software or any part thereof that is modified by Customer, or at Customer’s direction, after delivery by FlowFuse; (w) the Customer Claim arises from the use or combination of the Software or any part thereof with other products, processes or materials not provided by FlowFuse where the alleged infringement relates to such combination; (x) Customer continues allegedly infringing activity after being notified thereof or after being informed of modifications that would have avoided the alleged infringement; (y) the Customer Claim arises from software not created by FlowFuse, or (z) the Customer Claim results from Customer’s breach of this Agreement and/or applicable Order Forms. Notwithstanding the foregoing, in the event of a Customer Claim, FlowFuse, at its discretion, option and expense, reserves the rights to: (a) modify the Software to make it non-infringing provided there is no material loss of functionality; (b) settle such claim by procuring the right for Customer to continue using the Software; or (c) if in FlowFuse’s reasonable opinion neither (a) or (b) are commercially feasible, terminate the license to the Software and refund a pro-rata portion of the amount paid by Customer for such Software for the unused portion of the Subscription Term.
 </p>
 <p>
-10.2 Customer will defend FlowFuse and its Affiliates against any claim, demand, suit or proceeding made or brought against FlowFuse by a third party alleging: (i) that any Customer Content or Customer’s use of Customer Content with the Software or any software (or combination of software) provided by Customer and used with the Software, infringes or misappropriates such third party’s intellectual property rights, or (ii) arising from Customer’s use of the Software in an unlawful manner or in violation of the Agreement, the applicable documentation, or Quote (each a “FlowFuse Claim”). Customer will indemnify FlowFuse from any damages, reasonable attorneys’ fees and costs finally awarded against FlowFuse as a result of, or for any amounts paid by FlowFuse under a settlement approved (in writing) by Customer of a FlowFuse Claim, provided FlowFuse: (x) promptly gives Customer written notice of the FlowFuse Claim, (y) gives Customer sole control of the defense and settlement of the FlowFuse Claim (except that Customer may not settle any FlowFuse Claim unless it unconditionally releases FlowFuse of all liability), and (z) gives Customer all reasonable assistance, at Customer’s expense. The above defense and indemnification obligations do not apply if a FlowFuse Claim arises from FlowFuse’s breach of this Agreement and/or applicable Quote.
+10.2 Customer will defend FlowFuse and its Affiliates against any claim, demand, suit or proceeding made or brought against FlowFuse by a third party alleging: (i) that any Customer Content or Customer’s use of Customer Content with the Software or any software (or combination of software) provided by Customer and used with the Software, infringes or misappropriates such third party’s intellectual property rights, or (ii) arising from Customer’s use of the Software in an unlawful manner or in violation of the Agreement, the applicable documentation, or Order Form (each a “FlowFuse Claim”). Customer will indemnify FlowFuse from any damages, reasonable attorneys’ fees and costs finally awarded against FlowFuse as a result of, or for any amounts paid by FlowFuse under a settlement approved (in writing) by Customer of a FlowFuse Claim, provided FlowFuse: (x) promptly gives Customer written notice of the FlowFuse Claim, (y) gives Customer sole control of the defense and settlement of the FlowFuse Claim (except that Customer may not settle any FlowFuse Claim unless it unconditionally releases FlowFuse of all liability), and (z) gives Customer all reasonable assistance, at Customer’s expense. The above defense and indemnification obligations do not apply if a FlowFuse Claim arises from FlowFuse’s breach of this Agreement and/or applicable Order Form.
 </p>
 <p>
 10.3 This Section 10 (Indemnification) states the indemnifying party’s sole liability to, and the indemnified party’s exclusive remedy against the other party for any third-party claim described in this section.
@@ -380,7 +362,7 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 14.1 Without limiting FlowFuse’s obligations as stated in Section 7 (Confidentiality), FlowFuse shall be responsible for establishing and maintaining a commercially reasonable information security program that is designed to: (i) ensure the security and confidentiality of the Customer Content; (ii) protect against any anticipated threats or hazards to the security or integrity of the Customer Content; (iii) protect against unauthorized access to, or use of, the Customer Content; and (iv) ensure that all subcontractors of FlowFuse, if any, comply with all of the foregoing. In no case shall the safeguards of FlowFuse’s information security program be less stringent than the information security safeguards used by FlowFuse to protect its own commercially sensitive data. Customer shall use commercially reasonable security and anti-virus measures when accessing and using the Software and to prevent unauthorized access to, or use of the Software, and notify FlowFuse promptly of any such unauthorized access or use of which it becomes aware.
 </p>
 <p>
-14.2 With respect to the protection of information, the FlowFuse Privacy Statement located here https://flowfuse.com/privacy-policy/, shall apply. If this Agreement is entered into on behalf of an Enterprise, the terms of the data processing addendum at https://flowfuse.com/terms/#6.4-data-processing-agreement. (“DPA”) are hereby incorporated by reference and shall apply to the extent Customer Content includes Personal Data, as defined in the DPA. To the extent Personal Data from the European Economic Area (EEA), the United Kingdom and Switzerland are processed by FlowFuse, the Standard Contractual Clauses shall apply, as further set forth in the DPA. For the purposes of the Standard Contractual Clauses, Customer and its applicable Affiliates are each the data exporter, and Customer's acceptance of this Agreement, and an applicable Affiliate's execution of an Quote, shall be treated as its execution of the Standard Contractual Clauses.
+14.2 With respect to the protection of information, the FlowFuse Privacy Statement located here https://flowfuse.com/privacy-policy/, shall apply. If this Agreement is entered into on behalf of an Enterprise, the terms of the data processing addendum at https://flowfuse.com/terms/#6.4-data-processing-agreement. (“DPA”) are hereby incorporated by reference and shall apply to the extent Customer Content includes Personal Data, as defined in the DPA. To the extent Personal Data from the European Economic Area (EEA), the United Kingdom and Switzerland are processed by FlowFuse, the Standard Contractual Clauses shall apply, as further set forth in the DPA. For the purposes of the Standard Contractual Clauses, Customer and its applicable Affiliates are each the data exporter, and Customer's acceptance of this Agreement, and an applicable Affiliate's execution of an Order Form, shall be treated as its execution of the Standard Contractual Clauses.
 </p>
 <p>
 14.3 The parties acknowledge and agree that, (i) the Software is not designed for the purpose(s) of storing, processing, compiling or transmitting Sensitive Data (as defined herein), and (ii) Customer shall not use the Software, or otherwise provide to FlowFuse without prior written consent, Sensitive Data under this Agreement. “Sensitive Data” means: (a) special categories of data enumerated in European Union Regulation 2016/679, Article 9(1) or any successor legislation; (b) patient, medical, or other protected health information regulated by the Health Insurance Portability and Accountability Act (as amended and supplemented) (“HIPAA”); (c) credit, debit, or other payment card data or financial account information, including bank account numbers or other personally identifiable financial information; (d) social security numbers, driver’s license numbers, or other government identification numbers; (e) other information subject to regulation or protection under specific laws such as the Children’s Online Privacy Protection Act or Gramm-Leach-Bliley Act (“GLBA”) (or related rules or regulations); or (f) any data similar to the above protected under foreign or domestic laws. Customer further acknowledges that the Software and related features are not intended to meet any legal obligations for these uses, including HIPAA and GLBA requirements, and that FlowFuse is not a Business Associate as defined under HIPAA. Therefore, notwithstanding anything else in this Agreement, FlowFuse has no liability for Sensitive Data processed in connection with Customer’s use of the Software.
@@ -416,11 +398,8 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 15.8 This Agreement will be governed by the laws of the State of California, U.S.A. without regard to its conflict of laws provisions. The federal and state courts sitting in San Francisco County, California, U.S.A. will have proper and exclusive jurisdiction and venue with respect to any disputes arising from or related to the subject matter of this Agreement. The United Nations Convention on Contracts for the International Sale of Goods is expressly disclaimed by the Parties with respect to this Agreement and the transactions contemplated hereby.
 </p>
 <p>
-Both parties agree to the above terms by signing the Quote in which these terms are linked.
+Both parties agree to the above terms by signing the Order Form in which these terms are linked.
 </p>
-<h2></h2>
-
-
 <h2><strong>APPENDIX 1: FlowFuse Support Policies</strong></h2>
 
 
@@ -449,7 +428,7 @@ The applicable level of support and/or functionality of the Software, as set for
    </td>
   </tr>
   <tr>
-   <td>Team
+   <td>Premium
    </td>
    <td>FlowFuse Standard Support
    </td>
@@ -469,9 +448,6 @@ First Response Time SLA 4 Hours. Submit Tickets at https://flowfuse.com/support/
 </table>
 
 
-<h2></h2>
-
-
 <h2><strong>APPENDIX 2: Software as a Service (SaaS) Offering</strong></h2>
 
 
@@ -482,16 +458,13 @@ With respect to Customer’s purchase and/or use of the SaaS Software, the follo
 
 
 <p>
-The SaaS Software will be available to Customer 99.5% of each calendar month commencing with the first full calendar month following the Effective Date (“Uptime”). Availability shall be calculated by subtracting the cumulative minutes of Downtime in a  month from the total number of minutes in the applicable month, and representing the remaining minutes as a percentage of the total number of minutes that month (i.e., (total monthly minutes – cumulative minutes of Downtime) / (total monthly minutes).  Availability to the SaaS Software will be measured, and reported on, by FlowFuse using instrumentation and observation tools specifically designed to provide a representative measure of service availability. Recent status, references to availability measurement definition, and historical reporting will be available at or linked from the FlowFuse system status site located at https://status.FlowFuse.com/.
-</p>
-<p>
-Subject to the exclusions herein, “Downtime” is defined as any period of time during which Customer is unable to access the SaaS Software. “Downtime” specifically excludes: (i) scheduled maintenance, which is conducted between 9:00 PM (PT) and 4:00  AM (PT); (ii) Customer’s systems, networks, equipment, or connections; (iii) Customer’s acts other than in accordance with the Agreement, including, without limitation, any negligence, willful misconduct or use of the SaaS Software in breach of this Agreement; or (iv) Force Majeure - circumstances beyond FlowFuse’s reasonable control including, without limitation, acts of any governmental body, war, insurrection, sabotage, embargo, fire, flood, strike or other labor disturbance, unavailability of or interruption or delay in telecommunications or third party services, failure of third party software or inability to obtain supplies used in or equipment needed for provision of the SaaS Software.
+Availability to the SaaS Software will be measured, and reported on, by FlowFuse using instrumentation and observation tools specifically designed to provide a representative measure of service availability. Recent status, references to availability measurement definition, and historical reporting will be available at or linked from the FlowFuse system status site located at https://status.flowfuse.com/.
 </p>
 <h4><strong>RESILIENCY</strong></h4>
 
 
 <p>
-FlowFuse will architect and maintain an underlying cloud infrastructure with commercially reasonable resiliency for all data, compute, and network services. At a minimum, FlowFuse will maintain the highest documented level of “FlowFuse Reference Architecture” as detailed at https://flowfuse.com/docs/.
+FlowFuse will architect and maintain an underlying cloud infrastructure with commercially reasonable resiliency for all data, compute, and network services. At a minimum, FlowFuse will maintain the highest documented level of “FlowFuse Reference Architecture” as detailed at https://flowfuse.com/docs.
 </p>
 <h4><strong>BACKUPS</strong></h4>
 
@@ -521,5 +494,5 @@ FlowFuse will occasionally perform scheduled system maintenance which requires l
 
 
 <p>
-FlowFuse reserves the right to suspend service to the SaaS Software if: (i) Customer fails to comply with the Agreement and this Appendix; (ii)  Customer exceeds set application limits, or (iii) requests or usage deemed malicious in nature is identified to be sourced from Customer accounts, personnel, or systems.
+FlowFuse reserves the right to suspend service to the SaaS Software if: (i) Customer fails to comply with the Agreement and this Appendix, (ii) Customer exceeds set application limits, or (iii) requests or usage deemed malicious in nature is identified to be sourced from Customer accounts, personnel, or systems.
 </p>

--- a/src/handbook/customer/sales/subscription-agreements/subscription-agreement-1.5.njk
+++ b/src/handbook/customer/sales/subscription-agreements/subscription-agreement-1.5.njk
@@ -1,37 +1,45 @@
 ---
 # Note: Do not delete this file. It's still referenced in contracts and quotes.
-navTitle: Subscription Agreement 1.4
+navTitle: Subscription Agreement 1.5
 navGroup: Customer Department
-skipIndex: true
+permalink: /handbook/customer/sales/subscription-agreement-1.5/
+hubspot:
+  script: "hubspot/hs-form.njk"
+  formId: "f5a6441c-63a5-4a4a-b676-87aab37df998"
+  cta: "subscription-agreement"
+  reference: "subscription-agreement"
 ---
 
-<h2>This subscription has been superseded by <a href="./subscription-agreement-1.5/">Subscription Agreement 1.5</a>.</h2>
+<p>Below if the FlowFuse subscription agreement that applies to all self-hosted
+  installations. If you'd like to make alterations for your organisation, please
+  download the .docx file in the following form and initiate the legal part of
+  the negotiation through your account executive.</p>
+  
+<p class="pb-4">Note alterations to the following agreement are only accepted on the Enterprise tier.</p>
 
-<br />
+{% include hubspot.script %}
 
 <h2><strong>Subscription Agreement</strong></h2>
 
+<p>
+This Subscription Agreement (“Agreement”) is between FlowFuse Inc. DBA FlowFuse with offices at 548 Market St
+</p>
+<p>
+PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate entity is listed as “FlowFuse” on an Quote [as defined below], (“FlowFuse”), and the individual or entity signing or electronically accepting this Agreement, or any Quote that references this Agreement (“Customer”). This Agreement is entered into on the earlier of, (a) Customer clicking “Agree” or “Yes” to the terms of this Agreement to gain initial access to, or use of, the Software, (b) FlowFuse and Customer agreeing to an Quote referencing this Agreement, or (c) Customer is given access to the Software (“Effective Date”).
+</p>
 
-<p>
-This Subscription Agreement (“Agreement”) is between FlowFuse Inc. with offices at 548 Market St
-</p>
-<p>
-PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate entity is listed as “FlowFuse” on an Order Form [as defined below], (“FlowFuse”), and the individual or entity signing or electronically accepting this Agreement, or any Order Form that references this Agreement (“Customer”). This Agreement is entered into on the earlier of, (a) Customer clicking “Agree” or “Yes” to the terms of this Agreement to gain initial access to, or use of, the Software, (b) FlowFuse and Customer agreeing to an Order Form referencing this Agreement, or (c) Customer is given access to the Software (“Effective Date”).
-</p>
 <ul>
+<li>Individual Signing on Behalf of Company. IF THE INDIVIDUAL ACCEPTING THIS AGREEMENT IS ACCEPTING ON BEHALF OF AN ENTERPRISE OR OTHER LEGAL ENTITY, SUCH INDIVIDUAL REPRESENTS THAT THEY HAVE THE AUTHORITY TO BIND SUCH ENTERPRISE AND ITS AFFILIATES TO THESE TERMS AND CONDITIONS, IN WHICH CASE THE TERM “CUSTOMER” SHALL REFER TO SUCH ENTERPRISE AND ITS AFFILIATES.</li>
 
-<li>Individual Signing on Behalf of Company. IF THE INDIVIDUAL ACCEPTING THIS AGREEMENT IS ACCEPTING ON BEHALF OF AN ENTERPRISE OR OTHER LEGAL ENTITY, SUCH INDIVIDUAL REPRESENTS THAT THEY HAVE THE AUTHORITY TO BIND SUCH ENTERPRISE AND ITS AFFILIATES TO THESE TERMS AND CONDITIONS, IN WHICH CASE THE TERM “CUSTOMER” SHALL REFER TO SUCH ENTERPRISE AND ITS AFFILIATES.
+<li>Individual Not Authorized to Sign on Behalf of Company. IF THE INDIVIDUAL ACCEPTING THIS AGREEMENT DOES NOT HAVE SUCH AUTHORITY, OR DOES NOT AGREE WITH THESE TERMS AND CONDITIONS, SUCH INDIVIDUAL MUST NOT ACCEPT THIS AGREEMENT AND MAY NOT USE THE SERVICES OR SOFTWARE.</li>
 
-<li>Individual Not Authorized to Sign on Behalf of Company. IF THE INDIVIDUAL ACCEPTING THIS AGREEMENT DOES NOT HAVE SUCH AUTHORITY, OR DOES NOT AGREE WITH THESE TERMS AND CONDITIONS, SUCH INDIVIDUAL MUST NOT ACCEPT THIS AGREEMENT AND MAY NOT USE THE SERVICES OR SOFTWARE.
-
-<li>Individual Signing on Behalf of Individual But Using Company Email. IF THE INDIVIDUAL ACCEPTING THIS AGREEMENT IS ACCEPTING THIS AGREEMENT ON HIS OR HER OWN BEHALF BUT USING AN ENTERPRISE EMAIL ADDRESS TO DO SO, SUCH INDIVIDUAL ACKNOWLEDGES AND AGREES THAT USE OF SUCH ENTERPRISE EMAIL ADDRESS WILL ESTABLISH A FLOWFUSE ACCOUNT THAT WILL BE ASSOCIATED WITH THE APPLICABLE ENTERPRISE, AND CAN AND WILL BE TRANSFERRED ENTIRELY (BOTH CONTROL AND DATA/INFORMATION WITHIN THE ACCOUNT) TO SUCH ENTERPRISE UPON SUCH COMPANY’S REQUEST WITHOUT NOTICE OR LIABILITY TO THE INDIVIDUAL. AS SUCH, TO ENSURE NO LOSS OF PERSONAL CONTENT, FLOWFUSE STRONGLY RECOMMENDS ESTABLISHING A FLOWFUSE ACCOUNT TIED TO A PERSONAL EMAIL ADDRESS.
-</li>
+<li>Individual Signing on Behalf of Individual But Using Company Email. IF THE INDIVIDUAL ACCEPTING THIS AGREEMENT IS ACCEPTING THIS AGREEMENT ON HIS OR HER OWN BEHALF BUT USING AN ENTERPRISE EMAIL ADDRESS TO DO SO, SUCH INDIVIDUAL ACKNOWLEDGES AND AGREES THAT USE OF SUCH ENTERPRISE EMAIL ADDRESS WILL ESTABLISH A FLOWFUSE ACCOUNT THAT WILL BE ASSOCIATED WITH THE APPLICABLE ENTERPRISE, AND CAN AND WILL BE TRANSFERRED ENTIRELY (BOTH CONTROL AND DATA/INFORMATION WITHIN THE ACCOUNT) TO SUCH ENTERPRISE UPON SUCH COMPANY’S REQUEST WITHOUT NOTICE OR LIABILITY TO THE INDIVIDUAL. AS SUCH, TO ENSURE NO LOSS OF PERSONAL CONTENT, FLOWFUSE STRONGLY RECOMMENDS ESTABLISHING A FLOWFUSE ACCOUNT TIED TO A PERSONAL EMAIL ADDRESS.</li>
 </ul>
 <h3><strong>1. DEFINITIONS</strong></h3>
 
 
 <p>
-“Acceptance” of an Order Form shall occur at the earliest of the following: (a) execution of an Order Form, (b) reference to an Order Form Quote No. within a purchase order or similar document, or (c) the use of Software.
+“Acceptance” of a Quote shall occur at the earliest of the following: (a) execution of a Quote, (b) reference to an Quote Quote No. within a purchase order or similar document, or (c) the use of Software.
 </p>
 <p>
 “Affiliate” means any entity(ies) controlling, controlled by, and/or under common control with a party hereto, where “control” means the ownership of more than 50% of the voting securities in such an entity.
@@ -64,7 +72,7 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 “Designated National” is any person or entity on the U.S. Department of Treasury’s List of Specially Designated Nationals or the U.S. Department of Commerce’s Table of Denial Orders.
 </p>
 <p>
-"Effective Price" means the actual price paid by Customer (List Price minus any applicable discount(s)) as set forth on an Order Form or as purchased via the Website.
+"Effective Price" means the actual price paid by Customer (List Price minus any applicable discount(s)) as set forth on a Quote or as purchased via the Website.
 </p>
 <p>
 “Embargoed Countries” refers collectively to countries to which the United States maintains an embargo.
@@ -73,7 +81,7 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 “Enterprise” means the organization, company, corporation and/or other type of entity which procures the Software to be used on its behalf pursuant to the terms of this Agreement.
 </p>
 <p>
-“Fees” are those fees set forth within the Order Form, or, fees due immediately when purchasing via the web-portal.
+“Fees” are those fees set forth within the Quote, or, fees due immediately when purchasing via the web-portal.
 </p>
 <p>
 “Free Software” means a feature-limited version of Software provided to a Customer, User, end user, partner, or any other third party at no (or a greatly reduced cost) including but not limited to, the lowest tier offering of Software as made available by FlowFuse.
@@ -82,7 +90,7 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 “Individual” means a person who uses the Software on their own behalf, and not an Enterprise. An Individual must be over the age of thirteen (13) years old.
 </p>
 <p>
-"List Price" means the list price of the FlowFuse Software excluding (if applicable) any discount(s) set forth in an Order Form or as purchased via the Website.
+"List Price" means the list price of the FlowFuse Software excluding (if applicable) any discount(s) set forth in a Quote or as purchased via the Website.
 </p>
 <p>
 “Node-RED instance” means a runtime, editor, or other part of the Node-RED software offering.
@@ -91,7 +99,7 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 “Open-Source Edition Software” means the publicly available, community-developed open-source software and components which may be provided with the Software. Open-Source Edition Software is provided as Free Software (as defined herein).
 </p>
 <p>
-“Order Form” is a transactional document agreed to between the parties which states the Software and/or Supplemental Services being purchased, term of use, price, subscription duration, and other applicable transaction details. For the avoidance of doubt, the parties acknowledge and agree the terms and conditions stated within this Agreement and an executed Order Form shall govern with respect to all matters contemplated herein.
+“Quote” is a transactional document agreed to between the parties which states the Software and/or Supplemental Services being purchased, term of use, price, subscription duration, and other applicable transaction details. For the avoidance of doubt, the parties acknowledge and agree the terms and conditions stated within this Agreement and an executed Quote shall govern with respect to all matters contemplated herein.
 </p>
 <p>
 “Purchase Order” is a Customer’s processing document, or similar record, which is used by Customer to demonstrate internal approval and /or record of a purchase. Any terms stated within a Purchase Order shall be null and void and are expressly rejected by the parties.
@@ -100,22 +108,22 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 “Software” means software, and other branded offerings made available by FlowFuse or its Affiliate(s), including but not limited to, FlowFuse’s Application Platform.
 </p>
 <p>
-“Subscription” refers to the applicable services, support and function(s) of the Software as provided. Subscriptions are provided in tiers / levels as described in Appendix 1 and are based on the number of Users.
+“Subscription” refers to the applicable services, support and function(s) of the Software as provided. Subscriptions are provided in tiers / levels as described in Appendix 1 and are based on the number of Node-RED instances and Users.
 </p>
 <p>
-“Subscription Start Date” is, unless otherwise agreed to in writing, the start date, (i) stated on an Order Form, or, the date in which Customer is given access to the Software (whichever is later), or (ii) as indicated via a Website transaction, regardless if such purchase is direct with FlowFuse or via an Authorized Partner.
+“Subscription Start Date” is, unless otherwise agreed to in writing, the start date, (i) stated on an Quote, or, the date in which Customer is given access to the Software (whichever is later), or (ii) as indicated via a Website transaction, regardless if such purchase is direct with FlowFuse or via an Authorized Partner.
 </p>
 <p>
-“Subscription Term” shall begin on the Subscription Start Date and continue for twelve (12) months, unless the term length is otherwise agreed to in an Order Form or web-portal purchase.
+“Subscription Term” shall begin on the Subscription Start Date and continue for twelve (12) months, unless the term length is otherwise agreed to in an Quote or web-portal purchase.
 </p>
 <p>
-“Supplemental Services” means additional capacity, functionality, storage and/or other elements that Customer may procure in addition to the Software. Such Supplemental Services may be purchased by Order Form or web-portal. Supplemental Services purchased will be: (i) provided as a separate line item in an Order Form or web-portal purchase, and (ii) co-termed to the underlying Subscription Term if not purchased on the Subscription Start Date. For the avoidance of doubt, Supplemental Services are not part of the Software, but rather, are provided in addition to the Software and Supplemental Services shall be subject to the terms and conditions of this Agreement.
+“Supplemental Services” means additional capacity, functionality, storage and/or other elements that Customer may procure in addition to the Software. Such Supplemental Services may be purchased by Quote or web-portal. Supplemental Services purchased will be: (i) provided as a separate line item in an Quote or web-portal purchase, and (ii) co-termed to the underlying Subscription Term if not purchased on the Subscription Start Date. For the avoidance of doubt, Supplemental Services are not part of the Software, but rather, are provided in addition to the Software and Supplemental Services shall be subject to the terms and conditions of this Agreement.
 </p>
 <p>
 “User(s)” is defined as the unique and single Individual, employee, Contractor, or other third party individual or machine authorized by Customer (in accordance with this Agreement) that requires the provision of a seat within the admin platform, who are able to access the Software purchased under a Subscription, regardless of whether the User actually accesses or the frequency with which they access the Software. A User must be over the age of thirteen (13) years old.
 </p>
 <p>
-“Website” means FlowFuse’s website located at 'flowfuse.com', 'flowforge.cloud', 'flowfuse.cloud' and all subdomains, and all content, services, documentation provided on the Website.
+“Website” means FlowFuse’s website located at <a href="http://www.flowfuse.com">www.flowfuse.com</a>, <a href="http://www.flowforge.cloud">www.FlowFuse.cloud</a>,<a href="http://www.flowfuse.cloud">www.flowfuse.cloud</a> and all subdomains, and all content, services, documentation provided on the Website.
 </p>
 <h3><strong>2. SCOPE OF AGREEMENT</strong></h3>
 
@@ -136,13 +144,19 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 (i) purchasing via the FlowFuse Website;
 </p>
 <p>
-(ii) executing an Order Form with FlowFuse or an Affiliate of FlowFuse; or
+(ii) executing a Quote with FlowFuse or an Affiliate of FlowFuse; 
 </p>
 <p>
-(iii) purchase from an Authorized Partner.
+(iii) upgrading a license via FlowFuse Cloud or, if Customer is self-hosted, by requesting generation of a new license (either method, a “License Upgrade”)  or
 </p>
 <p>
-3.3 FlowFuse and Customer acknowledge and agree that Free Software may be: (i) modified and/or updated, without notice, and (ii) limited in functionality, features, maintenance, support and contain other limitations not present in Software purchased. NOTWITHSTANDING THE “WARRANTY” AND “INDEMNIFICATION” SECTIONS BELOW, FREE SOFTWARE AND SOFTWARE OFFERED ON A TRIAL BASIS (AS STATED IN AN ORDER FORM OR WEB-PORTAL PURCHASE) ARE PROVIDED “AS-IS” WITHOUT ANY WARRANTY AND FLOWFUSE SHALL HAVE NO INDEMNIFICATION OBLIGATIONS NOR LIABILITY OF ANY TYPE WITH RESPECT TO SUCH FREE SOFTWARE UNLESS SUCH EXCLUSION OF LIABILITY IS NOT ENFORCEABLE UNDER APPLICABLE LAW, IN WHICH CASE FLOWFUSE’S LIABILITY WITH RESPECT TO SUCH FREE SOFTWARE SHALL NOT EXCEED $1,000.00USD.
+(iv) purchase from an Authorized Partner.
+</p>
+<p>
+3.3 License Upgrades will be invoiced quarterly if accessed via FlowFuse Cloud, or immediately if Customer is self-hosted and requests a License Upgrade. License Upgrades will be payable in accordance with Section 6 (six) of this Agreement.
+</p>
+<p>
+3.4 FlowFuse and Customer acknowledge and agree that Free Software may be: (i) modified and/or updated, without notice, and (ii) limited in functionality, features, maintenance, support and contain other limitations not present in Software purchased. NOTWITHSTANDING THE “WARRANTY” AND “INDEMNIFICATION” SECTIONS BELOW, FREE SOFTWARE AND SOFTWARE OFFERED ON A TRIAL BASIS (AS STATED IN AN QUOTE OR WEB-PORTAL PURCHASE) ARE PROVIDED “AS-IS” WITHOUT ANY WARRANTY AND FLOWFUSE SHALL HAVE NO INDEMNIFICATION OBLIGATIONS NOR LIABILITY OF ANY TYPE WITH RESPECT TO SUCH FREE SOFTWARE UNLESS SUCH EXCLUSION OF LIABILITY IS NOT ENFORCEABLE UNDER APPLICABLE LAW, IN WHICH CASE FLOWFUSE’S LIABILITY WITH RESPECT TO SUCH FREE SOFTWARE SHALL NOT EXCEED $1,000.00USD.
 </p>
 <h3><strong>4. TERM AND TERMINATION</strong></h3>
 
@@ -151,10 +165,10 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 4.1 The Agreement commences on the Effective Date and continues until it is terminated in accordance with this Section 4.
 </p>
 <p>
-4.2 A Subscription Term shall begin as of the Subscription Start Date and remain in effect for the term length indicated on the Order Form (the "Initial Term") and automatically renew for successive twelve (12) month terms (each a "Renewal Term") unless either party gives notice of its intention not to renew thirty (30) days prior to the expiration of the current Subscription Term. Customer shall have the right to opt-out of such renewal, from within the Software, commencing upon the Subscription Start Date until thirty (30) days prior to the expiration of the Subscription Term. Subscriptions must be used during the Subscription Term and any unused Subscriptions will expire.
+4.2 A Subscription Term shall begin as of the Subscription Start Date and remain in effect for the term length indicated on the Quote (the "Initial Term") and automatically renew for successive twelve (12) month terms (each a "Renewal Term") unless either party gives notice of its intention not to renew thirty (30) days prior to the expiration of the current Subscription Term. Customer shall have the right to opt-out of such renewal, from within the Software, commencing upon the Subscription Start Date until thirty (30) days prior to the expiration of the Subscription Term. Subscriptions must be used during the Subscription Term and any unused Subscriptions will expire.
 </p>
 <p>
-4.3 Either party may terminate this Agreement and any Order Form executed between the parties if:
+4.3 Either party may terminate this Agreement and any Quote executed between the parties if:
 </p>
 <p>
 (a) the other party materially breaches this Agreement and does not cure the breach within thirty (30) days after written notice; or
@@ -166,7 +180,7 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 4.4 FlowFuse may (at its sole discretion) suspend delivering Subscriptions if Customer breaches the terms of Section 6 (Payment of Fees) until the breach is remedied.
 </p>
 <p>
-4.5 Unless otherwise stated herein, termination of this Agreement shall not affect any Subscriptions currently being delivered and this Agreement shall remain in full force and effect until the expiration of the then-current Subscription Term. In the event this Agreement is terminated by Customer in accordance with Section 4.3, FlowFuse will refund Customer any prepaid Fees for the prorated portion of unused Subscription Term. If this Agreement is terminated by FlowFuse in accordance with this Section 4, Customer will pay (if applicable) any unpaid Fees covering the remainder of the Subscription Term of all Order Forms, to the extent permitted by applicable law. For the avoidance of doubt, in no event will termination relieve Customer of its obligation to pay any Fees payable to FlowFuse for the period prior to the effective date of termination. The terms and conditions of this Agreement will apply to any Renewal Term(s) provided that, absent an Effective Price as set forth in an Order Form, Website purchase or other written agreement between the Parties, FlowFuse’s then-current List Price will apply with regard to any such Renewal Term(s). FlowFuse reserves the right to increase fees for any Renewal Term(s) with respect to its products and services, including the Software and Supplemental Services.
+4.5 Unless otherwise stated herein, termination of this Agreement shall not affect any Subscriptions currently being delivered and this Agreement shall remain in full force and effect until the expiration of the then-current Subscription Term. In the event this Agreement is terminated by Customer in accordance with Section 4.3, FlowFuse will refund Customer any prepaid Fees for the prorated portion of unused Subscription Term. If this Agreement is terminated by FlowFuse in accordance with this Section 4, Customer will pay (if applicable) any unpaid Fees covering the remainder of the Subscription Term of all Quotes, to the extent permitted by applicable law. For the avoidance of doubt, in no event will termination relieve Customer of its obligation to pay any Fees payable to FlowFuse for the period prior to the effective date of termination. The terms and conditions of this Agreement will apply to any Renewal Term(s) provided that, absent an Effective Price as set forth in an Quote, Website purchase or other written agreement between the Parties, FlowFuse’s then-current List Price will apply with regard to any such Renewal Term(s). FlowFuse reserves the right to increase fees for any Renewal Term(s) with respect to its products and services, including the Software and Supplemental Services.
 </p>
 <h3><strong>5. RESTRICTIONS AND RESPONSIBILITIES</strong></h3>
 
@@ -178,13 +192,13 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 (i) use the Software for any purpose other than as specifically authorized in this Agreement;
 </p>
 <p>
-(ii) use the Software in such a manner that would enable any third party to access the Software;
+(ii) use the Software in such a manner that would enable any unauthorized third party to access the Software;
 </p>
 <p>
 (iii) use the Software for time sharing or service bureau purposes (including without limitation, sublicensing, distributing, selling, reselling any Software);
 </p>
 <p>
-(iv) for any purpose other than its and its Affiliates’ own internal use;
+(iv) for any purpose other than its and its Affiliates’ own internal use, except as specifically set forth in a Reseller Agreement for authorized Sublicense Referrals;
 </p>
 <p>
 (v) use the Software other than in compliance with all applicable laws and regulations;
@@ -214,7 +228,13 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 (ii) any acts or omissions carried out by Contractors on Customer’s behalf. Customer shall ensure that Contractors are subject to terms no less stringent than those stated herein.
 </p>
 <p>
-5.6 Subject to this Agreement and the applicable Order Form, FlowFuse will provide Customer Support to Customer for the Subscriptions, during the Subscription Term, at no additional cost. Details regarding Customer Support can be found in Appendix 1.
+(iii) ensuring no firewalls or any other technical device prevent the Software from sending periodic pings to FlowFuse to enable it to monitor Customer’s  license compliance, or for any other reason.
+</p>
+<p>
+(iv) ensuring that Sublicense Referrals execute a Subscription Agreement with terms at least as restrictive as those set forth herein; for sake of clarity, Customer will be liable for Sublicense Referrals’ breach of this Agreement as though it were a Customer breach.
+</p>
+<p>
+5.6 Subject to this Agreement and the applicable Quote, FlowFuse will provide Customer Support to Customer for the Subscriptions, during the Subscription Term, at no additional cost. Details regarding Customer Support can be found in Appendix 1.
 </p>
 <p>
 5.7 Portions of the Software are governed by underlying open source licenses. This Agreement and applicable Appendix(eces) establish the rights and obligations associated with Subscriptions and Software and are not intended to limit Customer’s right to software code under the terms of an open source license.
@@ -238,13 +258,13 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 6.1 With respect to purchases direct from FlowFuse, all web-portal purchase Fees shall be due and payable immediately.
 </p>
 <p>
-6.2 With respect to purchases direct from FlowFuse, the Order Form shall: (i) reference this Agreement; (ii) state the Subscription Term(s) and Subscription(s) that are being purchased; and (iii) state the Fees due for the applicable Subscription(s).
+6.2 With respect to purchases direct from FlowFuse, the Quote shall: (i) reference this Agreement; (ii) state the Subscription Term(s) and Subscription(s) that are being purchased; and (iii) state the Fees due for the applicable Subscription(s).
 </p>
 <p>
-6.3 With respect to purchases direct from FlowFuse, such Order Form is hereby incorporated into this Agreement by reference. The parties hereby agree to the terms and conditions stated within this Agreement and those found within an Order Form to the exclusion of all other terms. The parties agree that all terms stated within a Purchase Order, or other similar document, shall be null and void and are expressly rejected.
+6.3 With respect to purchases direct from FlowFuse, such Quote is hereby incorporated into this Agreement by reference. The parties hereby agree to the terms and conditions stated within this Agreement and those found within an Quote to the exclusion of all other terms. The parties agree that all terms stated within a Purchase Order, or other similar document, shall be null and void and are expressly rejected.
 </p>
 <p>
-6.4 With respect to purchases direct from FlowFuse, Customer will pay FlowFuse the applicable Fees, including those for Supplemental Services, without any right of set-off or deduction. All payments will be made in accordance with the payment details stated within the applicable Order Form. If not otherwise specified: (i) FlowFuse (or applicable FlowFuse Affiliate) will invoice Customer for the Fees upon the Acceptance of an Order Form; and (ii) all Fees will be due and payable within thirty (30) days of Customer’s receipt of an invoice. Except as expressly set forth in this Agreement, all Fees paid or due hereunder (including prepaid amounts) are non-refundable, and no credit will be due, including without limitation if this Agreement is terminated in accordance with Section 4 herein.
+6.4 With respect to purchases direct from FlowFuse, Customer will pay FlowFuse the applicable Fees, including those for Supplemental Services, without any right of set-off or deduction. All payments will be made in accordance with the payment details stated within the applicable Quote. If not otherwise specified: (i) FlowFuse (or applicable FlowFuse Affiliate) will invoice Customer for the Fees upon the Acceptance of an Quote; and (ii) all Fees will be due and payable within thirty (30) days of Customer’s receipt of an invoice. Except as expressly set forth in this Agreement, all Fees paid or due hereunder (including prepaid amounts) are non-refundable, and no credit will be due, including without limitation if this Agreement is terminated in accordance with Section 4 herein.
 </p>
 <p>
 6.5 Any unpaid Fees are subject to a finance charge of one percent (1.0%) per month, or the maximum permitted by law, whichever is lower, plus all expenses of collection, including reasonable attorneys’ fees. Fees under this Agreement are exclusive of any and all taxes or duties, now or hereafter imposed by any governmental authority, including, but not limited to any national, state or provincial tax, sales tax, value-added tax, property and similar taxes, if any. Fees under this Agreement shall be paid without any withholding or deduction. In the case of any deduction or withholding requirements, Customer will pay any required withholding itself and will not reduce the amount to be paid to FlowFuse on account thereof.
@@ -280,7 +300,7 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 
 
 <p>
-8.1 Subject to the terms and conditions of this Agreement, FlowFuse hereby grants to Customer and its Affiliates a limited, non-exclusive, non-transferable, non-sublicensable license for Customer’s and its Affiliates’ Users to use, reproduce, modify, prepare derivative works based upon, and display the code of Software at the tier level selected by Customer, or as set forth in an Order Form, solely for: (i) its internal use in connection with the development of Customer’s and/or its Affiliates’ own software; and (ii) the number of Users for which Customer has paid FlowFuse. Notwithstanding anything to the contrary, Customer agrees that FlowFuse and/or its licensors (as applicable) retain all right, title and interest in and to all Software incorporated in such modifications and/or patches, and all such Software may only be used, copied, modified, displayed, distributed, or otherwise exploited in full compliance with this Agreement, and with a valid Subscription for the correct number of Users.
+8.1 Subject to the terms and conditions of this Agreement, FlowFuse hereby grants to Customer and its Affiliates a limited, non-exclusive, non-transferable, non-sublicensable license for Customer’s and its Affiliates’ Users to use, reproduce, modify, prepare derivative works based upon, and display the code of Software at the tier level selected by Customer, or as set forth in an Quote, solely for: (i) its internal use in connection with the development of Customer’s and/or its Affiliates’ own software; and (ii) the number of Users for which Customer has paid FlowFuse. Notwithstanding anything to the contrary, Customer agrees that FlowFuse and/or its licensors (as applicable) retain all right, title and interest in and to all Software incorporated in such modifications and/or patches, and all such Software may only be used, copied, modified, displayed, distributed, or otherwise exploited in full compliance with this Agreement, and with a valid Subscription for the correct number of Users.
 </p>
 <p>
 8.2 Except as expressly set forth herein, FlowFuse (and its licensors, where applicable) will retain all intellectual property rights relating to the Software and any suggestions, ideas, enhancement requests, feedback, or other recommendations provided by Customer, its Affiliates, Users or any third party relating to the Software (herein referred to as “Feedback Materials”), which are hereby assigned to FlowFuse. For the avoidance of doubt, Feedback Materials shall not include Customer Confidential Information or intellectual property owned by Customer. This Agreement does not constitute a sale of the Software and does not convey to Customer any rights of ownership in or related to the Software or any other intellectual property rights.
@@ -310,10 +330,10 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 
 
 <p>
-10.1 FlowFuse will defend Customer from any claim, demand, suit or proceeding made or brought against Customer by a third party alleging the Software (excluding Free Software as set forth in Section 3.3) provided by FlowFuse infringes or misappropriates such third party’s patent or copyright (a “Customer Claim”). FlowFuse will indemnify and hold Customer harmless from any damages, reasonable attorneys’ fees and costs finally awarded against Customer as a result of a Customer Claim, or for amounts paid by Customer under a settlement approved (in writing) by FlowFuse, provided Customer: (i) promptly notifies FlowFuse in writing of the Customer Claim; (ii) gives FlowFuse all reasonable assistance at FlowFuse’s expense; and (iii) gives FlowFuse sole control over defense and settlement thereof except that FlowFuse may not settle any Customer Claim unless it unconditionally releases Customer of all liability. The foregoing obligations do not apply if: (v) the Customer Claim arises from Software or any part thereof that is modified by Customer, or at Customer’s direction, after delivery by FlowFuse; (w) the Customer Claim arises from the use or combination of the Software or any part thereof with other products, processes or materials not provided by FlowFuse where the alleged infringement relates to such combination; (x) Customer continues allegedly infringing activity after being notified thereof or after being informed of modifications that would have avoided the alleged infringement; (y) the Customer Claim arises from software not created by FlowFuse, or (z) the Customer Claim results from Customer’s breach of this Agreement and/or applicable Order Forms. Notwithstanding the foregoing, in the event of a Customer Claim, FlowFuse, at its discretion, option and expense, reserves the rights to: (a) modify the Software to make it non-infringing provided there is no material loss of functionality; (b) settle such claim by procuring the right for Customer to continue using the Software; or (c) if in FlowFuse’s reasonable opinion neither (a) or (b) are commercially feasible, terminate the license to the Software and refund a pro-rata portion of the amount paid by Customer for such Software for the unused portion of the Subscription Term.
+10.1 FlowFuse will defend Customer from any claim, demand, suit or proceeding made or brought against Customer by a third party alleging the Software (excluding Free Software as set forth in Section 3.3) provided by FlowFuse infringes or misappropriates such third party’s patent or copyright (a “Customer Claim”). FlowFuse will indemnify and hold Customer harmless from any damages, reasonable attorneys’ fees and costs finally awarded against Customer as a result of a Customer Claim, or for amounts paid by Customer under a settlement approved (in writing) by FlowFuse, provided Customer: (i) promptly notifies FlowFuse in writing of the Customer Claim; (ii) gives FlowFuse all reasonable assistance at FlowFuse’s expense; and (iii) gives FlowFuse sole control over defense and settlement thereof except that FlowFuse may not settle any Customer Claim unless it unconditionally releases Customer of all liability. The foregoing obligations do not apply if: (v) the Customer Claim arises from Software or any part thereof that is modified by Customer, or at Customer’s direction, after delivery by FlowFuse; (w) the Customer Claim arises from the use or combination of the Software or any part thereof with other products, processes or materials not provided by FlowFuse where the alleged infringement relates to such combination; (x) Customer continues allegedly infringing activity after being notified thereof or after being informed of modifications that would have avoided the alleged infringement; (y) the Customer Claim arises from software not created by FlowFuse, or (z) the Customer Claim results from Customer’s breach of this Agreement and/or applicable Quotes. Notwithstanding the foregoing, in the event of a Customer Claim, FlowFuse, at its discretion, option and expense, reserves the rights to: (a) modify the Software to make it non-infringing provided there is no material loss of functionality; (b) settle such claim by procuring the right for Customer to continue using the Software; or (c) if in FlowFuse’s reasonable opinion neither (a) or (b) are commercially feasible, terminate the license to the Software and refund a pro-rata portion of the amount paid by Customer for such Software for the unused portion of the Subscription Term.
 </p>
 <p>
-10.2 Customer will defend FlowFuse and its Affiliates against any claim, demand, suit or proceeding made or brought against FlowFuse by a third party alleging: (i) that any Customer Content or Customer’s use of Customer Content with the Software or any software (or combination of software) provided by Customer and used with the Software, infringes or misappropriates such third party’s intellectual property rights, or (ii) arising from Customer’s use of the Software in an unlawful manner or in violation of the Agreement, the applicable documentation, or Order Form (each a “FlowFuse Claim”). Customer will indemnify FlowFuse from any damages, reasonable attorneys’ fees and costs finally awarded against FlowFuse as a result of, or for any amounts paid by FlowFuse under a settlement approved (in writing) by Customer of a FlowFuse Claim, provided FlowFuse: (x) promptly gives Customer written notice of the FlowFuse Claim, (y) gives Customer sole control of the defense and settlement of the FlowFuse Claim (except that Customer may not settle any FlowFuse Claim unless it unconditionally releases FlowFuse of all liability), and (z) gives Customer all reasonable assistance, at Customer’s expense. The above defense and indemnification obligations do not apply if a FlowFuse Claim arises from FlowFuse’s breach of this Agreement and/or applicable Order Form.
+10.2 Customer will defend FlowFuse and its Affiliates against any claim, demand, suit or proceeding made or brought against FlowFuse by a third party alleging: (i) that any Customer Content or Customer’s use of Customer Content with the Software or any software (or combination of software) provided by Customer and used with the Software, infringes or misappropriates such third party’s intellectual property rights, or (ii) arising from Customer’s use of the Software in an unlawful manner or in violation of the Agreement, the applicable documentation, or Quote (each a “FlowFuse Claim”). Customer will indemnify FlowFuse from any damages, reasonable attorneys’ fees and costs finally awarded against FlowFuse as a result of, or for any amounts paid by FlowFuse under a settlement approved (in writing) by Customer of a FlowFuse Claim, provided FlowFuse: (x) promptly gives Customer written notice of the FlowFuse Claim, (y) gives Customer sole control of the defense and settlement of the FlowFuse Claim (except that Customer may not settle any FlowFuse Claim unless it unconditionally releases FlowFuse of all liability), and (z) gives Customer all reasonable assistance, at Customer’s expense. The above defense and indemnification obligations do not apply if a FlowFuse Claim arises from FlowFuse’s breach of this Agreement and/or applicable Quote.
 </p>
 <p>
 10.3 This Section 10 (Indemnification) states the indemnifying party’s sole liability to, and the indemnified party’s exclusive remedy against the other party for any third-party claim described in this section.
@@ -361,7 +381,7 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 14.1 Without limiting FlowFuse’s obligations as stated in Section 7 (Confidentiality), FlowFuse shall be responsible for establishing and maintaining a commercially reasonable information security program that is designed to: (i) ensure the security and confidentiality of the Customer Content; (ii) protect against any anticipated threats or hazards to the security or integrity of the Customer Content; (iii) protect against unauthorized access to, or use of, the Customer Content; and (iv) ensure that all subcontractors of FlowFuse, if any, comply with all of the foregoing. In no case shall the safeguards of FlowFuse’s information security program be less stringent than the information security safeguards used by FlowFuse to protect its own commercially sensitive data. Customer shall use commercially reasonable security and anti-virus measures when accessing and using the Software and to prevent unauthorized access to, or use of the Software, and notify FlowFuse promptly of any such unauthorized access or use of which it becomes aware.
 </p>
 <p>
-14.2 With respect to the protection of information, the FlowFuse Privacy Statement located here https://flowfuse.com/privacy-policy/, shall apply. If this Agreement is entered into on behalf of an Enterprise, the terms of the data processing addendum at https://flowfuse.com/terms/#6.4-data-processing-agreement. (“DPA”) are hereby incorporated by reference and shall apply to the extent Customer Content includes Personal Data, as defined in the DPA. To the extent Personal Data from the European Economic Area (EEA), the United Kingdom and Switzerland are processed by FlowFuse, the Standard Contractual Clauses shall apply, as further set forth in the DPA. For the purposes of the Standard Contractual Clauses, Customer and its applicable Affiliates are each the data exporter, and Customer's acceptance of this Agreement, and an applicable Affiliate's execution of an Order Form, shall be treated as its execution of the Standard Contractual Clauses.
+14.2 With respect to the protection of information, the FlowFuse Privacy Statement located here https://flowfuse.com/privacy-policy/, shall apply. If this Agreement is entered into on behalf of an Enterprise, the terms of the data processing addendum at https://flowfuse.com/terms/#6.4-data-processing-agreement. (“DPA”) are hereby incorporated by reference and shall apply to the extent Customer Content includes Personal Data, as defined in the DPA. To the extent Personal Data from the European Economic Area (EEA), the United Kingdom and Switzerland are processed by FlowFuse, the Standard Contractual Clauses shall apply, as further set forth in the DPA. For the purposes of the Standard Contractual Clauses, Customer and its applicable Affiliates are each the data exporter, and Customer's acceptance of this Agreement, and an applicable Affiliate's execution of an Quote, shall be treated as its execution of the Standard Contractual Clauses.
 </p>
 <p>
 14.3 The parties acknowledge and agree that, (i) the Software is not designed for the purpose(s) of storing, processing, compiling or transmitting Sensitive Data (as defined herein), and (ii) Customer shall not use the Software, or otherwise provide to FlowFuse without prior written consent, Sensitive Data under this Agreement. “Sensitive Data” means: (a) special categories of data enumerated in European Union Regulation 2016/679, Article 9(1) or any successor legislation; (b) patient, medical, or other protected health information regulated by the Health Insurance Portability and Accountability Act (as amended and supplemented) (“HIPAA”); (c) credit, debit, or other payment card data or financial account information, including bank account numbers or other personally identifiable financial information; (d) social security numbers, driver’s license numbers, or other government identification numbers; (e) other information subject to regulation or protection under specific laws such as the Children’s Online Privacy Protection Act or Gramm-Leach-Bliley Act (“GLBA”) (or related rules or regulations); or (f) any data similar to the above protected under foreign or domestic laws. Customer further acknowledges that the Software and related features are not intended to meet any legal obligations for these uses, including HIPAA and GLBA requirements, and that FlowFuse is not a Business Associate as defined under HIPAA. Therefore, notwithstanding anything else in this Agreement, FlowFuse has no liability for Sensitive Data processed in connection with Customer’s use of the Software.
@@ -397,8 +417,11 @@ PMB 24889, San Francisco, California 94104-5401 (or, if a different corporate en
 15.8 This Agreement will be governed by the laws of the State of California, U.S.A. without regard to its conflict of laws provisions. The federal and state courts sitting in San Francisco County, California, U.S.A. will have proper and exclusive jurisdiction and venue with respect to any disputes arising from or related to the subject matter of this Agreement. The United Nations Convention on Contracts for the International Sale of Goods is expressly disclaimed by the Parties with respect to this Agreement and the transactions contemplated hereby.
 </p>
 <p>
-Both parties agree to the above terms by signing the Order Form in which these terms are linked.
+Both parties agree to the above terms by signing the Quote in which these terms are linked.
 </p>
+<h2></h2>
+
+
 <h2><strong>APPENDIX 1: FlowFuse Support Policies</strong></h2>
 
 
@@ -427,7 +450,7 @@ The applicable level of support and/or functionality of the Software, as set for
    </td>
   </tr>
   <tr>
-   <td>Premium
+   <td>Team
    </td>
    <td>FlowFuse Standard Support
    </td>
@@ -447,6 +470,9 @@ First Response Time SLA 4 Hours. Submit Tickets at https://flowfuse.com/support/
 </table>
 
 
+<h2></h2>
+
+
 <h2><strong>APPENDIX 2: Software as a Service (SaaS) Offering</strong></h2>
 
 
@@ -457,13 +483,16 @@ With respect to Customer’s purchase and/or use of the SaaS Software, the follo
 
 
 <p>
-Availability to the SaaS Software will be measured, and reported on, by FlowFuse using instrumentation and observation tools specifically designed to provide a representative measure of service availability. Recent status, references to availability measurement definition, and historical reporting will be available at or linked from the FlowFuse system status site located at https://status.flowfuse.com/.
+The SaaS Software will be available to Customer 99.5% of each calendar month commencing with the first full calendar month following the Effective Date (“Uptime”). Availability shall be calculated by subtracting the cumulative minutes of Downtime in a  month from the total number of minutes in the applicable month, and representing the remaining minutes as a percentage of the total number of minutes that month (i.e., (total monthly minutes – cumulative minutes of Downtime) / (total monthly minutes).  Availability to the SaaS Software will be measured, and reported on, by FlowFuse using instrumentation and observation tools specifically designed to provide a representative measure of service availability. Recent status, references to availability measurement definition, and historical reporting will be available at or linked from the FlowFuse system status site located at https://status.FlowFuse.com/.
+</p>
+<p>
+Subject to the exclusions herein, “Downtime” is defined as any period of time during which Customer is unable to access the SaaS Software. “Downtime” specifically excludes: (i) scheduled maintenance, which is conducted between 9:00 PM (PT) and 4:00  AM (PT); (ii) Customer’s systems, networks, equipment, or connections; (iii) Customer’s acts other than in accordance with the Agreement, including, without limitation, any negligence, willful misconduct or use of the SaaS Software in breach of this Agreement; or (iv) Force Majeure - circumstances beyond FlowFuse’s reasonable control including, without limitation, acts of any governmental body, war, insurrection, sabotage, embargo, fire, flood, strike or other labor disturbance, unavailability of or interruption or delay in telecommunications or third party services, failure of third party software or inability to obtain supplies used in or equipment needed for provision of the SaaS Software.
 </p>
 <h4><strong>RESILIENCY</strong></h4>
 
 
 <p>
-FlowFuse will architect and maintain an underlying cloud infrastructure with commercially reasonable resiliency for all data, compute, and network services. At a minimum, FlowFuse will maintain the highest documented level of “FlowFuse Reference Architecture” as detailed at https://flowfuse.com/docs.
+FlowFuse will architect and maintain an underlying cloud infrastructure with commercially reasonable resiliency for all data, compute, and network services. At a minimum, FlowFuse will maintain the highest documented level of “FlowFuse Reference Architecture” as detailed at https://flowfuse.com/docs/.
 </p>
 <h4><strong>BACKUPS</strong></h4>
 
@@ -493,5 +522,5 @@ FlowFuse will occasionally perform scheduled system maintenance which requires l
 
 
 <p>
-FlowFuse reserves the right to suspend service to the SaaS Software if: (i) Customer fails to comply with the Agreement and this Appendix, (ii) Customer exceeds set application limits, or (iii) requests or usage deemed malicious in nature is identified to be sourced from Customer accounts, personnel, or systems.
+FlowFuse reserves the right to suspend service to the SaaS Software if: (i) Customer fails to comply with the Agreement and this Appendix; (ii)  Customer exceeds set application limits, or (iii) requests or usage deemed malicious in nature is identified to be sourced from Customer accounts, personnel, or systems.
 </p>

--- a/src/redirects.njk
+++ b/src/redirects.njk
@@ -1,0 +1,5 @@
+---
+permalink: /_redirects
+eleventyExcludeFromCollections: true
+---
+/handbook/customer/sales/subscription-agreement/  /handbook/customer/sales/subscription-agreement-{{ latestAgreementVersion }}/


### PR DESCRIPTION
## Description

This PR introduces the variable `latestAgreementVersion` and a redirect to the latest agreement from `/handbook/customer/sales/subscription-agreement/`

## Related Issue(s)

closes #2734

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
