### PR TITLE
Update communication page to reference company-wide announcements

### DIFF
--- a/src/handbook/company/communication.md
+++ b/src/handbook/company/communication.md
@@ -6,6 +6,13 @@ navTitle: Communications
 
 As a distributed company we should be mindful of how we communicate.
 
+## Company-wide announcements
+
+Company-wide announcements are made in the #announcements channel in Slack. All team
+members are expected to follow all announcements made in this channel. Depending on the 
+kind of announcment, it will be accompanied with a video recording by the person making 
+the announcement and a link to the PR where the change was made. 
+
 ## Date and time
 
 ### Use UTC for times


### PR DESCRIPTION
## Description

Add a call out that company-wide announcements goes to #announcements and will link to the PR + video where relevant


## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
