### PR TITLE
add support for lastUpdated metadata in blog posts, sitemap

### DIFF
--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -29,6 +29,10 @@
                 {% if subtitle %}
                     <h4>{{ subtitle | safe }}</h4>
                 {% endif %}
+                {%- set updatedDate = lastUpdated or date -%}
+                <p class="text-sm text-gray-400 font-normal mb-1">
+                    This post was last updated on <time value="{{ updatedDate | dateToRfc3339 }}">{{ updatedDate | shortDate }}</time>
+                </p>
             </div>
         </div>
     {% endif %}

--- a/src/sitemap.njk
+++ b/src/sitemap.njk
@@ -5,17 +5,17 @@ eleventyExcludeFromCollections: true
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 {%- for page in collections.all -%}
-    {%- if page.data.skipIndex != true %}
-    <url>
-        <loc>{{ page.url | url | toAbsoluteUrl }}</loc>
-        <lastmod>{{ page.date.toISOString() }}</lastmod>
-        <priority>{{ page.data.sitemapPriority | default(0.6) }}</priority>
-    </url>
-{%- endif %}
+  {%- if page.data.skipIndex != true %}
+  <url>
+    <loc>{{ page.url | url | toAbsoluteUrl }}</loc>
+    <lastmod>{{ (page.data.lastUpdated or page.date) | dateToRfc3339 }}</lastmod>
+    <priority>{{ page.data.sitemapPriority | default(0.6) }}</priority>
+  </url>
+  {%- endif %}
 {%- endfor %}
-    <url>
-        <loc>https://app.flowfuse.com/account/create/</loc>
-        <lastmod>{{ currentDateISO }}</lastmod>
-        <priority>0.9</priority>
-    </url>
+  <url>
+    <loc>https://app.flowfuse.com/account/create/</loc>
+    <lastmod>{{ currentDateISO }}</lastmod>
+    <priority>0.9</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

This pull request adds support for a `lastUpdated` field in blog post front matter. If present, this value will now be used to:

* Display a "Last updated on..." message in the blog post layout
* Set the `<lastmod>` value in the sitemap

If `lastUpdated` is not defined, the original `date` is used as a fallback for all two cases.

I first tried placing the last updated text below the published date, but it didn’t look good. So I moved it under the subtitle, like most websites do

<img width="1199" alt="Untitled 2" src="https://github.com/user-attachments/assets/bb7a8b15-2839-44c5-8f04-5545df116b2e" />

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
