### PR TITLE
/changelog: Add RSS icon and link

### DIFF
--- a/src/_includes/changelog/template.njk
+++ b/src/_includes/changelog/template.njk
@@ -1,9 +1,12 @@
 <div class="ff-blog container m-auto text-left max-w-4xl pt-8 pb-24 w-full">
-    <div class="px-2 flex items-center gap-12">
+    <div class="px-2 flex items-end gap-12 justify-between">
         <div class="mb-0">
             <h1 class="mb-0">Changelog</h1>
             <p class="my-0">Getting all the news on new features we ship</p>
         </div>
+        <a href="/changelog/index.xml" class="mb-2 hover:text-blue-800 hover:cursor-pointer" title="View the changelog RSS feed">
+            {% include "components/rss.njk" %}
+        </a>
     </div>
     <ul class="flex flex-wrap border-t">
         {%- asyncEach item in posts -%}


### PR DESCRIPTION
## Description

As a follow-up to https://github.com/FlowFuse/website/pull/2751, this PR adds an RSS icon that links to the changelog `.xml` file. A tooltip has been added, I wasn't sure how discrete we wanted this to be.


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
