### PR TITLE
Docs banner: Add slugify to cta

### DIFF
--- a/src/_includes/components/docs-banner.njk
+++ b/src/_includes/components/docs-banner.njk
@@ -15,7 +15,7 @@
 <div class="w-full bg-indigo-50 border-indigo-300 border-2 rounded-lg max-lg:hidden p-3">
     {% set ad = docs_banner[0] %}
         {% if ad.expire and ad.expire | isFutureDate or not ad.expire %}
-            <a href="{{ ad.link }}" onclick="capture('cta-{{ ad.buttonText }}', {'reference': '{{ ad.reference }}'})" class="text-sm justify-center hover:no-underline">
+            <a href="{{ ad.link }}" onclick="capture('cta-{{ ad.buttonText | slugify }}', {'reference': '{{ ad.reference }}'})" class="text-sm justify-center hover:no-underline">
                 {% if ad.type %}
                     <span class="font-medium text-white px-2 py-1 bg-red-600 rounded-sm">{{ ad.type }}</span>
                 {% endif %}


### PR DESCRIPTION
## Description

Changes:
- Updated `docs-banner.njk` to apply the slugify filter to `ad.buttonText` in the PostHog capture function.

This change helps prevent issues with spaces in tracking identifiers.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
