### PR TITLE
Footer: Replace LI and YT icons for follow us buttons

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -307,49 +307,41 @@ eleventyComputed:
                     </ul>
                 </div>
                 <div class="w-full md:row-span-2">
-                    <ul class="flex flex-row w-full -mx-3 md:mx-0 text-base justify-between sm:justify-start sm:gap-x-4 lg:gap-x-6 md:justify-end">
-                        <li class="inline md:m-0 md:block">
-                            <a href="https://www.facebook.com/FlowFuse/" class="block px-3 py-3 md:p-0">
-                                <span class="sr-only">Visit our Facebook page</span>
-                                {% include "components/facebook.njk" %}
-                            </a>
-                        </li>                          
-                        <li class="inline md:m-0 md:block">
-                            <a href="https://www.linkedin.com/company/flowfuse" class="block px-3 py-3 md:p-0">
-                                <span class="sr-only">Visit our LinkedIn page</span>
-                                {% include "components/linkedin.njk" %}
-                            </a>
-                        </li>                          
-                        <li class="inline md:m-0 md:block">
-                            <a href="https://www.youtube.com/channel/UCbBzP8NZbv3WDtlt4UouA-g" class="block px-3 py-3 md:p-0">
-                                <span class="sr-only">Visit our YouTube channel</span>
-                                {% include "components/youtube.njk" %}
-                            </a>
-                        </li>    
-                        <li class="inline md:m-0 md:block">
-                            <a href="https://github.com/FlowFuse" class="block px-3 py-3 md:p-0">
-                              <span class="sr-only">Visit our GitHub page</span>
-                              {% include "components/github.njk" %}
-                            </a>
-                        </li>      
-                        <li class="inline md:m-0 md:block">
-                            <a href="https://discord.gg/2RrvW8dkrF" class="block px-3 py-3 md:p-0">
-                                <span class="sr-only">Join our Discord</span>
-                                {% include "components/discord.njk" %}
-                            </a>
-                        </li>
-                        <li class="inline md:m-0 md:block">
-                            <a href="https://www.reddit.com/r/flowfuse" class="block px-3 py-3 md:p-0">
-                                <span class="sr-only">Visit our Reddit community</span>
-                                {% include "components/reddit.njk" %}
-                            </a>
-                        </li>
-                        <li class="inline md:m-0 md:block">
-                            <a href="/blog/index.xml" class="block px-3 py-3 md:p-0">
-                                <span class="sr-only">Subscribe to our RSS feed</span>
-                                {% include "components/rss.njk" %}
-                            </a>
-                        </li>
+                    <ul class="flex flex-col gap-y-4 md:gap-y-6 w-full -mx-3 md:mx-0 text-base md:items-end">
+                      <!-- Follow us buttons -->
+                      <li class="flex flex-wrap gap-y-4 gap-x-4 lg:gap-x-5 px-3 md:px-0 justify-start md:justify-end">
+                        <div class="min-w-max h-6 flex items-end">
+                          <script src="https://platform.linkedin.com/in.js" type="text/javascript"> lang: en_US</script>
+                          <script type="IN/FollowCompany" data-id="71968747" data-counter="none"></script>
+                        </div>
+                        <div class="min-w-max h-6 flex items-end">
+                          <script src="https://apis.google.com/js/platform.js"></script>
+                          <div class="g-ytsubscribe" data-channelid="UCbBzP8NZbv3WDtlt4UouA-g" data-layout="default" data-count="default"></div>
+                        </div>
+                      </li>
+                      <!-- Social Icons -->
+                      <li class="flex flex-wrap gap-x-4 lg:gap-x-6 px-3 md:px-0 justify-between sm:justify-start md:justify-end">
+                        <a href="https://www.facebook.com/FlowFuse/" class="block">
+                          <span class="sr-only">Visit our Facebook page</span>
+                          {% include "components/facebook.njk" %}
+                        </a>
+                        <a href="https://github.com/FlowFuse" class="block">
+                          <span class="sr-only">Visit our GitHub page</span>
+                          {% include "components/github.njk" %}
+                        </a>
+                        <a href="https://discord.gg/2RrvW8dkrF" class="block">
+                          <span class="sr-only">Join our Discord</span>
+                          {% include "components/discord.njk" %}
+                        </a>
+                        <a href="https://www.reddit.com/r/flowfuse" class="block">
+                          <span class="sr-only">Visit our Reddit community</span>
+                          {% include "components/reddit.njk" %}
+                        </a>
+                        <a href="/blog/index.xml" class="block">
+                          <span class="sr-only">Subscribe to our RSS feed</span>
+                          {% include "components/rss.njk" %}
+                        </a>
+                      </li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
## Description

As part of the [growing followers strategy](https://docs.google.com/document/d/1DfbXlSZoaMxHXc5b9tPNPyybXke18qMQpGlwUE4cmSk/edit?usp=sharing), this PR implements the follow us buttons instead of the icons.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

