### PR TITLE
Make the cookie banner smaller for mobile devices

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -513,33 +513,6 @@ h4:hover .header-anchor::before {
     z-index: 1000;
 }
 
-@media (max-width: 640px) {
-    body.node-red-con {
-        background-size: 250% auto;
-        background-position: center top;
-    }
-
-    body.node-red-con h1 {
-        font-size: 2rem;
-        line-height: 2.4rem;
-    }
-
-    body.node-red-con h2 {
-        font-size: 1.75rem;
-        line-height: 2.1rem;
-    }
-
-    body.node-red-con h3 {
-        font-size: 1.5rem;
-        line-height: 1.9rem;
-    }
-
-    body.node-red-con .container.main {
-        padding-left: 1rem;
-        padding-right: 1rem;
-    }
-}
-
 .story .ff-tooltip:after {
     transform: translate(-50%, 100%);
     top: auto;
@@ -1670,6 +1643,29 @@ div.content section.footnotes ol li p {
 .pm__btn,
 .cm__btn {
     border: none !important;
+}
+
+@media (max-width: 640px) {
+    body #cc-main .cm__desc {
+        font-size: .8em;
+    }
+
+    body #cc-main .cm__btns {
+        padding: .25rem 1.1rem .5rem;
+    }
+    body #cc-main .cm__btn-group {
+        display: flex;
+        flex-direction: row !important;
+        gap: 1rem;
+    }
+
+    body #cc-main .pm__btn,
+    body #cc-main .cm__btn {
+        border: none;
+        align-self: end;
+        flex: 1;
+        padding: .4em 1em;
+    }
 }
 
 /*


### PR DESCRIPTION
## Description

makes the cookie consent modal a bit smaller when display port width under 640p:
- smaller font for text
- smaller padding for buttons
- list buttons as single row

<img width="411" height="916" alt="image" src="https://github.com/user-attachments/assets/43a38081-8074-4a0c-8855-b6aa2ef6dcee" />

Behavior and sizing preserved for higher dp widths.

Testing this won't be possible on pres-staging. What I did was to remove the `{%- if not DEV_MODE -%}` and force render 3rd party scripts locally in `src/_includes/layouts/base.njk:365`

## Related Issue(s)

closes https://github.com/FlowFuse/website/issues/3976

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

