### PR TITLE
Update engagements.md

### DIFF
--- a/src/handbook/customer/sales/engagements.md
+++ b/src/handbook/customer/sales/engagements.md
@@ -12,23 +12,7 @@ Clearly written, easy to understand quotes are crucial for customers to understa
 
 **What to Quote**
 
-When preparing a quote, include both the plan and any extras that go beyond what comes with the plan at the designated tier. Include a note in the Terms section that indicates what comes with the plan. (This will be pre-filled when using one of the HubSpot quote templates). The product plan will be listed as its own line, with a quantity of 1, and the minimum purchase price for that plan. On a separate line(s), include only additional items that are being added to the deal. Do not use line items to enumerate what comes with the plan. This will cause confusion and makes the line item(s) redundant.
-
-EXAMPLE 1:
-
-Suppose that a customer wants to purchase a year of the Team plan with 5 small instances, the minimum number for the Team plan. That quote would look like this (ignoring any discounts or other extras):
-
-| Item & Description | Quantity | Unit Price | Total |
-| ----- | ----- | ----- | ----- |
-| FlowFuse Team Platform \- Cloud | 1 | $X,000/year | $X,000 |
-
-Annual Subtotal	  $2,100  
-**Total**			  $2,100
-
-
-EXAMPLE 2:
-
-Suppose a customer wants to purchase a year of the Enterprise plan with 20 instances, plus 10 additional instances and 10 devices. That quote would look like this (ignoring any discounts or other extras):
+When preparing a quote, include both the plan and any extras that go beyond what comes with the plan at the designated tier. Include a note in the Terms section that indicates what comes with the plan. (This will be pre-filled when using one of the HubSpot quote templates). The product plan will be listed as its own line, with a quantity of 1, and the minimum purchase price for that plan. The add-on options should also be added to the product section, as referenced by the purchase term template.
 
 | Item & Description | Quantity | Unit Price | Total |
 | ----- | ----- | ----- | ----- |


### PR DESCRIPTION
## Description

Noticed that the handbook doesn't match the HS templates we're currently using. The templates say:

"For any additional capacity required beyond the included capacity of Node-RED instances and edge
devices, add-on blocks of 10 instances or 10 edge devices are available for purchase. Pricing for these
add-ons is detailed in the Products section of this quote."

So we should include the add ons but for 0 quantity as shown here: https://26586079.hs-sites-eu1.com/GvD59WWUq7Ci

Or change the templates to include all product pricing for reference.

I prefer this proposed change (the example I shared) since per product pricing can be deal dependent and is easier to change from the product page when quoting. Also, template terms can not be changed for one offs, the changes need to be made globally and then switched back per deal (not ideal).

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [x] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
