### PR TITLE
Preserve URL hash when updating query parameters

### DIFF
--- a/src/pricing/index.njk
+++ b/src/pricing/index.njk
@@ -447,7 +447,8 @@ hubspot:
 
         // Update the history
         let paramString = urlParams.toString();
-        window.history.replaceState({}, '', paramString ? "?" + paramString : window.location.pathname);
+        let currentHash = window.location.hash; // Preserve the current hash
+        window.history.replaceState({}, '', paramString ? "?" + paramString + currentHash : window.location.pathname + currentHash);
     }
 
     // Check the hosting parameter when the page loads


### PR DESCRIPTION
## Description

This PR ensures that the URL hash (e.g., #feature-comparison-table) is preserved when updating query parameters using window.history.replaceState. Previously, the hash was lost, causing navigation issues. The solution appends the current hash to the updated URL, maintaining proper functionality for anchor links.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
