### PR TITLE
A number of grammar/typo fixes related to the PeopleOps section of the handbook

### DIFF
--- a/src/handbook/peopleops/code-of-conduct.md
+++ b/src/handbook/peopleops/code-of-conduct.md
@@ -4,7 +4,7 @@ navTitle: Code of Conduct
 
 # Code of Conduct
 
-The primary goal of our Code of Conduct is to foster inclusive, collaborative
+The primary goal of our Code of Conduct is to foster inclusive, collaborative,
 and safe working conditions for all FlowFuse staff and community members who
 participate in our open core projects.
 

--- a/src/handbook/peopleops/code-of-conduct.md
+++ b/src/handbook/peopleops/code-of-conduct.md
@@ -18,7 +18,7 @@ well as the consequences for unacceptable behavior.
 ## Scope 
 
 The Code of Conduct applies to all FlowFuse staff. This includes full-time,
-part-time and contractor staff employed at every seniority level. It also applies
+part-time, and contractor staff employed at every seniority level. It also applies
 to contributors who engage with our open core projects.
 
 The Code of Conduct is to be upheld during all professional functions and events,

--- a/src/handbook/peopleops/compensation.md
+++ b/src/handbook/peopleops/compensation.md
@@ -41,10 +41,10 @@ FlowFuse can choose to increase compensation based on varying situations:
 
 ### Equity
 
-FlowFuse intents to offers equity for key roles. The level of stock compensation
+FlowFuse intends to offers equity for key roles. The level of stock compensation
 can vary based on when an employee joined, their performance, and the variables
 that decide salary. Equity is offered as stock options, which upon
-execution will be transformed in the underlying stock. Stock compensation are
+execution will be transformed in the underlying stock. Stock compensation is
 awarded on a 4 year vesting schedule with a 1 year cliff.
 
 Employees might be taxed personally when accepting or executing stock options.
@@ -52,7 +52,7 @@ FlowFuse does not provide any advice on financial decisions for employees. For
 FlowFuse employees the Fair Market Value of the underlying stock can be found
 in [this internal document](https://docs.google.com/document/d/1_DmqzQ5rmjYHlBvF5owJpj3JVR_BlJUg_S-pwfRtA5g).
 
-Equity is subject to board approval.
+Equity grants are subject to board approval.
 
 ### Benefits
 
@@ -73,7 +73,7 @@ account. You'll need to link your family, see also [their docs](https://support.
 
 ##### Launch Lunch
 
-A lunch is organized to celebrate every release, and team members participating in a social Zoom call are encouraged to order a meal. You can claim [expensed](./expenses) for the lunch, up to a maximum of $25, and all reimbursements must be processed through Deel.
+A lunch is organized to celebrate every release, and team members participating in a social Zoom call are encouraged to order a meal. You can [expense](./expenses) the lunch, up to a maximum of $25, and all reimbursements must be processed through Deel.
 
 ##### Dinner Bonus
 
@@ -88,7 +88,7 @@ added to the list, especially when you're considering a job offer at FlowFuse.
 
 ##### USA and Canada
 
-For employees located in the United States, FlowFuse offer basic health insurance coverage which includes dental and vision with 50% dependents coverage benefits through United Medical.
+For employees located in the United States, FlowFuse offer basic health insurance coverage which includes dental and vision with 50% dependent coverage benefits through United Medical.
 
 For employees located in the Canada, FlowFuse offer basic health insurance coverage which includes dental, vision, and health services via Sterling brokers/Manulife.  
 

--- a/src/handbook/peopleops/compensation.md
+++ b/src/handbook/peopleops/compensation.md
@@ -6,7 +6,7 @@ navTitle: Compensation
 
 FlowFuse provides a comprehensive compensation package with base salary, augmented
 depending on the role with stock options (equity), and/or performance bonus structure.
-FlowFUse aims to be competitive with similar companies. Factors like
+FlowFuse aims to be competitive with similar companies. Factors like
 company stage, market conditions, role, and level influence salary
 determination during the hiring process. FlowFuse typically pays in the local
 currency, unless there are explicit discussions stating otherwise, taking

--- a/src/handbook/peopleops/hiring.md
+++ b/src/handbook/peopleops/hiring.md
@@ -41,7 +41,7 @@ When conducting interviews to hire new team members, prioritize value-fit over c
 ### STAR interviews
 
 By utilizing [the STAR framework](https://www.themuse.com/advice/star-interview-method)
-andidates will be interviewed to share their past experiences. This approach enables us to assess their actions and achievements, aiming to predict their future performance.
+candidates will be interviewed to share their past experiences. This approach enables us to assess their actions and achievements, aiming to predict their future performance.
 
 For the interviewer a template is available with the [STAR questions](https://docs.google.com/document/d/1v6C1Tf6B-hDOlA9GhR44Y2ftDgiwx4x_twnuo_N4pZE){rel="nofollow"}
 to make a copy of.
@@ -77,12 +77,11 @@ During the onboarding process on our EOR provider platform, candidates must eith
 ## Onboarding
 
 Just before your first day of work at FlowFuse, you will receive an email requesting your GitHub username
-and preferred company email address. An issuewill be created on our [internal issue tracker][issue-tracker] with steps for you and
+and preferred company email address. An issue will be created on our [internal issue tracker](https://github.com/FlowFuse/admin/issues/new/choose){rel="nofollow"} with steps for you and
 the team to complete once you start.
 
 On the day you start, a message will be sent to your personal email address to grant you access to your FlowFuse email address.
 This process ensures that all new joiners receive access either on their first day or up to 24 hours before their official start date.
-
 
 Upon setting up your password, it is essential to [turn on the 2-Step Verification](https://support.google.com/accounts/answer/185839?hl=en&co=GENIE.Platform%3DDesktop). Failure to do so may result in being locked out of your account after a few days, requiring assistance from an admin to regain access.
 
@@ -90,7 +89,7 @@ Once your FlowFuse email is set up, you will have access to invitations to other
 
 On your first day, once your email and 1Password accounts are set up, it is important to prioritize
 gaining access to Slack, the FlowFuse GitHub organization, and completing your onboarding issue.
-Additionally, your manager will assign tasks for you to begin working on during your first week.
+Additionally, your manager will assign tasks for you to begin working on during your first week. Further details on Onboarding will be available in your Onboarding issue. 
 
 ## Greenhouse
 
@@ -98,7 +97,7 @@ Additionally, your manager will assign tasks for you to begin working on during 
 
 When opening a job post, you'll need a couple of things:
 
-1. A draft Job Description
+1. A draft Job Description.
 2. Verifying the availability of the approved role.
 3. Set up the role within Greenhouse. The CEO will provide support in case any custom alterations to the job post are required.
 
@@ -108,7 +107,7 @@ Once these elements are in place, the CEO will proceed to design a pipeline for 
 
 A pipeline needs to be designed, meaning; you'll need to define all stages of the hiring process.
 For each stage of the hiring pipeline scoresheets **must** be filled out. Each scorecard
-**must** include all values, and job requirements.
+**must** include all values and job requirements.
 
 #### Accepting applications
 
@@ -142,7 +141,7 @@ During this call FlowFuse should understand:
 1. Compensation range for the candidate
 1. Notice period, or time from offer to start
 
-For all candidates that are moved on the next stage a scorecard needs to be filled out.
+For all candidates that are moved on the next stage, a scorecard needs to be filled out.
 
 After this stage **no more than 25%** of the total number of candidates should remain.
 
@@ -158,7 +157,7 @@ When in doubt, reject the candidate.
 #### STAR interview
 After the skills assessment, the last round includes a behaviour interview. STAR interviews are aimed at discussing the candidates past performance in certain situations, and hopefully predict the way they acted is in line with FlowFuse expectations.
 
-Again, a scoresheet will be filled out.
+Again, a scorecard will be filled out.
 
 #### Offer stage
 
@@ -173,14 +172,14 @@ Before the peopleops team extends an offer, explicit approval is required from:
 1. The new manager of the candidate
 1. CEO
 
-When a candidate accepted an offer, proceed to [onboard them](#after-an-offer-is-accepted).
+When a candidate accepts an offer, proceed to [onboard them](#after-an-offer-is-accepted).
 
 ### Closing a job
 
 As soon as there's a pipeline that would support at least three strong candidates
 for the open position, take the job posting offline. Candidates applying for a job
-that's no longer available is a waste of their time and a bad experience with
-FlowFuse and hurts our reputation.
+that's no longer available is a waste of their time, a bad experience with
+FlowFuse, and hurts our reputation.
 
 ## Offboarding
 
@@ -190,7 +189,7 @@ When a team member or contractor decides to leave FlowFuse, they will receive a 
 
 ### Voluntary Resignation
 
-If a team member decides to leave FlowFuse they're expected to continue working to facilitate a smooth handover and enable us to find a suitable replacement. Please note that we generally expect the team member to work for the entire notice period.
+If a team member decides to leave FlowFuse, they're expected to continue working to facilitate a smooth handover and enable us to find a suitable replacement. Please note that we generally expect the team member to work for the entire notice period.
 
 If you are considering resigning from your position at FlowFuse, we highly recommend discussing your reasons with your manager or the People Ops manager. We are always open to improving and making changes that benefit our team members. While we understand that sometimes leaving is the best option, we encourage you to explore all possible solutions before making a final decision.
 
@@ -202,7 +201,7 @@ When a team member is being let go, it is usually due to either performance issu
 
 ### Communicating Departures
 
-When a team member voluntarily departs, we may ask if they would like to share their plans with the team. If the departure is involuntary,  reasons of the departure will be at the sole discretion of the FlowFuse management.
+When a team member voluntarily departs, we may ask if they would like to share their plans with the team. If the departure is involuntary, reasons of the departure will be at the sole discretion of the FlowFuse management.
 
 ## Offboarding process
 

--- a/src/handbook/peopleops/index.md
+++ b/src/handbook/peopleops/index.md
@@ -11,7 +11,7 @@ People operations contains information on HR related policies at FlowFuse.
 - [Compensation](./compensation.md)
 - [Expenses](./expenses.md)
 - [Hiring](./hiring.md)
-- [Organization](./organization.md)
+- [PeopleOps Policies](./organization.md)
 - [Vacation & Leave](./leave.md)
 - [Summits](./summit.md)
 

--- a/src/handbook/peopleops/leave.md
+++ b/src/handbook/peopleops/leave.md
@@ -30,7 +30,7 @@ will have the aforementioned 25 days instead.
 
 ## Sick leave
 
-Sick leave, or having limited availability is not recorded currently. Keep your
+Sick leave, or having limited availability, is not recorded currently. Keep your
 manager updated on your health, and let them know what FlowFuse can do for you
 to aid in your recovery.
 
@@ -46,7 +46,7 @@ Any employee can take up to 6-weeks if they wish without requiring manager
 approval. We recommend a minimum of 4 weeks, but recognise it's a personal
 choice to make. Further leave can be requested, but should be discussed with
 your manager. Inform your manager of the expected new family member at least 16
-weeks before the due date to qualify to the extended parental leave.
+weeks before the due date to qualify for the extended parental leave.
 
 If you live in a country that offers statutory leave longer than this, then
 FlowFuse will abide by this.
@@ -55,6 +55,6 @@ FlowFuse will abide by this.
 
 Our company understands the profound impact that the loss of a loved one can
 have on an employee, and we are committed to supporting our team members
-during these difficult times. Therefore, FlowFuse has a bereavement leave policy.
+during difficult times. Therefore, FlowFuse has a bereavement leave policy.
 Employees who experience the death of an immediate family member, such as a spouse,
 child, parent, or sibling, are eligible for up to five consecutive days of paid leave.

--- a/src/handbook/peopleops/organization.md
+++ b/src/handbook/peopleops/organization.md
@@ -1,14 +1,14 @@
 ---
-navTitle: HR Policies
+navTitle: PeopleOps Policies
 ---
 
 # PeopleOps policies
 
-All employees at FlowFuse will find HR policies in this section of the handbook. Please note that this section of the handbook will be continuously updated to reflect the evolving needs of our organization. As FlowFuse is actively in the process of developing and incorporating additional policies, we encourage you to check back regularly for the latest updates. Your familiarity with these policies ensures that you stay informed and aligned with our company's values and practices.
+All employees at FlowFuse will find PeopleOps policies in this section of the handbook. Please note that this section of the handbook will be continuously updated to reflect the evolving needs of our organization. As FlowFuse is actively in the process of developing and incorporating additional policies, we encourage you to check back regularly for the latest updates. Your familiarity with these policies ensures that you stay informed and aligned with our company's values and practices.
 
 ## Grievance Procedure
 
-We're all about making FlowFuse an great place to work for everyone, however if you ever run into any concerns while you're here, these guidelines are here to help you out in raising a grievance. 
+We're all about making FlowFuse an great place to work for everyone. However, if you ever run into any concerns while you're here, these guidelines are here to help you out in raising a grievance. 
 
 This procedure applies to all employees and full-time contractors regardless of length of service. It does not apply to ad-hoc freelancers.
 

--- a/src/handbook/peopleops/performance-review.md
+++ b/src/handbook/peopleops/performance-review.md
@@ -7,10 +7,10 @@ navTitle: Performance review
 In September a performance review is done for all employees. The performance
 review is based on [our values](../company/values) and meeting role
 expectations. A review is held by the direct manager of each employeee. The
-manager will write down their expectations, where these were met and where the
+manager will write down their expectations, where these were met, and where the
 employee can still grow. This text is shared with each individual employee.
 
-While this performance review is written down, each manager should've communicated
+While this performance review is written down, each manager should be communicating
 feedback regularly to minimize the chance for surprises during the written review.
 
 ## Structure
@@ -29,11 +29,11 @@ Each of the Company Values will be rated as one of the following:
 - **Room for Growth:** This is an area where the employee could improve.
 
 Details and examples should be provided with each instance. It is also important that employees are not disheartened
-if given "Room for Growth" feedback, in fact, managers are encouraged to assign this rating to at least one of the
+if given "Room for Growth" feedback. In fact, managers are encouraged to assign this rating to at least one of the
 company values, although this should not be forced.
 
 It is almost impossible to achieve/exceed all values perfectly, sometimes particular employees are more focus on
-customer/community engagement, others may be more focussed on specific technical requirements. This is normal and should be embraced.
+customer/community engagement, others may be more focused on specific technical requirements. This is normal and should be embraced.
 
 ### Highlights
 
@@ -45,11 +45,11 @@ on the positive aspects of the employee's work, great contributions made and the
 
 As per the ["Compensation"](../peopleops/compensation) section of the Handbook, FlowFuse can opt to adjust your compensation
 at the same time your performance reviews are delivered. Please see the ["Adjustments"](../peopleops/compensation#adjustment)
-section for more details on the factor of these changes.
+section for more details on the factors driving those changes.
 
 This section of the review should clearly state the Employee's existing compensation, the change (if any) to that compensation, and the net
 salary after the change.
 
 ### Notes
 
-This section should be used to capture employee thoughts and feedback, and any other topics that come up during the review.
+This section should be used to capture employee thoughts, feedback, and any other topics that come up during the review.


### PR DESCRIPTION
## Description

* Fixed some broken links
* Fixed typos and punctuation errors
* Standardized capitalization

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
