### PR TITLE
Changelog: Assign template to 2025 logs 

### DIFF
--- a/src/changelog/2025/2025.json
+++ b/src/changelog/2025/2025.json
@@ -1,0 +1,8 @@
+{
+    "tags": [
+        "changelog"
+    ],
+    "layout": "layouts/post-changelog.njk",
+    "nav": "changelog",
+    "searchTitle": "Changelog"
+}


### PR DESCRIPTION
## Description

The changelogs from 2025 didn't have a template assigned. This PR fixes that.

## Related Issue(s)

closes #2945

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
