### PR TITLE
Handbook: Job Bands

### DIFF
--- a/src/handbook/peopleops/job-bands.md
+++ b/src/handbook/peopleops/job-bands.md
@@ -1,0 +1,34 @@
+---
+navTitle: Job Bands
+---
+
+# Job Bands
+
+At FlowFuse we follow a unified model across the organization to evaluate and track employee's growth and progress. When employees are hired, their role will align to a band level and will progress as they grow in the company. These bands will influence your **compensation packages**, responsibilities, and the expectations against which you are measured as part of your [performance reviews](./performance-review.md).
+
+An important factor at FlowFuse in this growth is that you don't need to progress into management just to get promotions. Whilst promotions can include a move into management, progression can also be achieved by increasing the scope of your role and through additional responsibilities and contributions, with promotions up the band levels reflecting that growth.
+
+## Tracks
+
+### Engineering & Product
+
+Engineering roles are grouped into two tracks:
+
+- **IC Track** - Individual Contributor Track
+- **EM Track** - Engineering Manager Track
+
+| Band | EM Track | IC Track |
+|------|----------|----------|
+| 14 | CEO |  |
+| 12 | CXO |  |
+| 11 | VP?? |  |
+| 10 | Director | Distinguished Engineer |
+| 9 | Senior Manager | Principal Engineer |
+| 8 | Manager | Staff Engineer<br>Senior Product Manager |
+| 7 |  | Senior Engineer<br>Product Manager |
+| 6 |  | Engineer |
+| 5 |  | Junior Engineer |
+| 4 |  | Intern |
+
+The "Engineer" roles could equally be referring to a "Software Engineer", "DevOps Engineer", "Data Engineer", etc. It should also be noted that the above table includes roles and bands we do not currently have, but this is designed for future growth and expansion of the company.
+


### PR DESCRIPTION
## Description

As discussed in 1:1, in an attempt to start formalising structure a little more, especially around pay structure, as well as the concept of seniority and ensuring that a "promotion" doesn't enforce a need to go into management, I've put together the following proposal for a banding structure. 

Inspired by:

- [GitLab Grades](https://handbook.gitlab.com/handbook/total-rewards/compensation/compensation-calculator/#job-grades)
- [IBM Bands](https://www.thesalarynegotiator.com/ibm-software-engineer-salary#:~:text=Salary%20Negotiation%20Coaching-,IBM%20Software%20Engineer%20Levels,-Understanding%20the%20IBM) 

Currently, this just covers the engineering org (and general c-suite), but would be easy enough to add in CS, marketing & Sales in their own tables.

Once agreed upon, existing employees will be made aware of their Band, in alignment with their current responsibilities and pay.