### PR TITLE
Fix navTitle not being applied in handbook navigation

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -561,6 +561,9 @@ module.exports = function(eleventyConfig) {
                             'order': page.data.navOrder || Number.MAX_SAFE_INTEGER,
                             'children': {}
                         }
+                    }
+                    // Only update navTitle and navGroup for the last segment (the actual page)
+                    if (i === hierarchy.length - 1) {
                         if (page.data.navTitle) {
                             accumulator[currentValue].name = page.data.navTitle
                         }


### PR DESCRIPTION
The navTitle front matter was only applied when creating new navigation entries, which meant it wouldn't properly override for pages. This fix ensures navTitle is always applied to the actual page (last URL segment) in the hierarchy.


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

