### PR TITLE
Remove KPI meeting from handbook

### DIFF
--- a/src/handbook/company/achieving-success.md
+++ b/src/handbook/company/achieving-success.md
@@ -39,7 +39,7 @@ Given goals are intended to be bold and aggressive, performance on the OKRs has
 no influence on compensation or any other performance indicator of a department
 or individual.
 
-The current OKRs are documented [in this internal document](https://docs.google.com/document/d/1vtuOidsfSe4NQA9PKTlk898MJDNf8dcP2NPhSSqc84g/edit#){rel="nofollow"}.
+While we don't currently use OKRs as a management tool, when we did [OKRs used to be tracked in this internal doc](https://docs.google.com/document/d/12zOCFxot0rlRY-_hNwCmuv7_U1STqjzoaXh8EkIWtZI){rel="nofollow"}.
 
 ### Anatomy of an OKR
 
@@ -54,8 +54,3 @@ Head of Marketing, Head of UX, and product manager are expected to read the OKRs
 and work with their teams to develop at least 2 OKRs their team will implement to help achieve the company goal.
 
 At the start of the OKR period, each team will present their OKRs during a company meeting. Bi-weekly meetings will be held where each team will present a quick update on the status of their OKR and current work being done to achieve the key result. At the end of the OKR period, a company wide retrospective will he held to share lessons learned from the OKR.
-
-### Current OKRs
-
-[OKRs are tracked here](https://docs.google.com/document/d/12zOCFxot0rlRY-_hNwCmuv7_U1STqjzoaXh8EkIWtZI){rel="nofollow"}.
-Every two weeks updates are shared in the [Bi-weekly KPI meeting](./communication/#bi-weekly-kpi-meeting).

--- a/src/handbook/company/communication.md
+++ b/src/handbook/company/communication.md
@@ -164,13 +164,6 @@ other, and share things you want to share both professionally and personally.
 Personal updates don't have to be documented in the agenda, but please do keep a
 list of names in the agenda so everyone gets the opportunity to share.
 
-### Bi-weekly KPI meeting
-
-This 25-minute meeting is held to report on [key metrics](../company/achieving-success.md#kpi).
-Every department gets 5 minutes to explain what initiatives have been implemented
-over the past 2 weeks, what initiatives or milestones are scheduled for the next
-two weeks, and what results are expected to the company wide KPI.
-
 ## Feedback and Thanks
 
 In FlowFuse, we strongly encourage the sharing of feedback and thank you's. We have


### PR DESCRIPTION
## Description

Remove KPI meeting from handbook since this meeting isn't happening and call out that we're not doing OKRs right now

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
