### PR TITLE
Handbook: Clarify US health benefits start date

### DIFF
--- a/src/handbook/peopleops/compensation.md
+++ b/src/handbook/peopleops/compensation.md
@@ -120,6 +120,8 @@ added to the list, especially when you're considering a job offer at FlowFuse.
 
 For employees located in the United States, FlowFuse offers health insurance coverage through Deel; since this changes regularly, please see Deel for accurate information.
 
+Health insurance benefits begin on the employee’s **first day of employment**.
+
 We commit to offering at least one medical plan, one dental plan, and one vision plan with 100% coverage for team members. We also subsidize some level of coverage for dependants, as well, but specifics are tied to plan details.  
 
 In our health benefits for US employees, we offer:


### PR DESCRIPTION
## Description

Clarify that US employee health benefits begin on date of employment

## Related Issue(s)

Helps certify if people need gap insurance or not.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [X] I have considered the performance impact of these changes
 - [X] Suitable unit/system level tests have been added and they pass
 - [X] Documentation has been updated
 - [X] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

