### PR TITLE
Add FlowFuse Tables feature to pricing page

### DIFF
--- a/src/_data/pricingFeatures.yaml
+++ b/src/_data/pricingFeatures.yaml
@@ -142,6 +142,12 @@ sections:
         selfHostedValues: [ null, 'check' ]    
         tags: [ 'cloud', 'self-hosted' ]
         info: "<p>Monitoring of CPU and memory usage at the team level and instance level.</p>"
+      - id: tables
+        label: FlowFuse Tables
+        cloudValues: [ null, null, 'check' ]
+        selfHostedValues: [ null, 'check' ]    
+        tags: [ 'cloud', 'self-hosted' ]
+        info: "<p>Integrated database feature for storing, reading, writing, and querying data, within FlowFuse.</p>"
   - label: Secure
     rows:
       - id: audit-log


### PR DESCRIPTION
## Summary
- Add FlowFuse Tables as a new feature in the Scale section of the pricing table
- Feature is Enterprise-only (checkmarks only in Enterprise column)
- Added hover tooltip: "Integrated database feature for storing, reading, writing, and querying data, within FlowFuse."

## Test plan
- [x] Verify FlowFuse Tables appears in the Scale section at the bottom
- [x] Confirm feature shows checkmark only under Enterprise column (both Cloud and Self-hosted)
- [ ] Test hover functionality displays correct tooltip text
- [x] Check that feature appears on both Cloud and Self-hosted pricing tables

🤖 Generated with [Claude Code](https://claude.ai/code)