### PR TITLE
Homepage: Update blueprints

### DIFF
--- a/src/_includes/homepage_blueprints.njk
+++ b/src/_includes/homepage_blueprints.njk
@@ -1,4 +1,4 @@
-{% set blueprintIds = ["d9yNg20jRw", "e85N3lmyX6", "6EbLVbLa9j"] %}
+{% set blueprintIds = ["KoV08ENaBx", "e85N3lmyX6", "x5pLEb06ed"] %}
 {%- for item in collections.blueprints | reverse -%}
     {% if item.data.blueprintId in blueprintIds %}
     <li class="flex flex-col h-full">


### PR DESCRIPTION
## Description

This PR replaces the `Crud Mongodb api` and `historical data dashboard with influxdb` blueprints with `OEE Dashboard` and `Andon Task` on the homepage.

<img width="1081" alt="Screenshot 2025-03-26 at 18 05 26" src="https://github.com/user-attachments/assets/0ba23862-69da-4546-8399-bbc03a30dd7f" />


## Related Issue(s)

https://github.com/FlowFuse/website/issues/3074

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
