### PR TITLE
Adjust navbar for better responsiveness

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -182,7 +182,7 @@ eleventyComputed:
             {% include "../components/events-banner.njk" %}
             <!-- Navigation Header -->
             <header id="ff-header" class="ff-header">
-                <nav class="relative w-full flex items-center justify-between mx-auto container lg:max-w-screen-xl 2xl:max-w-[1920px]">
+                <nav class="relative w-full flex items-center justify-between mx-auto max-screen-none lg:max-w-screen-xl 2xl:max-w-[1920px]">
                     <a class="flex md:hidden lg:flex no-underline hover:no-underline font-bold h-8 w-40 flex-row"  href="/" style="font-family:'Baloo 2', sans-serif">
                         {% include "components/flowfuse-wordmark.njk" %}
                     </a>


### PR DESCRIPTION
## Description

Remove max-with for small screens.

Currently it's like this:
<img width="980" alt="Screenshot 2025-05-08 at 14 42 15" src="https://github.com/user-attachments/assets/260bdbaf-159a-458d-8d36-24a1c33414dc" />

And this PR adjusts it to be like this:
<img width="979" alt="Screenshot 2025-05-08 at 14 42 25" src="https://github.com/user-attachments/assets/f0d9423d-9bb5-4d5e-b433-a72f8ab09648" />


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
