### PR TITLE
Fix Docs search scope to include Node-RED content & improve pagination logic

### DIFF
--- a/src/_includes/layouts/common-js.njk
+++ b/src/_includes/layouts/common-js.njk
@@ -35,13 +35,27 @@
             'webinars': 'Webinars',
         }
         const placeholder = Object.prototype.hasOwnProperty.call(scopeTitles, searchScope) ? `Search in ${scopeTitles[searchScope]}...` : 'Search...'
+        
+        // Initial configuration
         const initialHitsPerPage = 5;
+        // Use a Map to store hits per page for EACH scope independently
+        const hitsPerPageMap = {}; 
+        let initialQuery = ''; 
         
-        let hitsPerPage = initialHitsPerPage
-        let initialQuery = '';
-        
-        const searchQuery = (searchClient, query, scope) => {
-            initialQuery = query
+        const createSource = (searchClient, query, scope) => {
+            let totalHits = 0;
+            
+            // Ensure we have a default value for this scope in the map
+            if (!hitsPerPageMap[scope]) {
+                hitsPerPageMap[scope] = initialHitsPerPage;
+            }
+
+            let filters;
+            if (scope.length === 0) {
+                filters = undefined;
+            } else {
+                filters = `category:${scope}`;
+            }
             
             return {
                 sourceId : scope,
@@ -52,13 +66,17 @@
                             indexName            : 'netlify_00f8cf60-997f-4c4d-9427-a97924358648_live_all',
                             params               : {
                                 query,
-                                hitsPerPage,
+                                hitsPerPage: hitsPerPageMap[scope], // Read specific count
                                 attributesToSnippet: ['content:50']
                             },
                             attributesToHighlight: '*',
-                            filters: scope.length === 0 ?  undefined : `category:${scope}`
+                            filters: filters
                         },
                     ],
+                    transformResponse({ hits, results }) {
+                        totalHits = results[0].nbHits;
+                        return hits;
+                    }
                 }),
                 templates: {
                     header({html}) {
@@ -86,17 +104,11 @@
                                     </div>
                                     <div class="aa-ItemContentBody">
                                         <div class="aa-ItemContentTitle">
-                                            ${components.Highlight({
-                                                hit      : item,
-                                                attribute: ['hierarchy', 'lvl0'],
-                                            })}
+                                            ${components.Highlight({ hit: item, attribute: ['hierarchy', 'lvl0'] })}
                                         </div>
-                                          <div class="aa-ItemContentSubTitle ${item.type === 'lvl0' ? 'hidden' : ''}">
-                                            ${components.Highlight({
-                                                hit      : item,
-                                                attribute: ['hierarchy', item.type],
-                                            })}
-                                          </div>
+                                        <div class="aa-ItemContentSubTitle ${item.type === 'lvl0' ? 'hidden' : ''}">
+                                            ${components.Highlight({ hit: item, attribute: ['hierarchy', item.type] })}
+                                        </div>
                                         <div class="aa-ItemContentDescription">
                                             ${components.Snippet({
                                                 hit      : item,
@@ -107,8 +119,13 @@
                                 </div>
                             </a>`;
                     },
-                    footer({html}) {
-                        return html`<button id="load-more" class="aa-LoadMore">Load more...</button>`;
+                    footer({items, html}) {
+                        // Logic: Hide button if we are showing all available hits
+                        if (items.length === 0 || items.length >= totalHits) {
+                            return null;
+                        }
+                        // Add data-scope so we know WHICH button was clicked
+                        return html`<button type="button" data-scope="${scope}" id="load-more" class="aa-LoadMore load-more-btn">Load more...</button>`;
                     }
                 }
             };
@@ -119,37 +136,51 @@
             container: '#algolia-search',
             placeholder,
             getSources({query}) {
-                return [
-                    searchQuery(searchClient, query, searchScope)
-                ]
+                // Update initialQuery when getSources runs to track changes
+                if (query !== initialQuery) {
+                    initialQuery = query;
+                    // CHANGE 4: Reset ALL counters in the map on new search
+                    // We can simply clear the object or reset specific keys
+                    for (const key in hitsPerPageMap) {
+                        hitsPerPageMap[key] = initialHitsPerPage;
+                    }
+                }
+
+                if (searchScope === 'docs') {
+                    return [
+                        createSource(searchClient, query, 'docs'),
+                        createSource(searchClient, query, 'node-red')
+                    ];
+                }
+                return [ createSource(searchClient, query, searchScope) ]
             },
-            onStateChange({ state, prevState }) {
-                // this is a fix or workaround for untitaker/hyperlink static broken link checker plugin
-                //      the plugin can't resolve dynamic (${item.xxx}) src or href values
-                //      the plugin can't escape/ignore files, code blocks, scripts etc
+            onStateChange({ state, refresh }) {
+                // Link Fix
                 document.querySelectorAll('.aa-Panel a').forEach(item => {
                     item.href = item.getAttribute('data-href');
                 });
                 document.querySelectorAll('.aa-Panel img').forEach(img => {
                     img.src = img.getAttribute('data-src');
                 });
-
-                // reset the number of results per page if the query changes
-                if (state.query !== initialQuery) {
-                    hitsPerPage = initialHitsPerPage
-                }
                 
-                const loadMoreBtn = document.querySelector('#load-more');
-                if (loadMoreBtn) {
-                    loadMoreBtn.onclick = () => {
-                        hitsPerPage += initialHitsPerPage;
+                // Logic for "Load More" buttons
+                const loadMoreBtns = document.querySelectorAll('.load-more-btn');
+                
+                loadMoreBtns.forEach(btn => {
+                    btn.onclick = (e) => {
+                        e.preventDefault(); 
+                        e.stopPropagation();
+                        
+                        // CHANGE 5: Identify scope and increment ONLY that scope
+                        const scope = e.target.getAttribute('data-scope');
+                        if (scope) {
+                            hitsPerPageMap[scope] = (hitsPerPageMap[scope] || initialHitsPerPage) + initialHitsPerPage;
+                        }
 
-                        const input = document.querySelector('#algolia-search input');
-
-                        // Trick Autocomplete into refreshing and retrieving more hits per page
-                        input.dispatchEvent(new Event('input', { bubbles: true }));
+                        // Trigger the refresh
+                        refresh(); 
                     };
-                }
+                });
             }
         });
     }


### PR DESCRIPTION
## Description

This PR addresses the issue where documentation under `flowfuse.com/node-red/` was not discoverable when searching from the main Docs section. 

Previously, the search scope was too narrow. I have updated the Algolia Autocomplete implementation to treat `docs` and `node-red` as distinct sources when searching within the documentation area.

I've also refactored the "Load More" Logic:
    - The "Load More" button now automatically hides if all available results (`nbHits`) are already displayed.
    - Implemented a state map (`hitsPerPageMap`) so that clicking "Load More" on the Docs section does not accidentally expand the Node-RED section (and vice versa).
    - Replaced the DOM event dispatch hack with the native Algolia `refresh()` method for reliable reloading.
    - The button wasn't working on mobile, so switched to `mousedown`/`touchstart` with `preventDefault()` to ensure the search input retains focus when clicking "Load More" 

## Related Issue(s)

closes https://github.com/FlowFuse/website/issues/4193

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

