### PR TITLE
ci: Bump calibreapp/image-actions to `1.3.0` version

### DIFF
--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -39,9 +39,9 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Compress Images
         id: calibre
-        uses: calibreapp/image-actions@006692e15ca7d6312e06cc49b57a466d8ed45848 # main
+        uses: calibreapp/image-actions@51921e25c9b0b62ed202c0ad0a2121f0f3ad186d # 1.3.0
         with:
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # For non-Pull Requests, run in compressOnly mode and we'll PR after.
           compressOnly: ${{ github.event_name != 'pull_request' }}
       - name: Create Pull Request


### PR DESCRIPTION
## Description

This pull request bumps the version of `calibreapp/image-actions` to `1.3.0`

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
