### PR TITLE
board meetings: Update to new process

### DIFF
--- a/src/handbook/company/board.md
+++ b/src/handbook/company/board.md
@@ -12,7 +12,7 @@ To balance the high cadence, board meetings are only scheduled for an hour.
 The 60 minutes of each meeting are structured in the following time blocks:
 
 * 10 minutes Metrics and Company Performance - The company presents key metrics, comparing against the plan and updates projections. The figures will be distributed well in advance, and as such the discussion should be focussed on the reflections of the numbers.
-* 40 minutes Strategic Dicussion - A comprehensive pre-read document is distributed to all board members and designated observers a week prior to the meeting. This pre-read is mandatory, ensuring that all participants arrive prepared to engage in a productive, informed discussion.
+* 40 minutes Strategic Discussion - A comprehensive pre-read document is distributed to all board members and designated observers a week prior to the meeting. This pre-read is mandatory, ensuring that all participants arrive prepared to engage in a productive, informed discussion.
 * 10 minutes "Any other business" - Providing an open forum for board members and observers to raise additional topics, propose motions, or conduct votes, such as those related to stock options or other pertinent matters. It would be highly appreciated if topics to be discussed are shared in advance with the rest of the board.
 
 ### Post meeting action items

--- a/src/handbook/company/board.md
+++ b/src/handbook/company/board.md
@@ -1,21 +1,25 @@
 ---
 navTitle: Board
 ---
-# Board of Directors
 
 ## Board meetings
 
-### Preparation
+Scheduled over a month in advance, these meetings occur roughly every six weeks, reflecting a cadence designed for focused, high-impact engagement.
+To balance the high cadence, board meetings are only scheduled for an hour.
 
-One week after the last board meeting
+### Structure
 
-1. Set up the next meeting
-   - Invite all current board members
-   - Invite counsel to keep minutes and advise during the meeting
-1. Request minutes of past meeting and circulate the minutes to attendees
+The 60 minutes of each meeting are structured in the following time blocks:
 
-Two weeks before the next board meeting
+* 10 minutes Metrics and Company Performance - The company presents key metrics, comparing against the plan and updates projections. The figures will be distributed well in advance, and as such the discussion should be focussed on the reflections of the numbers.
+* 40 minutes Strategic Dicussion - A comprehensive pre-read document is distributed to all board members and designated observers a week prior to the meeting. This pre-read is mandatory, ensuring that all participants arrive prepared to engage in a productive, informed discussion.
+* 10 minutes "Any other business" - Providing an open forum for board members and observers to raise additional topics, propose motions, or conduct votes, such as those related to stock options or other pertinent matters. It would be highly appreciated if topics to be discussed are shared in advance with the rest of the board.
 
-1. Set the strategic topics to discuss. Propose 3 topics to attendees and ask them to pick two
-1. Set agenda structure and send the concept agenda to attendees
+### Post meeting action items
 
+Within a week after the board meeting, the CEO will distribute assets related to the board meeting.
+
+Assets will always include:
+1. The final board deck with metrics
+2. The updated pre-read for the Strategic Discussion
+3. List of action items


### PR DESCRIPTION
Changing the board meetings up slightly, with the intent to not push folks through a board deck for the whole meeting, but stop sharing after 10 minutes.

That opens the floor up more for discussion.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [X] Documentation has been updated
