### PR TITLE
/pricing: Update cloud enterprise CTA

### DIFF
--- a/src/pricing/index.njk
+++ b/src/pricing/index.njk
@@ -170,7 +170,7 @@ hubspot:
                             </div>
                             <a class="md:self-end ff-btn ff-btn--primary uppercase align-baseline w-full"
                             {% if cloud %}
-                               href="/book-demo/" onclick="capture('cta-lets-talk', {'position': 'primary'}, {'plan': 'sh-enterprise'})">book a demo</a>
+                               href="#contact-us" onclick="scrollToAnchor(event, 'contact-us'); capture('cta-contact-us', {'position': 'primary'}, {'plan': 'cloud-enterprise'})">Contact Us</a>
                             {% else %}
                                 href="#request-trial-license" onclick="scrollToAnchor(event, 'request-trial-license'); capture('cta-trial-license', {'position': 'primary'}, {'plan': 'sh-enterprise'});">Get 30-day Trial License</a>
                             {% endif %}


### PR DESCRIPTION
## Description

We're replacing the `book a demo` CTA with `contact us` on the cloud-enterprise card in the pricing page.

## Related Issue(s)

https://github.com/FlowFuse/website/issues/2862
https://github.com/FlowFuse/website/issues/2868

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
