### PR TITLE
Add details on change control processes we have

### DIFF
--- a/src/handbook/development/releases/process.md
+++ b/src/handbook/development/releases/process.md
@@ -175,8 +175,8 @@ must be done manually.
    to update the version and `CHANGELOG.md` file with suitable details.
  - Create the GitHub release with the appropriate `vX.Y.Z` tag.
 
-Finally, create two change request issues in the CloudProject repo, one for staging and
-one for production to upgrade to the latest version.
+Finally, create two [change requests](/handbook/operations/change/), one for
+staging and one for production to upgrade to the latest version.
 
 ### Unmanaged Releases
 

--- a/src/handbook/operations/change.md
+++ b/src/handbook/operations/change.md
@@ -24,6 +24,8 @@ and provide all of the necessary details to enact the change and to verify the c
 
 Where access is required to a system, a `Access / Permission Request` issue should be created in the [admin repository](https://github.com/FlowFuse/admin/issues/new?template=access-request.md).
 
+Note: when onboarding/offboarding a new employee, this is managed via the Onboarding/Offboarding change request.
+
 # New GitHub Repository
 
 If a new repository is required within our GitHub organisation, a `New Repository Checklist` issue should be created in the [admin repository](https://github.com/FlowFuse/admin/issues/new?template=new-repo.md).

--- a/src/handbook/operations/change.md
+++ b/src/handbook/operations/change.md
@@ -1,6 +1,10 @@
 ---
-navTitle: FlowFuse Cloud Change Control
+navTitle: Change Control
 ---
+
+As part of our [secure operations policies](https://flowfuse.com/handbook/company/security/) we implement a Change Control process for certain operations in order to provide auditable, reviewable changes to key systems.
+
+The following tasks should be completed under change control.
 
 # FlowFuse Cloud Change Control
 
@@ -11,7 +15,20 @@ The issues should record the nature of the change required, which environment it
 and provide all of the necessary details to enact the change and to verify the change was successful.
 
 1. Create a Change Request issue on the [CloudProject repository](https://github.com/FlowFuse/CloudProject/issues/new?assignees=&labels=change-request&template=change-request.yml&title=Change%3A+){rel="nofollow"}.
-2. Obtain a review and approval to make the change from Engineering leadership - this should be done as a comment on the issue.
+2. Obtain a review and approval to make the change from Engineering leadership
 3. Assign the issue to the person making the change.
 4. Once the change has been applied, verify the change is complete
 5. Close the issue once verified
+
+# Access / Permission Request
+
+Where access is required to a system, a `Access / Permission Request` issue should be created in the [admin repository](https://github.com/FlowFuse/admin/issues/new?template=access-request.md).
+
+# New GitHub Repository
+
+If a new repository is required within our GitHub organisation, a `New Repository Checklist` issue should be created in the [admin repository](https://github.com/FlowFuse/admin/issues/new?template=new-repo.md).
+
+# Onboarding/Offboarding
+
+When bringing a new employee into the company, or saying goodbye to an existing one, the appropriate `Onboarding` or `Offboarding` issue should be created in the [admin repository](https://github.com/FlowFuse/admin/issues/new/choose)
+


### PR DESCRIPTION
Adds a central summary of the change control processes we have.

They are already linked to in-context of other parts of the handbook, but this overview summaries them all and hopefully makes them more discoverable.