### PR TITLE
ci: Send handbook updates to gh-handbook Slack channel

### DIFF
--- a/.github/workflows/handbook-changes-notify.yaml
+++ b/.github/workflows/handbook-changes-notify.yaml
@@ -41,7 +41,7 @@ jobs:
         token: ${{ secrets.SLACK_GHBOT_TOKEN }}
         payload: |
           {
-            "channel": "C03AP45RSFP",
+            "channel": "C02UNQAFZPV",
             "blocks": [
               {
                 "type": "header",


### PR DESCRIPTION
## Description

This pull request updates `Notify on Handbook Changes` workflow to send handbook notofications to `gh-handbook` Slack channel.

## Related Issue(s)

Closes https://github.com/FlowFuse/website/issues/3096

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
