### PR TITLE
Make the support search bar full width

### DIFF
--- a/src/css/algolia-theme.css
+++ b/src/css/algolia-theme.css
@@ -65,6 +65,9 @@
 
 .aa-Panel .aa-ItemContent .aa-ItemContentBody {
     grid-column: span 4;
+    align-self: stretch;
+    display: flex;
+    flex-direction: column;
 }
 
 

--- a/src/support.njk
+++ b/src/support.njk
@@ -15,7 +15,7 @@ hubspot:
     <div class="text-center mb-8">
       <h4>Find answers<span class="text-indigo-600"> instantly</span></h4>
     </div>
-    <div class="max-w-lg m-auto px-6 md:px-0 md:mb-10">
+    <div class="max-w-screen-lg m-auto px-6 md:px-0 md:mb-10">
       <div id="algolia-search" class="border rounded"></div>
     </div>
     <div class="container m-auto max-w-screen-lg ">


### PR DESCRIPTION
## Description

Makes the support search field full width

before:
![image](https://github.com/user-attachments/assets/2fc47a42-d8bb-4cf5-b1f9-31cf45313c66)

After:
![image](https://github.com/user-attachments/assets/327ea84f-42c9-427d-a033-fdfe860952de)


## Related Issue(s)

part of https://github.com/FlowFuse/website/issues/3185

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
