### PR TITLE
Make the blog search bar full width

### DIFF
--- a/src/_includes/blog/template.njk
+++ b/src/_includes/blog/template.njk
@@ -1,9 +1,9 @@
 <div class="ff-blog container m-auto text-left max-w-4xl pt-8 pb-24 w-full">
     <div class="px-2 flex items-center gap-12">
         <h1 class="mb-0">Blog</h1>
-        <div class="w-full px-2 my-4 grid">
-            <div id="algolia-search" class="border rounded w-full md:w-1/2 justify-self-end"></div>
-        </div>
+    </div>
+    <div class="w-full px-2 my-4 grid">
+        <div id="algolia-search" class="border rounded w-full justify-self-end"></div>
     </div>
     <div class="px-2 my-4 flex flex-wrap flex-row gap-4 md:justify-between">
         {%- for tag in blogTags -%}

--- a/src/css/algolia-theme.css
+++ b/src/css/algolia-theme.css
@@ -65,6 +65,9 @@
 
 .aa-Panel .aa-ItemContent .aa-ItemContentBody {
     grid-column: span 4;
+    align-self: stretch;
+    display: flex;
+    flex-direction: column;
 }
 
 


### PR DESCRIPTION
## Description

Made the Blog page search bar full width.

before:
![image](https://github.com/user-attachments/assets/81cd0b8f-e70c-4197-aed8-0d2226af22fc)

After:
![image](https://github.com/user-attachments/assets/d46b3fa2-a7aa-43ab-b92b-6d9066057add)


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
