### PR TITLE
Update release process following 2.21 release retro

### DIFF
--- a/src/handbook/development/releases/process.md
+++ b/src/handbook/development/releases/process.md
@@ -46,14 +46,14 @@ The Release Manager chooses when to start the release process. We usually aim to
 start the release process at 10am/11am (UK/CET) as that gets to the end of Phase
 Two before the team [Launch Lunch](#launch-lunch).
 
-A huddle should be started in the `#dev` channel at the start of the process to
+A huddle should be started in the `#dept-engineering` channel at the start of the process to
 enable others to contribute where needed.
 
 It is also useful for the wider team if the Release Manager posts status updates
-to `#dev` throughout the process.
+to `#dept-engineering` throughout the process.
 
 If at any point a team member identifies a problem that needs checking before the
-release can continue, they should post a message to `#dev` and join the huddle
+release can continue, they should post a message to `#dept-engineering` and join the huddle
 to ensure the Release Manage is aware.
 
 ### Phase One
@@ -149,7 +149,7 @@ Once everything has been published, the Release Manager should:
 3. Notify the CTO/Senior Engineer that the release is ready to publish to production.
 
 Once Production has been updated and verified, the Release Manager should announce
-the availability of the release in `#dev`. At this point, the marketing team
+the availability of the release in `#dept-engineering`. At this point, the marketing team
 will take over for Phase Four
 
 ### Phase Four
@@ -184,17 +184,21 @@ staging and one for production to upgrade to the latest version.
 The Unmanaged Repositories have a simpler release process. They are released
 as needed in coordination with the CTO/Senior Engineer.
 
-All release activity should be highlighted in #dev so the team is aware.
+All release activity should be highlighted in #dept-engineering so the team is aware.
 
 1. Check that all changes have been merged to main
 1. Update the `package.json` version number
-1. Run the `generate-changelog` script from `flowfuse/admin` repository. This
+1. `cd` into the directory of the package you want to release
+1. Run the `generate-changelog` script, found in the `flowfuse/admin` repository. Run this
+   whilst in the folder/repository that you are releasing. This
    generates a list of the PRs merged since the last tagged release. Note: this
    script require the `gh` cli to be installed and logged in.
    Update `CHANGELOG.md` with the output of the script.
+1. Run `npm install`
 1. Open a new PR with the `package.json` and `CHANGELOG.md` changes. Get the PR reviewed
    by someone else and then merged.
-1. Create a new GitHub Release with the appropriate version number eg `v0.1.1`.
+1. Create a new GitHub Release with the appropriate version number eg `v0.1.1`. It is
+   advised to use the "Generate Release Notes" option to create the release notes and title.
 1. Once the release is created, the GitHub Action will take care of publishing to
    NPM. Check the action to ensure it completes.
 
@@ -207,4 +211,4 @@ the release day. See also the [peopleops section](../../peopleops/compensation#l
 
 The day after each release, a one hour meeting is conducted which anyone from the company can join. The purpose of this meeting is to reflect on the past four weeks of development effort, the release process and any other thoughts or comments that can help us refine processes moving forward.
 
-In the retrospective, the CTO or Engineering Manager will also cover any new items that have been added to the [Development Board](../project-management#development-board) and any relevant plans for engineering resource to be assigned to that work.
+In the retrospective, the CTO or Engineering Manager will also cover any new items that have been added to the [Development Board](../project-management#dept-engineeringelopment-board) and any relevant plans for engineering resource to be assigned to that work.

--- a/src/handbook/development/releases/process.md
+++ b/src/handbook/development/releases/process.md
@@ -211,4 +211,4 @@ the release day. See also the [peopleops section](../../peopleops/compensation#l
 
 The day after each release, a one hour meeting is conducted which anyone from the company can join. The purpose of this meeting is to reflect on the past four weeks of development effort, the release process and any other thoughts or comments that can help us refine processes moving forward.
 
-In the retrospective, the CTO or Engineering Manager will also cover any new items that have been added to the [Development Board](../project-management#dept-engineeringelopment-board) and any relevant plans for engineering resource to be assigned to that work.
+In the retrospective, the CTO or Engineering Manager will also cover any new items that have been added to the [Development Board](../project-management#development-board) and any relevant plans for engineering resource to be assigned to that work.


### PR DESCRIPTION
## Description

- Replace `#dev` with `#dept-engineering`
- Add in step to ensure `cd` into working directory for unmanaged release
- Add the advisory to use the "General Release Notes" button

### Related Issues

https://github.com/FlowFuse/admin/issues/422