### PR TITLE
copy: Transition to US english

### DIFF
--- a/src/handbook/customer/marketing/website.md
+++ b/src/handbook/customer/marketing/website.md
@@ -4,7 +4,7 @@ navTitle: Marketing - Website
 
 # Marketing Website
 
-- All written content should be in UK English.
+- All written content should be in US English.
 - All page titles should summarise the content, keep the URL length as short as practical and use [Kebab Case](https://en.wiktionary.org/wiki/kebab_case).
 - All images should use informative [alt tags](https://www.w3.org/WAI/tutorials/images/tips/) which clearly describe the point of an image rather than all the details. Alt tags should be no longer than 60 characters.
 - When mentioning [FlowFuse Concepts](/docs/user/concepts/) (terminology) where possible we should link to an explanation of that concept.


### PR DESCRIPTION
We now adopt US English over UK English because it is understood by a larger global audience due to the United States' significant influence. Furthermore, key international business sectors like technology and entertainment predominantly use US English, and many global style guides lean towards its conventions, making it a more practical choice for broad communication.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [x] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
