### PR TITLE
ci: Send hanbook notifications back to `gh-handbook`

### DIFF
--- a/.github/workflows/handbook-changes-notify.yaml
+++ b/.github/workflows/handbook-changes-notify.yaml
@@ -51,7 +51,7 @@ jobs:
           {
             "unfurl_links": true,
             "unfurl_media": true,
-            "channel": "C03AP45RSFP",
+            "channel": "C02UNQAFZPV",
             "blocks": [
               {
                 "type": "header",


### PR DESCRIPTION
## Description

Send hanbook notifications back to `gh-handbook` channel

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
