### PR TITLE
Remove H1 from the changelog entry for resending team notifications

### DIFF
--- a/src/changelog/2025/02/resend-and-extend-team-invitation-expiration.md
+++ b/src/changelog/2025/02/resend-and-extend-team-invitation-expiration.md
@@ -7,8 +7,6 @@ tags:
 - changelog
 ---
 
-# Re-send Team Invitations and extend their expiration
-
 We have added the ability to **re-send team invitations**, which also extends the expiration date of the invitation. This improvement ensures that invitations remain valid for a longer period and allows team administrators to easily re-invite users who may have missed their initial invitation.
 
 This update enhances user management and simplifies the process of maintaining team memberships within FlowFuse.


### PR DESCRIPTION
## Description

I should have caught this in the review of https://github.com/FlowFuse/website/pull/2991, but didn't, so this is me making amends.

### Before:

<img width="1038" alt="Screenshot 2025-02-28 at 18 13 59" src="https://github.com/user-attachments/assets/c196eff7-acab-4f0b-87ae-a14a779718e1" />

### After

<img width="1163" alt="Screenshot 2025-02-28 at 18 14 13" src="https://github.com/user-attachments/assets/8ad5b9a1-086f-45db-81c0-994eae78f3e1" />
