### PR TITLE
Add Google Calendar delegation instructions to handbook

### DIFF
--- a/src/handbook/company/communication.md
+++ b/src/handbook/company/communication.md
@@ -78,6 +78,16 @@ Most meetings are scheduled to discuss items and make decisions. There's meeting
 that just shouldn't take place when there's nothing to discuss on the agenda
 5 minutes prior to the meeting.
 
+### Google Calendar Delegation
+
+You can allow other team members to manage created events on your calendar by adjusting the modify permissions on a per event basis or have it enabled by default. Having it enabled by default allows co-management of your created events which is particularly helpful if the person who created the event is unable to edit it when needed. Allowing broader permissions works well for most events in an async remote work environment.
+
+To enable it by default for all your future created events:
+1. Sign in to https://calendar.google.com with your FlowFuse email address.
+1. In the top right click on the Gear icon to go into the [pGoogle Calendar Settings](https://support.google.com/calendar/answer/6084644?hl=en&co=GENIE.Platform%3DDesktop&oco=0)
+1. Go to `Event settings`
+1. Adjust `Guest permissions` to include `Modify event`
+
 ### Coffee calls
 
 Coffee calls are social of nature and thus are the exception to the rule that


### PR DESCRIPTION


## Description

<!-- Describe your changes in detail -->

<img width="1182" height="1068" alt="CleanShot 2025-11-17 at 11 28 01@2x" src="https://github.com/user-attachments/assets/6793753a-85ac-404e-b5c3-01ee5cc10a43" />

Added instructions for enabling Google Calendar delegation for event management (allowing edits on events by default be participants).

Allows for shared editing responsibilities of created events

## Related Issue(s)

<!-- What issue does this PR relate to? -->

Part of responsibilities of https://github.com/FlowFuse/admin/issues/452

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

