### PR TITLE
Fix capitalization of 'Industrial Application Platform' in messaging

### DIFF
--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -8,7 +8,7 @@
     },
     "messaging": {
         "tagLine": "Unlock Industrial Data. Integrate Everything. Optimize Faster.",
-        "subtitle": "FlowFuse is the industrial application platform that empowers teams to build, deploy and manage applications that optimize industrial operations.",
+        "subtitle": "FlowFuse is the Industrial Application Platform that empowers teams to build, deploy and manage applications that optimize industrial operations.",
         "title": "Build workflows and integrations that optimize your industrial operations",
         "keywords": "Node-RED, Application Development, IoT, IIoT, Low-Code, open source, Integration, Workflow, Automation, Data Processing, Data Integration, Data Transformation, Data Visualization, Industrial Automation, Industrial IoT, Industry 4.0"
     }

--- a/src/handbook/marketing/messaging.md
+++ b/src/handbook/marketing/messaging.md
@@ -77,7 +77,7 @@ pure value of Node-RED) which can still be factored into the conversation.
 
 ## Messaging
 
-FlowFuse is the open-source Industrial application platform.
+FlowFuse is the open-source Industrial Application Platform.
 
 ### Tagline
 


### PR DESCRIPTION
## Summary
- Fixed capitalization of "industrial application platform" to "Industrial Application Platform" in site.json
- Updated messaging documentation to use consistent capitalization

## Test plan
- [ ] Verify homepage displays "Industrial Application Platform" with proper capitalization
- [ ] Confirm messaging documentation reflects the updated capitalization

🤖 Generated with [Claude Code](https://claude.ai/code)