### PR TITLE
Hannover page: Update tag

### DIFF
--- a/src/events/hannover-messe-2025.njk
+++ b/src/events/hannover-messe-2025.njk
@@ -2,7 +2,7 @@
 layout: layouts/base.njk
 image: /events/images/hm25/hm-25-hero.png
 tags:
-    - event
+    - trade-show
 meta:
     title: "FlowFuse at Hannover Messe 2025"
     description: "Visit us at Hall 15, Stand H71 and experience live demos, explore real-time data visualisations, and see how open source innovation is shaping the future of industrial operations."


### PR DESCRIPTION
## Description

The `event` tag is used for webinars and AMA sessions. Using it for trade shows implied they would be listed on the webinars page as well. This PR replaces it with the `trade-show` tag.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
