### PR TITLE
Handbook: Override default margin for signature

### DIFF
--- a/src/handbook/design/branding.md
+++ b/src/handbook/design/branding.md
@@ -351,7 +351,7 @@ Instructions for setting up your signature: [Configure Gmail signature](https://
 
 ##### Copy the signature below:
 
-<table cellpadding="0" cellspacing="0" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size:14px; color:#333; width:auto;">
+<table cellpadding="0" cellspacing="0" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size:14px; color:#333; width:auto; margin-top:0; margin-bottom:0">
     <tr>
         <td style="padding-right:10px; vertical-align:middle;">
             <img src="https://flowfuse.com/images/flowfuse-icon.png" alt="FlowFuse icon" width="48" height="48" style="display:block;border:0;border-radius:0;outline:none;width:65px;height:65px;">


### PR DESCRIPTION
## Description

Our handbook files have pre-defined classes for all the HTML tags. This overrides the margins of the signature to make sure it has the right spacing when used in email messages.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

