### PR TITLE
Update security.txt canonical

### DIFF
--- a/src/public/.well-known/security.txt
+++ b/src/public/.well-known/security.txt
@@ -1,6 +1,6 @@
 Contact: mailto:security@flowfuse.com
 Expires: 2025-12-31T23:00:00.000Z
 Preferred-Languages: en
-Canonical: https://flowforge.com/.well-known/security.txt
+Canonical: https://flowfuse.com/.well-known/security.txt
 Policy: https://github.com/FlowFuse/flowfuse/blob/main/SECURITY.md
 


### PR DESCRIPTION
## Description

After merging https://github.com/FlowFuse/website/pull/2928/files I realised the canonical was still pointing to `flowforge.com` it has a redirect, so it was still working, but it's better if we avoid the unnecessary redirect.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
