### PR TITLE
Remove availability restriction from AI Co-Pilot feature

### DIFF
--- a/src/blog/2025/09/flowfuse-release-2-22.md
+++ b/src/blog/2025/09/flowfuse-release-2-22.md
@@ -23,8 +23,6 @@ We've enhanced the capabilities of the FlowFuse AI Assistant, which now provides
 
 With this change, the FlowFuse assistant can now write HTML, CSS, SQL, Javascript, and JSON, all based on your words, and with awareness of your FlowFuse environment (like your Tables structure), cursor position, and where in your code you are editing.
 
-Available for Pro and Enterprise.
-
 ## FlowFuse Team Broker Automatic Schema Detection
 
 ![Image showing schema detection](./images/schema-autodetect.png)


### PR DESCRIPTION
## Summary
• Removed "Available for Pro and Enterprise" line from the AI Co-Pilot for Node Editing section in the FlowFuse 2.22 release blog post

## Test plan
- [x] Verify the line has been removed from the blog post
- [x] Confirm the section still reads properly without the availability restriction

🤖 Generated with [Claude Code](https://claude.ai/code)