### PR TITLE
Add Roadmap section to company strategy page

### DIFF
--- a/src/handbook/product/strategy.md
+++ b/src/handbook/product/strategy.md
@@ -156,5 +156,13 @@ FlowFuse's commitment to a low-programming approach via Node-RED, complemented b
 
 - Manufacturing Widgets Extension for Dashboard 2.0. This extension should provide very classic manufacturing visualization, making it even easier to create Node-RED Dashboards for manufacturing.
 
+## Roadmap
+
+The company roadmap shows a high-level view of the features we are building to bring our company vision to fruition. Our roadmap provides transparency into our development priorities and helps align our team's efforts with our strategic objectives.
+
+You can view our current roadmap in the [12 Month Plan view](https://github.com/orgs/FlowFuse/projects/3/views/19) of our Product Planning project on GitHub.
+
+The roadmap may need to be adjusted over time as we pivot when we identify better ways to accomplish our company goals. This flexibility allows us to respond to market changes, customer feedback, and emerging opportunities while maintaining our focus on delivering maximum value to our customers.
+
 
 


### PR DESCRIPTION
## Summary
- Added new Roadmap section to the company strategy handbook page
- Explains the purpose of the roadmap as showing high-level features to achieve company vision
- Provides link to 12 Month Plan view in Product Planning GitHub project
- Includes note about roadmap flexibility for pivoting based on better approaches

## Test plan
- [ ] Review the updated strategy page content
- [ ] Verify the GitHub project link works correctly
- [ ] Ensure formatting and tone match existing handbook content

🤖 Generated with [Claude Code](https://claude.ai/code)