### PR TITLE
Add bots to robots

### DIFF
--- a/src/public/robots.txt
+++ b/src/public/robots.txt
@@ -1,5 +1,14 @@
 # Algolia-Crawler-Verif: 77BE7DC6E58603CB
 
+User-agent: AhrefsBot
+Disallow: /
+
+User-agent: petalbot
+Disallow: /
+
+User-agent: SemrushBot
+Disallow: /
+
 User-agent: *
 Allow: /
 


### PR DESCRIPTION
Adds some AI crawlers to out robots.txt to try to block their access.

This is a *temporary* attempt at a fix to bring our website bandwidth usage under control. I've picked some of the most active bots on the site to see if it has an impact on our bandwidth, without impacting the main search engine bots etc.