### PR TITLE
handbook: Allow sub-values to be linked elsewhere

### DIFF
--- a/src/handbook/company/values.md
+++ b/src/handbook/company/values.md
@@ -14,49 +14,49 @@ Our values are as follows:
 
 ## 📈 Results
 
-1. We value results over the hours you spend working. We appreciate the effort, but value the results. Make users happy, care about the team member you helped. You schedule your day to make the most out of it for you. Don’t brag about hours worked, take pride in your achievements.
+1. <a name="resultsoverhours">Results over Hours</a>: We value results over the hours you spend working. We appreciate the effort, but value the results. Make users happy, care about the team member you helped. You schedule your day to make the most out of it for you. Don't brag about hours worked, take pride in your achievements.
 1. <a name="doitnow">Do it now</a>: Growth is exponential; Ship today, observe first results tomorrow, observe compounding effects in just 2 days.
-1. Ownership: Take initiative, keep stakeholders in the loop, find and resolve bottlenecks. Collaborate with others. There’s one individual responsible for your achievements; You! Something is never "not my job". If you see an opportunity to drive something forward, do it.
+1. <a name="ownership">Ownership</a>: Take initiative, keep stakeholders in the loop, find and resolve bottlenecks. Collaborate with others. There's one individual responsible for your achievements; You! Something is never "not my job". If you see an opportunity to drive something forward, do it.
 1. <a name="disagreeandcommit">Disagree and commit</a>: Discussion is healthy, but decisions do not need full consensus. Disagree with a point-of-view, make your case, but accept other solutions are valid too. Once a choice is made, commit as a team to follow it. Allow others to prove themselves. Reaching consensus for every decision does not scale.
-1. Keep it short and simple: Don’t over-engineer your solution or let the scope creep beyond what makes sense for an iteration. Fast progress requires fast understanding. Boring solutions are good. Allow everyone to understand your solution. There will always be another iteration.
+1. <a name="keepitshortandsimple">Keep it short and simple</a>: Don't over-engineer your solution or let the scope creep beyond what makes sense for an iteration. Fast progress requires fast understanding. Boring solutions are good. Allow everyone to understand your solution. There will always be another iteration.
 
 ## 🔁 Iterative Improvement
 
-1. Small Steps: Every mountain can be climbed with small steps. Make a change,
+1. <a name="smallsteps">Small Steps</a>: Every mountain can be climbed with small steps. Make a change,
 reassess your direction, repeat. Scope down your work item, reflect, and scope
 it down again. Get the minimal amount of work down, but no less, find the [golden mean](https://en.wikipedia.org/wiki/Golden_mean_%28philosophy%29).
-1. Bias for Action: Don’t overthink, do what is the most natural in this moment. [Do it now](#doitnow).
-1. Accepting Change: Be eager to accept change: Is it better than yesterday, and can we improve on it tomorrow?
-1. Everything is a Draft: Today won’t be perfect, tomorrow will be better. Perfection is the death of progress.
-1. Decide where good is good enough; understand where excellence is our company's
+1. <a name="biasforaction">Bias for Action</a>: Don't overthink, do what is the most natural in this moment. [Do it now](#doitnow).
+1. <a name="acceptingchange">Accepting Change</a>: Be eager to accept change: Is it better than yesterday, and can we improve on it tomorrow?
+1. <a name="everythingisadraft">Everything is a Draft</a>: Today won't be perfect, tomorrow will be better. Perfection is the death of progress.
+1. <a name="decidewheregoodisgoodenough">Decide where good is good enough</a>; understand where excellence is our company's
 edge. Apply the [pareto principle](https://en.wikipedia.org/wiki/Pareto_principle).
 
 ## 👥 Collaborative Community
 
-1. Be inclusive: in a community everyone is different; allow them to be. We
+1. <a name="beinclusive">Be inclusive</a>: in a community everyone is different; allow them to be. We
 value empathy, courtesy, and respect for each other.
 1. [Information wants to be free](https://en.wikipedia.org/wiki/Information_wants_to_be_free):
 Store information in public places by default: our Handbook and GitHub issues.
 Allow others to understand you and your decisions.
-1. Write things down: information stuck in calls or private conversations is lost.
+1. <a name="writethingsdown">Write things down</a>: information stuck in calls or private conversations is lost.
 Allow progress being made by anyone. Keep an agenda for meetings, write down decisions.
-1. Think big picture: It’s not “your” issue/bug, the whole community can have
+1. <a name="thinkbigpicture">Think big picture</a>: It's not "your" issue/bug, the whole community can have
 opinions and provide suggestions.
 
 ## ⛑️ Constructive Candor
 
-1. Feedback aids growth: it reinforces what is good and helps drive improvement where needed.
-1. Be considerate: feedback is about helping others to improve, not scoring points. Use care and consideration of how it will be received.
-1. Provide timely feedback: it is better to address things when they are fresh in our minds and quicker to remedy.
-1. Assume positive intent when receiving feedback. When you feel defensive it’s OK to
+1. <a name="feedbackaidsgrowth">Feedback aids growth</a>: it reinforces what is good and helps drive improvement where needed.
+1. <a name="beconsiderate">Be considerate</a>: feedback is about helping others to improve, not scoring points. Use care and consideration of how it will be received.
+1. <a name="providetimelyfeedback">Provide timely feedback</a>: it is better to address things when they are fresh in our minds and quicker to remedy.
+1. <a name="assumepositiveintent">Assume positive intent</a> when receiving feedback. When you feel defensive it's OK to
  respond later.
 1. <a id="optimism">Be optimistic</a>, treat situations as if a positive outcome is always possible.
-1. Be open and honest about your own mistakes, take ownership of them and their resolve.
-1. Appreciate each other. Say thanks often, preferably in public.
+1. <a name="beopenandhonest">Be open and honest</a> about your own mistakes, take ownership of them and their resolve.
+1. <a name="appreciateeachother">Appreciate each other</a>. Say thanks often, preferably in public.
 
 ## 🤝 Customer Empathy
 
-1. Focus on the customer: We want them to be successful. Pay attention to competition, but put the customer first.
-1. Be curious, not judgemental: Understanding starts with asking questions. Aim to get a deep understanding of their desires and motivations.
-1. Listen to feedback and respond quickly and respectfully. Customers may be frustrated or potentially seem unreasonable - we are here to listen and help them move forward.  [Apply optimism](#optimism), and be friendly.
-1. Show empathy in all interactions and choices. Our solutions aim to solve customer problems effectively and efficiently.
+1. <a name="focusonthecustomer">Focus on the customer</a>: We want them to be successful. Pay attention to competition, but put the customer first.
+1. <a name="becuriousnotjudgemental">Be curious, not judgemental</a>: Understanding starts with asking questions. Aim to get a deep understanding of their desires and motivations.
+1. <a name="listentofeedback">Listen to feedback</a> and respond quickly and respectfully. Customers may be frustrated or potentially seem unreasonable - we are here to listen and help them move forward.  [Apply optimism](#optimism), and be friendly.
+1. <a name="showempathy">Show empathy</a> in all interactions and choices. Our solutions aim to solve customer problems effectively and efficiently.


### PR DESCRIPTION
When we reference _why_ we do things the way we do in the handbook, it would be convenient to just link to a sub-value. We had a couple linkable items already, this change allows everything to be linked.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
