### PR TITLE
Preserve uppercase acronyms in blueprint tags

### DIFF
--- a/src/_includes/blueprints/blueprint-card.njk
+++ b/src/_includes/blueprints/blueprint-card.njk
@@ -2,7 +2,13 @@
     <div class="mb-2">
         {%- for tag in item.data.tags -%}
         {% if tag !== "blueprints" %}
-        <label class="text-gray-700 text-xs font-light rounded-sm bg-indigo-50 py-1.5 px-2 inline-block w-auto">{{ tag | replace('-', ' ') | replace('20', '2.0') | title }}</label>
+        <label class="text-gray-700 text-xs font-light rounded-sm bg-indigo-50 py-1.5 px-2 inline-block w-auto">
+            {%- if tag == tag.toUpperCase() -%}
+                {{ tag }}
+            {%- else -%}
+                {{ tag | replace('-', ' ') | replace('20', '2.0') | title }}
+            {%- endif -%}
+        </label>
         {% endif %}
         {%- endfor %}
     </div>


### PR DESCRIPTION
## Description

Fixed the tag capitalization logic to preserve uppercase acronyms (e.g., MES, HMI) while properly formatting lowercase tags in blueprint cards.

For more details, see [GitHub issue #165](https://github.com/FlowFuse/blueprint-library/issues/165).


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
