### PR TITLE
/pricing: Add additional instance cost

### DIFF
--- a/src/pricing/index.njk
+++ b/src/pricing/index.njk
@@ -80,7 +80,7 @@ hubspot:
                                     </ul>
                                     <span class="hidden md:inline"><br></span>
                                     <br>
-                                    <note class="font-semibold">Includes 1 hosted instance.
+                                    <note class="font-semibold">Includes 1 hosted instance. Additional instances are $20/month.
                                     </note>
                                 </div>
                             </div>
@@ -107,7 +107,7 @@ hubspot:
                                 onclick="capture('cta-join', {'position': 'primary'}, {'plan': 'cloud-starter'})">TRY FOR FREE</a>
                         </div>
                     </div>
-                    <!-- Team -->
+                    <!-- Pro -->
                     <div class="pricing-tile md:h-full">
                         {% macro team(cloud=true) %}
                         <div class="pricing-tile-background pb-6 md:grid md:grid-rows-[auto_1fr_minmax(36px,_36px)]">
@@ -134,7 +134,7 @@ hubspot:
                                     </ul>
                                     {% if cloud %}<span class="hidden md:inline"><br></span>{% endif %}
                                     <br>
-                                    <note class="font-semibold">Includes {% if cloud %}5{% else %}5{% endif %} hosted instances or remote instances.
+                                    <note class="font-semibold">Includes {% if cloud %}5{% else %}5{% endif %} hosted instances or remote instances. Additional instances start at $35/month.
                                     </note>
                                 </div>
                             </div>


### PR DESCRIPTION
## Description

This PR adds pricing details for additional instances to the Starter and Pro cards, with the latter covering both cloud and self-hosted.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
