### PR TITLE
Handbook - Add "navTitle" to contributing.md

### DIFF
--- a/src/handbook/development/contributing.md
+++ b/src/handbook/development/contributing.md
@@ -1,4 +1,5 @@
 ---
+navTitle: Contributing
 originalPath: development/contributing.md
 updated: git modified
 ---


### PR DESCRIPTION
## Description

Seems like the website is trying to auto-generate the title, and doing so incorrectly.

### Before

<img width="320" alt="Screenshot 2025-01-07 at 11 25 27" src="https://github.com/user-attachments/assets/e843dfbc-cea6-4e2d-941a-14195afb7833" />

### After

<img width="310" alt="Screenshot 2025-01-07 at 11 27 13" src="https://github.com/user-attachments/assets/b35e6b24-0c9d-4f6b-ab48-e9f7b9acdb0c" />
