### PR TITLE
Homepage: tagline fix

### DIFF
--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -9,7 +9,7 @@
         "d2fe": "https://boards.greenhouse.io/flowfuse/jobs/5185319004"
     },
     "messaging": {
-        "tagLine": "Unlock Industrial Data<br /> Integrate Everything<br />Optimize Faster",
+        "tagLine": "Unlock Industrial Data. Integrate Everything. Optimize Faster.",
         "subtitle": "Quickly build workflows, applications and integrations that optimize your operations with our low-code, open-source, end to end platform.",
         "title": "Build workflows and integrations that optimize your industrial operations",
         "keywords": "Node-RED, Application Development, IoT, IIoT, Low-Code, open source, Integration, Workflow, Automation, Data Processing, Data Integration, Data Transformation, Data Visualization, Industrial Automation, Industrial IoT, Industry 4.0"

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -62,10 +62,10 @@ eleventyComputed:
     <title>{{ title }} &#x2022; FlowFuse{% if page.url and page.url.match('\/handbook\/.+') %} Handbook{% endif %}{% if page.url and page.url.match('\/docs\/.+') %} Docs{% endif %}</title>
     {% else %}
     {% set extractedTitle = content | extractH1Content %}
-    {% if extractedTitle %}
+    {% if extractedTitle and page.url != '/' %}
     <title>{{ extractedTitle }} &#x2022; FlowFuse{% if page.url and page.url.match('\/handbook\/.+') %} Handbook{% endif %}{% if page.url and page.url.match('\/docs\/.+') %} Docs{% endif %}</title>
     {% else %}
-    <title>FlowFuse &#x2022; {{ site.messaging.title }}</title>
+    <title>FlowFuse &#x2022; {{ site.messaging.tagLine }}</title>
     {% endif %}
     {% endif %}
 

--- a/src/index.njk
+++ b/src/index.njk
@@ -13,7 +13,7 @@ hubspot:
         <div class="container m-auto text-left max-w-screen-lg lg:flex lg:flex-row lg:items-start lg:justify-between lg:gap-6">
             <div class="max-w-xl mx-auto lg:mx-0 lg:my-auto lg:py-10 lg:max-w-[600px]">
                 <h1 class="font-medium leading-tight max-w-xl m-auto lg:m-0 text-center lg:text-left text-indigo-800 text-4xl">
-                    {{ site.messaging.tagLine | safe }}
+                    {{ site.messaging.tagLine | replace('. ', ' <br />') | replace('.', '') | safe }}
                 </h1>
                 <p class="mt-6 text-center lg:text-left">
                     {{ site.messaging.subtitle }}


### PR DESCRIPTION
## Description

On Google search, FlowFuse appears as:
![image](https://github.com/user-attachments/assets/bb65ee34-4f61-4d83-8e7b-67c98135bf4a)


The same issue appears in the browser title for the homepage, no dots and wrong spacing.

This PR fixes those issues.


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
