### PR TITLE
Fix Device Agent installer description in release 2.22 blog post

### DIFF
--- a/src/blog/2025/09/flowfuse-release-2-22.md
+++ b/src/blog/2025/09/flowfuse-release-2-22.md
@@ -68,7 +68,7 @@ We've added an new option so that a users SSO Group memberships can be included 
 
 ## Device Agent Installer handles Multiple Remote Instances
 
-We're continuing to work on making the process for installing the Device Agent as simple, easy, fast, and reliable as possible. With this release, the Device Agent Installer can install the Device Agent on multiple remote instances within the same operating system is now possible, by allowing you to install the Device Agent in a non-default directory and specify a non-default port. In addition, clearer installation summaries, documentation links, and improved installer output have improved the overall usability of the installer.
+We're continuing to work on making the process for installing the Device Agent as simple, easy, fast, and reliable as possible. With this release, the Device Agent Installer can install multiple Device Agents on a single remote device, by allowing you to install the Device Agent in a non-default directory and specify a non-default port. In addition, clearer installation summaries, documentation links, and improved installer output have improved the overall usability of the installer.
 
 ## Dashboard Fixes
 


### PR DESCRIPTION
## Summary
- Fixed confusing wording in the FlowFuse 2.22 release blog post about the Device Agent installer
- Clarified that the installer can install multiple Device Agents on a single remote device
- Improved readability and accuracy of the feature description

## Test plan
- [x] Review the corrected text for clarity and accuracy
- [x] Verify the change maintains the intended meaning while improving clarity

🤖 Generated with [Claude Code](https://claude.ai/code)