### PR TITLE
Fix blueprints card image sizing

### DIFF
--- a/src/_includes/blueprints/blueprint-card.njk
+++ b/src/_includes/blueprints/blueprint-card.njk
@@ -9,7 +9,7 @@
     <div class="grid bg-white ff-image-cover blueprint rounded-lg border drop-shadow-md hover:drop-shadow-lg grow">
         <a href="{{ item.url }}" class="w-full flex flex-col group hover:no-underline">
             <div class="transition-transform group-hover:scale-105 ff-image-cover aspect-video border-b">
-                {% tileImage item, "./images/og-blog.jpg", "Image with logo and the slogan: Elevate Node-RED with Flowfuse", 285 %}
+                {% tileImage item, "./images/og-blog.jpg", null, "Image with logo and the slogan: Elevate Node-RED with Flowfuse", 380 %}
             </div>
             <h5 class="mt-4 mb-0 group-hover:underline px-4 font-medium text-lg leading-6">{{ item.data.title }}</h5>
             <p class="text-sm leading-normal font-light pt-1 mb-4 mt-3 px-4 text-gray-500">

--- a/src/_includes/homepage_blueprints.njk
+++ b/src/_includes/homepage_blueprints.njk
@@ -12,7 +12,7 @@
         <div class="grid bg-indigo-50 ff-image-cover blueprint rounded-lg border drop-shadow-md hover:drop-shadow-lg grow pb-4">
             <a href="{{ item.url }}" class="w-full flex flex-col group hover:no-underline">
                 <div class="transition-transform group-hover:scale-105 ff-image-cover aspect-video border-b">
-                    {% tileImage item, "./images/og-blog.jpg", "Image with logo and the slogan: Elevate Node-RED with Flowfuse", 285 %}
+                    {% tileImage item, "./images/og-blog.jpg", null, "Image with logo and the slogan: Elevate Node-RED with Flowfuse", 340 %}
                 </div>
                 <div class="pt-4 my-auto">
                     <h5 class="my-auto group-hover:underline px-4 font-medium text-lg leading-6">{{ item.data.title }}</h5>


### PR DESCRIPTION
## Description

This PR fixes the parameter order issue in the `tileImage` shortcode implementation. The `defaultImage` parameter was incorrectly used instead of `defaultDescription`, causing improper handling of the `imageSize` parameter. 

The changes ensure that `null` is explicitly passed for unused parameters to avoid misalignment.

Note: These changes will only take effect in production environments.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
