### PR TITLE
handbook: Stock compensation vesting schedule to 5 years

### DIFF
--- a/src/handbook/peopleops/compensation.md
+++ b/src/handbook/peopleops/compensation.md
@@ -59,7 +59,7 @@ FlowFuse intends to offers equity for key roles. The level of stock compensation
 can vary based on when an employee joined, their performance, and the variables
 that decide salary. Equity is offered as stock options, which upon
 execution will be transformed in the underlying stock. Stock compensation is
-awarded on a 5 year vesting schedule with a 1 year cliff.
+awarded on a 5-year monthly vesting schedule with a 1 year cliff.
 
 Employees might be taxed personally when accepting or executing stock options.
 FlowFuse does not provide any advice on financial decisions for employees. For

--- a/src/handbook/peopleops/compensation.md
+++ b/src/handbook/peopleops/compensation.md
@@ -59,7 +59,7 @@ FlowFuse intends to offers equity for key roles. The level of stock compensation
 can vary based on when an employee joined, their performance, and the variables
 that decide salary. Equity is offered as stock options, which upon
 execution will be transformed in the underlying stock. Stock compensation is
-awarded on a 4 year vesting schedule with a 1 year cliff.
+awarded on a 5 year vesting schedule with a 1 year cliff.
 
 Employees might be taxed personally when accepting or executing stock options.
 FlowFuse does not provide any advice on financial decisions for employees. For


### PR DESCRIPTION
As retention is high at FlowFuse, it's convenient for the company to update the vesting schedule to 60 months and increase the grant. This delays the need for refresh grants.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
