### PR TITLE
Homepage: Create blueprint section from blueprints repo

### DIFF
--- a/src/_includes/homepage_blueprints.njk
+++ b/src/_includes/homepage_blueprints.njk
@@ -1,0 +1,24 @@
+{% set blueprintIds = ["d9yNg20jRw", "e85N3lmyX6", "6EbLVbLa9j"] %}
+{%- for item in collections.blueprints | reverse -%}
+    {% if item.data.blueprintId in blueprintIds %}
+    <li class="flex flex-col h-full">
+        <div class="mb-2">
+            {%- for tag in item.data.tags -%}
+            {% if tag !== "blueprints" %}
+            <label class="text-gray-700 text-xs font-light rounded-sm bg-indigo-50 py-1.5 px-2 inline-block w-auto">{{ tag | replace('-', ' ') | replace('20', '2.0') | title }}</label>
+            {% endif %}
+            {%- endfor %}
+        </div>
+        <div class="grid bg-indigo-50 ff-image-cover blueprint rounded-lg border drop-shadow-md hover:drop-shadow-lg grow pb-4">
+            <a href="{{ item.url }}" class="w-full flex flex-col group hover:no-underline">
+                <div class="transition-transform group-hover:scale-105 ff-image-cover aspect-video border-b">
+                    {% tileImage item, "./images/og-blog.jpg", "Image with logo and the slogan: Elevate Node-RED with Flowfuse", 285 %}
+                </div>
+                <div class="pt-4 my-auto">
+                    <h5 class="my-auto group-hover:underline px-4 font-medium text-lg leading-6">{{ item.data.title }}</h5>
+                </div>
+            </a>
+        </div>
+    </li>
+    {% endif %}
+{%- endfor -%}

--- a/src/index.njk
+++ b/src/index.njk
@@ -131,7 +131,44 @@ hubspot:
             </div>
         </div>
     </div>
-
+    
+    <!-- Blueprints -->
+    <div class="max-w-md sm:max-w-xl md:max-w-screen-lg mx-auto mt-24 mb-20">
+        <h2 class="text-center w-full md:text-left"><span class="text-indigo-600">Drive industrial innovation</span> with Node-RED and FlowFuse</h2>
+        <p class="text-center w-full md:text-left">Create powerful industrial applications — from real-time monitoring to complex automation — all in one platform. Whether you're optimising production, tracking performance, or visualising data, FlowFuse makes it easy to turn ideas into reality. And to help you get started faster, explore our library of ready-made blueprints for quick, customisable solutions.</p>
+        <div class="container m-auto text-left max-w-sm md:max-w-none pt-8 w-full gap-4">
+            <ul class="flex flex-col sm:grid md:grid-cols-3 gap-x-6 gap-y-12">
+                {% set blueprintIds = ["d9yNg20jRw", "e85N3lmyX6", "6EbLVbLa9j"] %}
+                {%- for item in collections.blueprints | reverse -%}
+                    {% if item.data.blueprintId in blueprintIds %}
+                    <li class="flex flex-col h-full">
+                        <div class="mb-2">
+                            {%- for tag in item.data.tags -%}
+                            {% if tag !== "blueprints" %}
+                            <label class="text-gray-700 text-xs font-light rounded-sm bg-indigo-50 py-1.5 px-2 inline-block w-auto">{{ tag | replace('-', ' ') | replace('20', '2.0') | title }}</label>
+                            {% endif %}
+                            {%- endfor %}
+                        </div>
+                        <div class="grid bg-indigo-50 ff-image-cover blueprint rounded-lg border drop-shadow-md hover:drop-shadow-lg grow pb-4">
+                            <a href="{{ item.url }}" class="w-full flex flex-col group hover:no-underline">
+                                <div class="transition-transform group-hover:scale-105 ff-image-cover aspect-video border-b">
+                                    {% tileImage item, "./images/og-blog.jpg", "Image with logo and the slogan: Elevate Node-RED with Flowfuse", 285 %}
+                                </div>
+                                <div class="pt-4 my-auto">
+                                    <h5 class="my-auto group-hover:underline px-4 font-medium text-lg leading-6">{{ item.data.title }}</h5>
+                                </div>
+                            </a>
+                        </div>
+                    </li>
+                    {% endif %}
+                {%- endfor -%}
+            </ul>
+            <a href="/blueprints/" class="w-full text-right flex flex-row items-center justify-end self-end justify-self-end gap-1 mt-6">
+                See all
+                {% include "components/icons/arrow-long-right.svg" %}
+            </a>
+        </div>
+    </div>
     <!-- Testimonials -->
     <div class="w-full mt-24 md:px-0">
         <div class="sm:max-w-screen-lg mx-auto">

--- a/src/index.njk
+++ b/src/index.njk
@@ -138,30 +138,7 @@ hubspot:
         <p class="text-center w-full md:text-left">Create powerful industrial applications — from real-time monitoring to complex automation — all in one platform. Whether you're optimising production, tracking performance, or visualising data, FlowFuse makes it easy to turn ideas into reality. And to help you get started faster, explore our library of ready-made blueprints for quick, customisable solutions.</p>
         <div class="container m-auto text-left max-w-sm md:max-w-none pt-8 w-full gap-4">
             <ul class="flex flex-col sm:grid md:grid-cols-3 gap-x-6 gap-y-12">
-                {% set blueprintIds = ["d9yNg20jRw", "e85N3lmyX6", "6EbLVbLa9j"] %}
-                {%- for item in collections.blueprints | reverse -%}
-                    {% if item.data.blueprintId in blueprintIds %}
-                    <li class="flex flex-col h-full">
-                        <div class="mb-2">
-                            {%- for tag in item.data.tags -%}
-                            {% if tag !== "blueprints" %}
-                            <label class="text-gray-700 text-xs font-light rounded-sm bg-indigo-50 py-1.5 px-2 inline-block w-auto">{{ tag | replace('-', ' ') | replace('20', '2.0') | title }}</label>
-                            {% endif %}
-                            {%- endfor %}
-                        </div>
-                        <div class="grid bg-indigo-50 ff-image-cover blueprint rounded-lg border drop-shadow-md hover:drop-shadow-lg grow pb-4">
-                            <a href="{{ item.url }}" class="w-full flex flex-col group hover:no-underline">
-                                <div class="transition-transform group-hover:scale-105 ff-image-cover aspect-video border-b">
-                                    {% tileImage item, "./images/og-blog.jpg", "Image with logo and the slogan: Elevate Node-RED with Flowfuse", 285 %}
-                                </div>
-                                <div class="pt-4 my-auto">
-                                    <h5 class="my-auto group-hover:underline px-4 font-medium text-lg leading-6">{{ item.data.title }}</h5>
-                                </div>
-                            </a>
-                        </div>
-                    </li>
-                    {% endif %}
-                {%- endfor -%}
+                {% include "homepage_blueprints.njk" %}
             </ul>
             <a href="/blueprints/" class="w-full text-right flex flex-row items-center justify-end self-end justify-self-end gap-1 mt-6">
                 See all


### PR DESCRIPTION
## Description

The preview won't display the blueprint cards because it doesn't find the blueprints repo while building it.

Here's a screenshot of how it looks locally for reference:
<img width="1056" alt="Screenshot 2025-03-10 at 10 20 52" src="https://github.com/user-attachments/assets/eaf2e1ea-ce3f-4ddf-be54-7ba02b0629e4" />


## Related Issue(s)

https://github.com/FlowFuse/website/issues/2796

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
