### PR TITLE
Improve default fallback response

### DIFF
--- a/src/_includes/components/ai-expert-modal.njk
+++ b/src/_includes/components/ai-expert-modal.njk
@@ -782,7 +782,7 @@ document.addEventListener('DOMContentLoaded', function() {
             
             // Fallback to simulated response for local development
             const simulatedResponses = {
-                default: "This is a test response as the API is not available right now",
+                default: "Sorry, something went wrong trying to answer your question. Please try again.",
                 summary: "We discussed FlowFuse implementation strategies and Node-RED workflow development."
             };
             


### PR DESCRIPTION
The FF Expert shows a fallback response if there's any errors with the API request.

> This is a test response as the API is not available right now

This PR changes it to a more user-friendly default:

> Sorry, something went wrong trying to answer your question. Please try again.