### PR TITLE
ci: run image compression against pull requests only

### DIFF
--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -1,19 +1,6 @@
-# Image Actions will run in the following scenarios:
-# - on Pull Requests containing images (not including forks)
-# - on pushing of images to `main` (for forks)
-# - on demand (https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/)
-# - at 11 PM every Sunday in anything gets missed with any of the above scenarios
-# For Pull Requests, the images are added to the PR.
-# For other scenarios, a new PR will be opened if any images are compressed.
 name: Compress images
 on:
   pull_request:
-    paths:
-      - '**.jpg'
-      - '**.jpeg'
-      - '**.png'
-      - '**.webp'
-  push:
     branches:
       - main
     paths:
@@ -21,19 +8,12 @@ on:
       - '**.jpeg'
       - '**.png'
       - '**.webp'
-  workflow_dispatch:
-  schedule:
-    - cron: '15 23 * * 0' # once a week on Sunday at 23:15
 
 jobs:
   build:
     name: calibreapp/image-actions
     runs-on: ubuntu-latest
-    # Only run on main repo on and PRs that match the main repo.
-    if: |
-      github.repository == 'FlowFuse/website' &&
-      (github.event_name != 'pull_request' ||
-       github.event.pull_request.head.repo.full_name == github.repository)
+    if: github.repository == 'FlowFuse/website' && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout Branch
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -45,14 +25,3 @@ jobs:
           # For non-Pull Requests, run in compressOnly mode and we'll PR after.
           compressOnly: ${{ github.event_name != 'pull_request' }}
           pngQuality: '80'
-      - name: Create Pull Request
-        # If it's not a Pull Request then commit any changes as a new PR.
-        if: |
-          github.event_name != 'pull_request' &&
-          steps.calibre.outputs.markdown != ''
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
-        with:
-          title: Auto Compress Images
-          branch-suffix: timestamp
-          commit-message: Compress Images
-          body: ${{ steps.calibre.outputs.markdown }}

--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -44,6 +44,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # For non-Pull Requests, run in compressOnly mode and we'll PR after.
           compressOnly: ${{ github.event_name != 'pull_request' }}
+          pngQuality: '80'
       - name: Create Pull Request
         # If it's not a Pull Request then commit any changes as a new PR.
         if: |


### PR DESCRIPTION
## Description

As per the discussion in [this issue](https://github.com/FlowFuse/website/pull/3742#issuecomment-3257838268), this pull request adjusts when the `Compress images` workflow is executed.
From now on, image compression happens on the pull requests only.
Addiotionally, as mentioned in the `calibreapp/compress-action` GH action [bug](https://github.com/calibreapp/image-actions/issues/349#issuecomment-3247316617), the PNG quality has set to `80`.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
