### PR TITLE
Fix Co-Pilot capitalization to copilot in FlowFuse 2.22 release post

### DIFF
--- a/src/blog/2025/09/flowfuse-release-2-22.md
+++ b/src/blog/2025/09/flowfuse-release-2-22.md
@@ -1,7 +1,7 @@
 ---
-title: "FlowFuse 2.22: AI Co-Pilot for node editing, FlowFuse Broker schema autodetection, Improved Snapshots Interface, eCharts enablement, and FlowFuse Dashboard Updates"
-subtitle: "AI Co-Pilot for node editing, FlowFuse Broker schema autodetection, Improved Snapshots Interface, eCharts enablement, and FlowFuse Dashboard Updates"
-description: "AI Co-Pilot for node editing, FlowFuse Broker schema autodetection, Improved Snapshots Interface, eCharts enablement, and FlowFuse Dashboard Updates"
+title: "FlowFuse 2.22: AI Copilot for node editing, FlowFuse Broker schema autodetection, Improved Snapshots Interface, eCharts enablement, and FlowFuse Dashboard Updates"
+subtitle: "AI Copilot for node editing, FlowFuse Broker schema autodetection, Improved Snapshots Interface, eCharts enablement, and FlowFuse Dashboard Updates"
+description: "AI Copilot for node editing, FlowFuse Broker schema autodetection, Improved Snapshots Interface, eCharts enablement, and FlowFuse Dashboard Updates"
 date: 2025-09-25
 authors: ["greg-stoutenburg"]
 image: blog/2025/09/images/2.22-release.png
@@ -15,11 +15,11 @@ FlowFuse 2.22 provides more powerful development by bringing the FlowFuse Assist
 
 <!--more-->
 
-## AI Co-Pilot for Node Editing
+## AI Copilot for Node Editing
 ![Gif showing AI Assistant in Function node](./images/inline-assist-function.gif)
 _FlowFuse Assistant at work_
 
-We've enhanced the capabilities of the FlowFuse AI Assistant, which now provides automatic suggestions to draft and edit your code that extends to Tables nodes, Dashboard Template nodes (ui-template), and Function nodes. You can now simply start typing, and the FlowFuse Assistant will provide code for you based on your context, making the FlowFuse Assistant your AI co-pilot in Node-RED.
+We've enhanced the capabilities of the FlowFuse AI Assistant, which now provides automatic suggestions to draft and edit your code that extends to Tables nodes, Dashboard Template nodes (ui-template), and Function nodes. You can now simply start typing, and the FlowFuse Assistant will provide code for you based on your context, making the FlowFuse Assistant your AI copilot in Node-RED.
 
 With this change, the FlowFuse assistant can now write HTML, CSS, SQL, Javascript, and JSON, all based on your words, and with awareness of your FlowFuse environment (like your Tables structure), cursor position, and where in your code you are editing.
 


### PR DESCRIPTION
## Summary
- Updated all instances of "Co-Pilot" to use proper capitalization in the FlowFuse 2.22 release post
- Used "Copilot" (title case) in headings and titles  
- Used "copilot" (lowercase) in body text
- Total of 5 instances updated across title, subtitle, description, section heading, and body text

## Test plan
- [x] Verify all "Co-Pilot" instances have been updated
- [x] Confirm proper capitalization rules applied (title case in headings, lowercase in body)
- [x] Review changes for accuracy and consistency

🤖 Generated with [Claude Code](https://claude.ai/code)