### PR TITLE
Customer stories: Add book a demo CTA

### DIFF
--- a/src/_includes/layouts/story.njk
+++ b/src/_includes/layouts/story.njk
@@ -82,7 +82,7 @@ layout: layouts/base.njk
                             </ul>
                             {% endif %}
                         </div>
-                        <div class="pt-3 pb-3">
+                        <div class="pt-3 pb-3 border-b">
                             <h3 class="text-base">Results</h3>
                             <ul class="list-disc pl-6">
                                 {% for result in story.results %}
@@ -92,6 +92,8 @@ layout: layouts/base.njk
                                 {% endfor %}
                             </ul>
                         </div>
+                        <a class="md:self-end ff-btn ff-btn--primary uppercase align-baseline w-full mt-3" href="/book-demo/"
+                        onclick="capture('cta-book-demo', {'reference': 'Customer Story: {{ title }}'})">BOOK A DEMO</a>
                     </div>
                     {% if hubspot.formId %}
                     <div class="flex flex-col mt-6 px-6">


### PR DESCRIPTION
## Description

This PR adds a “Book a demo” CTA to all customer stories. In our ad campaign, these stories are classified as assets for the “Interest” stage — where the goal is to deepen engagement and move qualified prospects closer to action.

After reading a success story, visitors are more likely to be motivated to explore how FlowFuse could work for them. Offering a direct path to book a demo provides a natural next step.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
