### PR TITLE
Fix PostHog.register TypeError by ensuring execution after window load

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -469,15 +469,12 @@ eleventyComputed:
     /*
         Get User Agent String
     */
-    console.log(posthog);
-    
     window.addEventListener('load', () => {
         if (posthog && typeof posthog.register === 'function') {
             const phUA = {
                 "user_agent_string": window.navigator.userAgent
             };
             posthog.register(phUA);
-            console.log('PostHog.register called with:', phUA);
         } else {
             console.error('PostHog is not fully initialized.');
         }

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -387,7 +387,7 @@ eleventyComputed:
         console.log("No feature flags found - falling back to 'control' content")
     }
 
-    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
     let optOutByDefault = false;
 
     fetch('/country')
@@ -405,9 +405,10 @@ eleventyComputed:
             console.error('Initializing PostHog with opt_out_capturing_by_default set to true due to Fetch failed by:', error);
             optOutByDefault = true;
         })
+
         .finally(() => {
             posthog.init('{{ POSTHOG_APIKEY }}', {
-                api_host:'https://eu.posthog.com',
+                api_host: 'https://eu.i.posthog.com',
                 person_profiles: 'always',
                 bootstrap: phBootstrap,
                 capture_pageleave: false,
@@ -468,10 +469,19 @@ eleventyComputed:
     /*
         Get User Agent String
     */
-    const phUA = {
-        "user_agent_string": window.navigator.userAgent
-    }
-    posthog.register(phUA)
+    console.log(posthog);
+    
+    window.addEventListener('load', () => {
+        if (posthog && typeof posthog.register === 'function') {
+            const phUA = {
+                "user_agent_string": window.navigator.userAgent
+            };
+            posthog.register(phUA);
+            console.log('PostHog.register called with:', phUA);
+        } else {
+            console.error('PostHog is not fully initialized.');
+        }
+    });
 
     function capture (eventName, props) {
         if (posthog) {


### PR DESCRIPTION
## Description

This PR fixes an issue where `posthog.register` was not recognized as a function. The solution ensures that the code runs only after the window load event, guaranteeing that all resources, including the PostHog library, are fully initialized.

This also updates the PostHog snippet to [its most recent version](https://posthog.com/docs/getting-started/install).

This solution can only be tested locally, you need to remove the `{%- if not DEV_MODE -%}` condition that wraps the last block in the file `base.njk`

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
