### PR TITLE
Update PR checklist to require Art Request for blog articles

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,3 +14,5 @@
  - [ ] I have considered the performance impact of these changes
  - [ ] Suitable unit/system level tests have been added and they pass
  - [ ] Documentation has been updated
+ - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))
+


### PR DESCRIPTION
## Description

Adds a checklist item to remind author to create an Art Request before submitting a blog PR.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
