### PR TITLE
Update sales commission link to point to dedicated sales compensation…

### DIFF
--- a/src/handbook/peopleops/compensation.md
+++ b/src/handbook/peopleops/compensation.md
@@ -45,16 +45,7 @@ into this [private Google Drive directory](https://drive.google.com/drive/folder
 ## Sales Commissions
 
 FlowFuse pays out commissions to sales reps, the terms of which are to be found
-in [this template doc](https://docs.google.com/document/d/14KSf0N5H6vzUPJrpIqQGffgHk-_5OK2HeS-fuRHTSYw).
-
-### Sales Compensation Structure
-
-FlowFuse follows a balanced sales compensation model:
-- **Base/Commission Split**: 50/50 split between base salary and commission opportunity
-- **OTE Target**: FlowFuse targets a 5x OTE (On-Target Earnings) multiple for sales roles
-- **Commission Basis**: Commission is calculated based on booked new Annual Recurring Revenue (ARR)
-
-This structure ensures competitive compensation while aligning sales performance with company growth objectives.
+in the [Sales Compensation Plan](/handbook/sales/commission-plan/).
 
 ## Performance Review
 


### PR DESCRIPTION
- Changed link from Google doc to /handbook/sales/commission-plan/
- Removed redundant Sales Compensation Structure section
- Consolidated sales compensation information into single source

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

