### PR TITLE
ci: Test website with docs from `FlowFuse/flowfuse:main` branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'FlowFuse/flowfuse'
-          ref: maintenance
+          ref: main
           path: 'flowfuse'
       - name: Generate a token
         id: generate_token


### PR DESCRIPTION
## Description

This pull request changes the branch from which FlowFuse docs are pulled and tested from `maintenance` to `main`. This change reflects the content which is published after tests completes.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
