### PR TITLE
Add reseller agreement section to partnerships handbook

### DIFF
--- a/src/handbook/sales/partnerships.md
+++ b/src/handbook/sales/partnerships.md
@@ -6,6 +6,12 @@ navTitle: Partnerships
 
 FlowFuse engages with both hardware parters and referral partners. Here are [our standard terms](https://docs.google.com/document/d/1BVls7LEC1CBQ6wlrb8GeWSYr2vj9fMqgdsWiWLoQZOY/edit#heading=h.gjdgxs).
 
+## Reseller Agreement
+
+For reseller partnerships, please refer to our [Reseller Agreement](https://docs.google.com/document/d/1uaRahdTSWYxMvejAXlg0FT-WYXXpcEEKKMPGDtrhf4g). Upon signing, partners will also receive access to our [Deal Registration Form](https://docs.google.com/document/d/16_ebDfXdC9tenUOhOA5-sTDnJBN2aqTZ4vmqmfJ7v9I) for opportunity tracking.
+
+## Partnership Requirements
+
 When there's interest in becoming a partner FlowFuse requires a project to colaborate on jointly.
 Implementation projects structure the partnership and learning on both sides.
 


### PR DESCRIPTION
## Summary
- Added reseller agreement link for partner documentation
- Added note about deal registration form being shared upon signing  
- Reorganized content with clear section headers for better structure

## Test plan
- [ ] Verify links are accessible to appropriate audiences
- [ ] Review formatting and content structure
- [ ] Confirm partnership workflow remains clear