### PR TITLE
Ensure we capture "Person" objects for all events to better track new arrivals

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -406,6 +406,7 @@ eleventyComputed:
         .finally(() => {
             posthog.init('{{ POSTHOG_APIKEY }}', {
                 api_host:'https://eu.posthog.com',
+                person_profiles: 'always',
                 bootstrap: phBootstrap,
                 capture_pageleave: false,
                 opt_out_capturing_by_default: optOutByDefault


### PR DESCRIPTION
## Description

On December 6th, PostHog introduced "Anonymous Events", which still record the actual event taking place, but remove any meta data about the users doing them, unless they've been directly identified by our application, i.e. they've signed in.

This has meant that we've lost a lot of data around visitors to our site, where those users have come from, and a breakdown of new/returning visitors too.

This config change reverts it back to the behaviour in place _before_ Dec 6th.