### PR TITLE
Add "Read more stories" section to customer story pagesAdd read more section to stories template

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -68,6 +68,14 @@ module.exports = function(eleventyConfig) {
         return null;
       });
 
+    eleventyConfig.addFilter("excludeCurrent", (items, currentUrl) => {
+        return items.filter(item => item.url !== currentUrl);
+    });
+
+      eleventyConfig.addFilter("shuffle", (array) => {
+        return array.sort(() => Math.random() - 0.5);
+    });
+
     // Add a global data variable for the current date
     eleventyConfig.addGlobalData("currentDateISO", new Date().toISOString());  
 

--- a/src/_includes/layouts/story.njk
+++ b/src/_includes/layouts/story.njk
@@ -22,7 +22,7 @@ layout: layouts/base.njk
                 {% include "components/icons/chevron-left.svg" %}
                 Back to Customer Stories
             </a>
-            <div class="ff-prose flex flex-col-reverse md:flex-row md:gap-8">
+            <div class="ff-prose flex flex-col-reverse md:flex-row md:gap-8 mb-6 border-b">
                 <div class="flex-grow">
                     <div class="prose">
                         <q class="py-6 md:pt-3 px-6 text-xl text-gray-600 italic font-bold w-full block">
@@ -105,6 +105,8 @@ layout: layouts/base.njk
                     {% endif %}
                 </div>
             </div>
+            <h3 class="mt-6 -mb-4 text-indigo-400">Read more stories</h3>
+            {% include "stories-block.njk" %}
         </div>
     </div>
 </div>

--- a/src/_includes/stories-block.njk
+++ b/src/_includes/stories-block.njk
@@ -1,7 +1,7 @@
 <ul class="w-full max-w-md md:max-w-none mx-auto flex flex-col md:grid md:grid-cols-3 gap-3 md:gap-x-4 pt-8">
     {% from "stories/customer-story.njk" import storyTile %}
-    
-    {%- for item in collections.stories | sort(attribute='item.date') | reverse | limit(3) -%}
-    {{ storyTile(title=item.data.title, url=item.url, brand=item.data.story.brand, logo=item.data.logo, image=item.data.image) }}
+
+    {%- for item in collections.stories | excludeCurrent(page.url) | shuffle | limit(3) -%}
+        {{ storyTile(title=item.data.title, url=item.url, brand=item.data.story.brand, logo=item.data.logo, image=item.data.image) }}
     {%- endfor -%}
 </ul>


### PR DESCRIPTION
## Description

This PR adds a “Read more stories” section at the end of each customer story page, displaying 3 randomly selected case studies. The goal is to encourage deeper engagement by helping readers discover additional success stories.

This change reinforces social proof and guides visitors toward further exploration.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
