### PR TITLE
handbook: Fix dashboard url on the `Customer Success` page

### DIFF
--- a/src/handbook/sales/customer-success.md
+++ b/src/handbook/sales/customer-success.md
@@ -113,7 +113,7 @@ and can be
 
 ## Shipped Feature Updates
 
-Customer success contacts FlowFuse customers and prospective customers (anyone we have had in a sales cycle who has requested a feature) when a requested feature is shipped. To facilitate this, there is a view in the Development board on GitHub called []"CS View"](https://github.com/orgs/FlowFuse/projects/1/views/61). It filters to all issues marked Done by the Engineering team, and those with the label Sales Request or Customer Request. The Customer Success Manager will review this board upon each release and contact customers or prospects who requested a feature to inform them that it has shipped, and invite a conversation or feedback.
+Customer success contacts FlowFuse customers and prospective customers (anyone we have had in a sales cycle who has requested a feature) when a requested feature is shipped. To facilitate this, there is a view in the Development board on GitHub called ["CS View"](https://github.com/orgs/FlowFuse/projects/1/views/61). It filters to all issues marked Done by the Engineering team, and those with the label Sales Request or Customer Request. The Customer Success Manager will review this board upon each release and contact customers or prospects who requested a feature to inform them that it has shipped, and invite a conversation or feedback.
 
 All team members are asked to identify customer and prospect requests in the following way:
 - On a GitHub issue, use the label Sales Request or Customer Request, as appropriate. (A request is a Sales Request when a member of the Sales team learns that a prospect is interested in a feature. It is a Customer Request when an existing customer makes a request. An issue can be both a Customer Request and a Sales Request.)


### PR DESCRIPTION
## Description

This pull request fixes the GitHub dashboard URL on the `Customer Success` handbook page. 

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
