### PR TITLE
Add redirect for AI hype blog article

### DIFF
--- a/src/redirects.njk
+++ b/src/redirects.njk
@@ -84,4 +84,5 @@ eleventyExcludeFromCollections: true
 /landing/technology-migration-1/ /vs/kepware/ 301
 /landing/technology-migration-2/ /vs/kepware/ 301
 /customer-stories/scaling-manufacturing-automation-with-flowfuse/ /customer-stories/ 301
+/blog/2025/10/the-ai-orchestation-hype/ /blog/2025/10/the-ai-orchestration-hype/ 301
 


### PR DESCRIPTION
## Description

The PR https://github.com/FlowFuse/website/pull/3933 changed the name of the file but didn't add a redirect. This had already been shared in social channels, and a follower mentioned today that the link was broken. This PR fixes that.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

