### PR TITLE
/thank-you/contact/: Add stories block

### DIFF
--- a/src/_includes/explore-more-content.njk
+++ b/src/_includes/explore-more-content.njk
@@ -1,6 +1,7 @@
 {% if readingResources and readingResources == "stories" %}
  {% include "stories-block.njk" %}
-{% else %}
+ <h4 class="mt-20 w-full text-center text-gray-500 pt-12 border-t">Learn more about how FlowFuse helps with your industrial data applications</h4>
+ {% endif %}
 <div class="w-full max-w-md md:max-w-none mx-auto flex flex-col md:grid md:grid-cols-3 gap-6 md:gap-x-8 pt-8">
     <div class="w-full my-2 grid grid-cols-1 pb-4">
         <div class="pb-2 md:pb-0">
@@ -63,4 +64,3 @@
         </div>
     </div>
 </div>
-{% endif %}

--- a/src/_includes/explore-more-content.njk
+++ b/src/_includes/explore-more-content.njk
@@ -1,3 +1,6 @@
+{% if readingResources and readingResources == "stories" %}
+ {% include "stories-block.njk" %}
+{% else %}
 <div class="w-full max-w-md md:max-w-none mx-auto flex flex-col md:grid md:grid-cols-3 gap-6 md:gap-x-8 pt-8">
     <div class="w-full my-2 grid grid-cols-1 pb-4">
         <div class="pb-2 md:pb-0">
@@ -60,3 +63,4 @@
         </div>
     </div>
 </div>
+{% endif %}

--- a/src/_includes/layouts/thank-you.njk
+++ b/src/_includes/layouts/thank-you.njk
@@ -15,7 +15,7 @@ hubspot:
 </div>
 <!-- Content -->
 <div class="flex flex-col max-w-5xl mx-auto gap-x-10 px-6">
-  <div class="max-w-md sm:max-w-screen-lg m-auto max-w-5xl pb-12">
+  <div class="max-w-md sm:max-w-screen-lg m-auto max-w-5xl pb-6">
       {% include "explore-more-content.njk" %}
     </div>
   <!-- Social proof logos -->

--- a/src/_includes/layouts/thank-you.njk
+++ b/src/_includes/layouts/thank-you.njk
@@ -1,10 +1,19 @@
 ---
-layout: layouts/page.njk
+layout: layouts/base.njk
 skipIndex: true
 hubspot:
   script: "hubspot/hs-form.njk"
   formId: 159c173d-dd95-49bd-922b-ff3ef243e90c
 ---
+<!-- Hero section -->
+<div class="hero {{ 'hero-lg' if heroLg else ''}} container m-auto text-center flex flex-wrap pt-6 px-6 pb-12 md:flex-nowrap md:max-w-4xl md:pt-12">
+  <div class="mx-auto max-w-screen-xl md:max-w-xl">
+      <h1>{{ title | safe }}</h1>
+      <h4 class="text-gray-500">{{ subtitle | safe }}</h4>
+      <p class="lead-p m-auto mt-3">{{ description | safe }}</p>
+  </div>           
+</div>
+<!-- Content -->
 <div class="flex flex-col max-w-5xl mx-auto gap-x-10 px-6">
   <div class="max-w-md sm:max-w-screen-lg m-auto max-w-5xl pb-12">
       {% include "explore-more-content.njk" %}

--- a/src/_includes/stories-block.njk
+++ b/src/_includes/stories-block.njk
@@ -1,0 +1,7 @@
+<ul class="w-full max-w-md md:max-w-none mx-auto flex flex-col md:grid md:grid-cols-3 gap-3 md:gap-x-4 pt-8">
+    {% from "stories/customer-story.njk" import storyTile %}
+    
+    {%- for item in collections.stories | sort(attribute='item.date') | reverse | limit(3) -%}
+    {{ storyTile(title=item.data.title, url=item.url, brand=item.data.story.brand, logo=item.data.logo, image=item.data.image) }}
+    {%- endfor -%}
+</ul>

--- a/src/thank-you/contact.njk
+++ b/src/thank-you/contact.njk
@@ -1,8 +1,9 @@
 ---
 title: Thank you for contacting us
-subtitle: "<a href='https://meetings-eu1.hubspot.com/flowfuse/book-a-demo-call?uuid=22122d0b-0581-44fb-ab2c-4ae4ff8dc4f5'>Schedule a call right now</a> or get inspired by our customer success stories while you wait for someone from our team to reach out to you."  
-description: 
+subtitle: "<a href='https://meetings-eu1.hubspot.com/flowfuse/book-a-demo-call?uuid=22122d0b-0581-44fb-ab2c-4ae4ff8dc4f5' class='underline'>Schedule a call right now</a>"  
+description: Or get inspired by our customer success stories while you wait for someone from our team to reach out to you.
 downloadFollowUp: false
+readingResources: stories
 hubspot:
   cta: "cta-blog-subscribe"
   reference: "thank-you-contact"


### PR DESCRIPTION
## Description

This PR introduces a partial with the most recent customer stories.
The block was added to the `/thank-you/contact/` page.
The subtitles are now grey instead of indigo for increased contrast with `<a>` elements.

## Related Issue(s)

This is a follow-up to https://github.com/FlowFuse/website/pull/2851

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
