### PR TITLE
Homepage: meta title and tagline fix

### DIFF
--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -9,9 +9,9 @@
         "d2fe": "https://boards.greenhouse.io/flowfuse/jobs/5185319004"
     },
     "messaging": {
-        "tagLine": "Unlock Industrial Data<br /> Integrate Everything<br />Optimize Faster",
-        "subtitle": "Quickly build workflows, applications and integrations that optimize your operations with our low-code, open-source, end to end platform.",
+        "tagLine": "Unlock Industrial Data <br />Integrate Everything <br />Optimize Faster",
         "title": "Build workflows and integrations that optimize your industrial operations",
+        "subtitle": "Quickly build workflows, applications and integrations that optimize your operations with our low-code, open-source, end to end platform.",
         "keywords": "Node-RED, Application Development, IoT, IIoT, Low-Code, open source, Integration, Workflow, Automation, Data Processing, Data Integration, Data Transformation, Data Visualization, Industrial Automation, Industrial IoT, Industry 4.0"
     }
 }

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -4,7 +4,7 @@ meta:
   type: page
   site:
     name: FlowFuse
-    description: {{ messaging.title }}
+    description: {{ messaging.subtitle }}
     url: https://FlowFuse.com
     logo:
       src: https://flowfuse.com/handbook/images/logos/ff-logo--square--dark.png
@@ -62,8 +62,8 @@ eleventyComputed:
     <title>{{ title }} &#x2022; FlowFuse{% if page.url and page.url.match('\/handbook\/.+') %} Handbook{% endif %}{% if page.url and page.url.match('\/docs\/.+') %} Docs{% endif %}</title>
     {% else %}
     {% set extractedTitle = content | extractH1Content %}
-    {% if extractedTitle %}
-    <title>{{ extractedTitle }} &#x2022; FlowFuse{% if page.url and page.url.match('\/handbook\/.+') %} Handbook{% endif %}{% if page.url and page.url.match('\/docs\/.+') %} Docs{% endif %}</title>
+    {% if extractedTitle and page.url != '/' %}
+        <title>{{ extractedTitle }} &#x2022; FlowFuse{% if page.url and page.url.match('\/handbook\/.+') %} Handbook{% endif %}{% if page.url and page.url.match('\/docs\/.+') %} Docs{% endif %}</title>
     {% else %}
     <title>FlowFuse &#x2022; {{ site.messaging.title }}</title>
     {% endif %}


### PR DESCRIPTION
## Description

On Google search, FlowFuse appears as:
<img width="684" alt="Screenshot 2025-04-16 at 13 24 38" src="https://github.com/user-attachments/assets/494086f3-0878-4309-bc65-be9b434db052" />

The same issue appears in the browser title for the homepage. This is incorrect—it should be `messaging.title` instead of `messaging.tagLine`. This PR addresses the issue and fixes the tagline spacing.

Also, the site description was the `messaging.title`, while the `messaging.subtitle` seems more suited for this field

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
