### PR TITLE
refactor: improve 'What is Node-RED' page heading hierarchy and content

### DIFF
--- a/src/node-red/index.njk
+++ b/src/node-red/index.njk
@@ -3,7 +3,7 @@ layout: page
 nohero: true
 meta:
     title: "What is Node-RED?"
-    keywords: Node-RED, FlowFuse Cloud, Node-RED use cases, Node-RED FAQs, Node-RED tips, Node-RED concepts
+    keywords: what is node-red, what is Node-RED, how does node-red works, low-code programming, visual programming, flow-based programming, node-red enterprise, node-red for production
     faq:
         - question: "What is Node-RED and how does it work?"
           answer: >
@@ -62,12 +62,9 @@ sitemapPriority: 0.8
         <div class="flex flex-col px-6 md:my-16 items-center md:flex-row md:items-start container mx-auto text-center md:text-left md:max-w-screen-lg gap-8">
         <div class="md:my-auto md:w-1/2 max-w-md">
             <h1 class="mt-0 px-12 md:px-0 m-auto text-indigo-800">
-                FlowFuse makes Node-RED safe, reliable and scalable.</span>
+                What is <span class="inline-block">Node-RED?</span>
             </h1>
             <p>
-            <h2 class="mt-0 px-12 md:px-0 m-auto text-indigo-800">
-                What is <span class="inline-block">Node-RED?</span>
-            </h2>
             <p>
                 Co-created by Nick O'Leary, CTO of FlowFuse, Node-RED is <span class="font-semibold">the <span class="inline-block">low-code</span> programming language of choice for industrial applications</span>. Industrial engineers use Node-RED to collect, transform, and integrate data through visualized dashboards.
             </p>
@@ -291,5 +288,3 @@ sitemapPriority: 0.8
         {% include "faq.njk" %}
     </div>
 </div>
-
-


### PR DESCRIPTION
## Description

This PR updates the page so that “What is Node-RED” is used as the main H1, targeting the primary keyword that drives traffic. Following SEO best practices, the main keyword should be included in the H1. It also removes an unnecessary H2 heading that duplicated content already explained in the FlowFuse section. Adding extra H1 or H2 headings was affecting the page layout and style, so this update ensures the design remains consistent as well.

pr also adds relevant and valid keywords

This PR reverts the headings back to the previous structure, though not sure when they were changed.

Before 

<img width="1078" height="611" alt="nr-page-before" src="https://github.com/user-attachments/assets/4254cefa-bece-48e5-80fd-62ced645dad0" />

After

<img width="1039" height="494" alt="nr-page-after" src="https://github.com/user-attachments/assets/2b75c40a-857a-49d0-be80-665f49880043" />


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

