### PR TITLE
Fix inconsistent team member image sizing on /team/ page

### DIFF
--- a/src/css/style.page.css
+++ b/src/css/style.page.css
@@ -425,13 +425,14 @@
 }
 
 .team-headshot img {
+    width: 100%;
+    aspect-ratio: 512 / 647;
+    object-fit: cover;
+    object-position: center top;
     border-top-left-radius: var(--border-radius);
     border-top-right-radius: var(--border-radius);
     border-width: var(--border-width);
     border-color: theme(colors.indigo.200);
-}
-
-.team-headshot img {
     background: linear-gradient(to bottom, theme(colors.indigo.50), theme(colors.indigo.200));
     border-bottom: 0;
     background-size: cover;


### PR DESCRIPTION
Added CSS constraints to ensure all team member images display with consistent dimensions regardless of source image aspect ratios. Images now use object-fit: cover with a fixed 512:647 aspect ratio.

## Description

<!-- Describe your changes in detail -->

| Before | After
|--------|--------|
| <img width="1438" height="1604" alt="CleanShot 2025-11-11 at 12 42 18@2x" src="https://github.com/user-attachments/assets/69a6231d-ac11-4678-a266-c6b8c98e6574" /> | <img width="1696" height="1692" alt="CleanShot 2025-11-11 at 12 58 41@2x" src="https://github.com/user-attachments/assets/e7b938e7-dacc-4b97-af71-debcecc9b27d" /> |

## Related Issue(s)

<!-- What issue does this PR relate to? -->

https://github.com/FlowFuse/website/pull/4054

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

