### PR TITLE
Orphan loading indicator when creating a new FlowFuse expert session after using "Start over" button

### DIFF
--- a/src/_includes/components/ai-expert-modal.njk
+++ b/src/_includes/components/ai-expert-modal.njk
@@ -501,6 +501,9 @@ document.addEventListener('DOMContentLoaded', function() {
         
         // Scroll to bottom using auto-scroll function
         scrollToBottom();
+        
+        // Return the index of the newly added message
+        return messages.length - 1;
     }
 
     function renderMessages() {
@@ -543,17 +546,12 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     async function showWelcomeMessage() {
-        // Add welcome message container (this doesn't count as a real conversation message)
-        const messageDiv = document.createElement('div');
-        messageDiv.className = 'flex justify-start mb-4';
+        // Add welcome message using addMessage to maintain array/DOM sync
+        const messageIndex = addMessage('', 'ai');
         
-        const messageBubble = document.createElement('div');
-        messageBubble.className = 'max-w-xs lg:max-w-md px-4 py-2 rounded-lg bg-gray-100 text-gray-800 rounded-bl-sm';
-        messageBubble.textContent = '';
-        
-        messageDiv.appendChild(messageBubble);
-        chatMessages.appendChild(messageDiv);
-        scrollToBottom();
+        // Get the message bubble element that was just created
+        const messageDiv = chatMessages.children[messageIndex];
+        const messageBubble = messageDiv.querySelector('div:last-child');
         
         // Animate the typing of the welcome message
         const welcomeText = 'Hello! I am here to help you get started with FlowFuse and Node-RED. Please tell me what you are hoping to achieve.';
@@ -563,6 +561,7 @@ document.addEventListener('DOMContentLoaded', function() {
         for (let i = 0; i < words.length; i++) {
             currentText += (i > 0 ? ' ' : '') + words[i];
             messageBubble.textContent = currentText;
+            messages[messageIndex].content = currentText; // Update the messages array too
             scrollToBottom();
             
             // Small delay between words for typing effect


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

Orphan loading indicator when creating a new FlowFuse expert session after using "Start over" button

<img width="1876" height="2078" alt="CleanShot 2025-10-20 at 10 38 03@2x" src="https://github.com/user-attachments/assets/2535cfc3-31bd-4e7a-9c48-7916c05a6d68" />

## Related Issue(s)

https://flowforgeworkspace.slack.com/archives/C021LKE5EAY/p1760948252098999?thread_ts=1760947527.759559&cid=C021LKE5EAY

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

