### PR TITLE
Update for Quote reference on PO

### DIFF
--- a/src/handbook/sales/engagements.md
+++ b/src/handbook/sales/engagements.md
@@ -89,6 +89,9 @@ evidenced by one of the following:
 - **Signed Company Quote**: A formal, written quotation provided by our company,
   which has been duly signed, indicating their acceptance of the terms and
   conditions outlined therein.
+- **Note**: In the event a customer does not return a signed Company Quote,
+  the PO must include the Company Quote Reference Number found in the upper
+  right corner of the Company Quote (e.g. Reference: 20250820-153746396)
 
 Important Note: Verbal agreements, informal emails, or other non-binding
 expressions of interest do not constitute a closed deal. The legal commitment,


### PR DESCRIPTION
Customer POs are often missing three important pieces of information we need for our subscriptions. 
1. Official start date for the subscription
2. Packaging/feature details within the FlowFuse platform
3. Prices for purchasing additional capacity within the term of the subscription. 

This information is always included in the Company Quote we send to the customer. By requiring the customer to add the quote reference number to their PO we ensure the information above is included in the sale.

## Description

<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
