### PR TITLE
Add bio property to Greg Stoutenburg's team profile

### DIFF
--- a/src/_data/team/greg-stoutenburg.json
+++ b/src/_data/team/greg-stoutenburg.json
@@ -7,7 +7,7 @@
     "country": "US",
     "email": "greg@flowfuse.com",
     "headshot": "greg.png",
-    "bio": "Greg is a Product-Led Growth Manager who focuses on building features that help FlowFuse accomplish its [mission](https://flowfuse.com/handbook/company/strategy/#flowfuse's-mission) and driving the self-service portion of the business by making FlowFuse easy to use, for all users.",
+    "bio": "Greg is a Product-Led Growth Manager who focuses on building features that help FlowFuse accomplish its mission and driving the self-service portion of the business by making FlowFuse easy to use, for all users.",
     "facts": [
         "Specialist in improving user onboarding and engagement",
         "Wide background includes a philosophy PhD and time at Stack Overflow",

--- a/src/_data/team/greg-stoutenburg.json
+++ b/src/_data/team/greg-stoutenburg.json
@@ -7,6 +7,7 @@
     "country": "US",
     "email": "greg@flowfuse.com",
     "headshot": "greg.png",
+    "bio": "Greg is a Product-Led Growth Manager who focuses on building features that help FlowFuse accomplish its [mission](https://flowfuse.com/handbook/company/strategy/#flowfuse's-mission) and driving the self-service portion of the business by making FlowFuse easy to use, for all users.",
     "facts": [
         "Specialist in improving user onboarding and engagement",
         "Wide background includes a philosophy PhD and time at Stack Overflow",


### PR DESCRIPTION
## Summary
• Added a bio property to Greg Stoutenburg's team JSON file
• Bio describes Greg's role as Product-Led Growth Manager and focus on FlowFuse's mission

## Test plan
• [x] Verify JSON syntax is valid
• [ ] Check that bio displays correctly on team page

🤖 Generated with [Claude Code](https://claude.ai/code)