### PR TITLE
Update [Generation stopped] to Stopped your request

### DIFF
--- a/src/_includes/components/ai-expert-modal.njk
+++ b/src/_includes/components/ai-expert-modal.njk
@@ -445,18 +445,18 @@ document.addEventListener('DOMContentLoaded', function() {
         } catch (error) {
             if (error.name === 'AbortError') {
                 // Update message to show it was stopped
-                updateMessage(aiMessageIndex, messages[aiMessageIndex].content + ' [Generation stopped]');
+                updateMessage(aiMessageIndex, messages[aiMessageIndex].content + ' Stopped your request');
             } else {
                 // Handle other errors
                 updateMessage(aiMessageIndex, 'Sorry, an error occurred while generating the response.');
             }
         }
-        
+
         // Mark generation as complete
         isGenerating = false;
         currentAbortController = null;
         updateInputState();
-        
+
         // Button visibility is now handled by updateInputState()
     }
 
@@ -1099,13 +1099,13 @@ document.addEventListener('DOMContentLoaded', function() {
         } catch (error) {
             if (error.name === 'AbortError') {
                 // Update message to show it was stopped
-                updateMessage(aiMessageIndex, messages[aiMessageIndex].content + ' [Generation stopped]');
+                updateMessage(aiMessageIndex, messages[aiMessageIndex].content + ' Stopped your request');
             } else {
                 // Handle other errors
                 updateMessage(aiMessageIndex, 'Sorry, an error occurred while generating the response.');
             }
         }
-        
+
         // Mark generation as complete
         isGenerating = false;
         currentAbortController = null;
@@ -1199,13 +1199,13 @@ document.addEventListener('DOMContentLoaded', function() {
                 } catch (error) {
                     if (error.name === 'AbortError') {
                         // Update message to show it was stopped
-                        updateMessage(aiMessageIndex, messages[aiMessageIndex].content + ' [Generation stopped]');
+                        updateMessage(aiMessageIndex, messages[aiMessageIndex].content + ' Stopped your request');
                     } else {
                         // Handle other errors
                         updateMessage(aiMessageIndex, 'Sorry, an error occurred while generating the response.');
                     }
                 }
-                
+
                 // Mark generation as complete
                 isGenerating = false;
                 currentAbortController = null;


### PR DESCRIPTION
### problem

Right now, clicking the stop button while a generation is in progress results in "[Generation stopped]" which can look a little auto-generated.

<img width="1914" height="676" alt="Image" src="https://github.com/user-attachments/assets/d1cea9d6-c417-41d5-9715-426c3fdb335f" />

### Proposed solution

Change this to "Stopped your request"

## Related Issue(s)

Fixes https://github.com/FlowFuse/website/issues/3992

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

