### PR TITLE
Make the documentation's pages search bar full width

### DIFF
--- a/src/_includes/layouts/documentation.njk
+++ b/src/_includes/layouts/documentation.njk
@@ -12,8 +12,8 @@ date: git Last Modified
     <div class="px-10 pt-8">
         <!-- Breadcrumbs - Desktop -->
         <div class="w-full">
-            <div class="font-medium border-b pb-1 flex flex-col md:flex-row md:items-end">
-                <div class="md:flex-1 ">
+            <div class="font-medium border-b pb-1 flex flex-col gap-1">
+                <div class="md:flex-1">
                     {% if version %}
                     v{{ version }}
                     {% endif %}
@@ -21,7 +21,7 @@ date: git Last Modified
                     {{ page.url | handbookBreadcrumbs | safe }}
                     {% endif %}
                 </div>
-                <div class="w-full xl:max-w-[30%] md:max-w-[50%] sm:w-full md:ml-auto mb-1 max-md:mt-3">
+                <div class="w-full mb-1">
                     <div id="algolia-search" class="border rounded"></div>
                 </div>
             </div>

--- a/src/css/algolia-theme.css
+++ b/src/css/algolia-theme.css
@@ -65,6 +65,9 @@
 
 .aa-Panel .aa-ItemContent .aa-ItemContentBody {
     grid-column: span 4;
+    align-self: stretch;
+    display: flex;
+    flex-direction: column;
 }
 
 


### PR DESCRIPTION
## Description

Makes the documentation search field full width

Before:
![image](https://github.com/user-attachments/assets/1b7bc7d5-073e-482a-b17f-ca0d9ca4270d)

After:
![image](https://github.com/user-attachments/assets/2758118d-f6a7-401b-8014-a00184ce0d60)


## Related Issue(s)

part of https://github.com/FlowFuse/website/issues/3185

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
