### PR TITLE
Adjust homepage title size for better responsiveness on small screens

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -12,7 +12,7 @@ hubspot:
     <div class="max-w-md sm:max-w-screen-lg mt-12 mx-auto">
         <div class="container m-auto text-left max-w-screen-lg lg:flex lg:flex-row lg:items-start lg:justify-between lg:gap-6">
             <div class="max-w-xl mx-auto lg:mx-0 lg:my-auto lg:py-10 lg:max-w-[600px]">
-                <h1 class="font-medium leading-tight max-w-xl m-auto lg:m-0 text-center lg:text-left text-indigo-800 text-4xl">
+                <h1 class="font-medium leading-tight max-w-xl m-auto lg:m-0 text-center lg:text-left text-indigo-800 text-3xl md:text-4xl">
                     {{ site.messaging.tagLine | replace('. ', ' <br />') | replace('.', '') | safe }}
                 </h1>
                 <p class="mt-6 text-center lg:text-left">


### PR DESCRIPTION
## Description

The title size was originally optimized for a shorter tagline. This PR adjusts the size to improve readability on smaller screens.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
