### PR TITLE
Gracefully handle any hubspot form loading error and present an error message

### DIFF
--- a/src/_includes/hubspot/hs-form.njk
+++ b/src/_includes/hubspot/hs-form.njk
@@ -11,5 +11,23 @@
             }
         });
     }
+    function fallback() {
+        const targetScript = [...document.scripts].find(
+            s => s.src === 'https://js-eu1.hsforms.net/forms/embed/v2.js' || s.src === 'http://js-eu1.hsforms.net/forms/embed/v2.js'
+        );
+
+        if (targetScript && targetScript.parentNode) {
+            const errorSection = document.createElement('section');
+            errorSection.classList.add('text-center', 'border', 'border-indigo-300', 'rounded-lg', 'bg-white');
+            errorSection.innerHTML = `
+                <p class="text-indigo-500"><strong>Hmm… there was supposed to be a form here.</strong></p>
+                <p>
+                    If you’re using strict privacy settings or navigating in private mode, it might be blocked.
+                    Try adjusting your settings or switching browsers to continue.
+                </p>
+            `;
+            targetScript.parentNode.insertBefore(errorSection, targetScript.nextSibling);
+        }
+    }
 </script>
-<script async type="text/javascript" charset="utf-8" src="//js-eu1.hsforms.net/forms/embed/v2.js" onload="displayHubSpotForm()"></script>
+<script async type="text/javascript" charset="utf-8" src="//js-eu1.hsforms.net/forms/embed/v2.js" onload="displayHubSpotForm()" onerror="fallback();"></script>


### PR DESCRIPTION
## Description

Handles any possible contact us hs form load errors by displaying an user friendly message

## Related Issue(s)

part of https://github.com/FlowFuse/website/issues/3232#issuecomment-2865552859

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
