### PR TITLE
Optimize Takt time article

### DIFF
--- a/src/blog/2025/09/what-is-takt-time.md
+++ b/src/blog/2025/09/what-is-takt-time.md
@@ -3,8 +3,8 @@ title: "What is Takt Time? Definition, Calculation, & More [2026 Edition]"
 subtitle: "Master takt time to synchronize production with customer demand using lean manufacturing principles"
 description: "Complete guide to takt time in manufacturing. Learn the formula, calculation methods, implementation strategies, and how to overcome common challenges. Includes real-world examples and troubleshooting tips."
 date: 2025-09-25
-lastUpdated: 2025-12-22
-keywords: takt time
+lastUpdated: 2025-12-24
+keywords: takt time, takt time formula, takt time defination, takt time calculation, what is takt time
 video: G8eYPuHQgk0
 authors: ["sumit-shinde"]
 image: /blog/2025/09/images/takt-time-flowfuse.png
@@ -13,42 +13,36 @@ tags:
 meta:
   faq:
   - question: "What is the difference between takt time and cycle time?"
-    answer: "Takt time is the rate at which products must be completed to meet customer demand, while cycle time is the actual time it takes to complete one unit. Takt time is based on customer requirements, whereas cycle time measures your current production capability. Ideally, cycle time should be equal to or slightly less than takt time to meet demand without overproducing."
-  - question: "What's the difference between takt time and lead time?"
-    answer: "Takt time is the pace at which you need to produce to meet demand, while lead time is the total time from customer order to delivery. Lead time includes processing time, waiting time, transportation, and all other delays. Takt time focuses specifically on production rhythm."
+    answer: "Takt time defines how often a product must be completed to meet customer demand, while cycle time measures how long it actually takes to produce one unit. Takt time is demand-driven (a target), whereas cycle time reflects production capability (reality). To consistently meet demand, cycle time should be equal to or less than takt time."
+
+  - question: "What is the difference between takt time and lead time?"
+    answer: "Takt time sets the production pace required to satisfy customer demand, while lead time is the total time from customer order to delivery. Lead time includes processing, waiting, transportation, and delays, whereas takt time focuses only on maintaining the correct production rhythm."
+
   - question: "How is takt time different from throughput?"
-    answer: "Takt time is the required production pace to meet demand (target), while throughput is the actual number of units produced in a given time (reality). Takt time sets the rhythm, throughput measures if you're keeping pace."
-  - question: "How do I calculate takt time if customer demand varies throughout the day?"
-    answer: "For variable demand, calculate takt time for specific time periods or use average demand over a meaningful timeframe. You can also calculate multiple takt times for different shifts or production windows. FlowFuse allows you to monitor these variations in real-time and adjust production pace accordingly."
-  - question: "Does takt time include downtime and breaks?"
-    answer: "No, takt time is calculated using available production time, which excludes planned downtime such as breaks, maintenance, shift changes, and scheduled meetings. This gives you a realistic production pace that accounts for these necessary interruptions."
-  - question: "How often should I recalculate takt time?"
-    answer: "Recalculate takt time whenever customer demand changes significantly or when available production time is modified. With FlowFuse, this calculation happens automatically in real-time, ensuring your production pace always aligns with current demand."
-  - question: "How often should you check takt time during production?"
-    answer: "Monitor takt time continuously during production using visual boards or digital displays. While the calculation only changes when demand shifts, track actual performance constantly to identify deviations immediately and take corrective action."
-  - question: "What should I do if my cycle time is longer than my takt time?"
-    answer: "If cycle time exceeds takt time, you're unable to meet customer demand. Solutions include adding more workers, improving processes to reduce cycle time, extending available production hours, or investing in faster equipment. You may also need to analyze bottlenecks in your production line."
-  - question: "What happens if the bottleneck runs slower than takt time?"
-    answer: "The bottleneck constrains your entire production line, preventing you from meeting customer demand. Solutions include redistributing work, adding resources to the bottleneck, improving the process, investing in faster equipment, or implementing parallel processing to eliminate the constraint."
-  - question: "Is a lower takt time always better?"
-    answer: "Not necessarily. A lower takt time means higher demand and faster required production pace, which can strain resources. The goal isn't to minimize takt time but to match it with your cycle time, creating a balanced production system that meets demand without waste."
-  - question: "How does takt time relate to lean manufacturing?"
-    answer: "Takt time is a fundamental concept in lean manufacturing. It helps eliminate waste by preventing overproduction, balancing workloads across stations, and creating a steady production flow. It's often used alongside other lean tools like value stream mapping and continuous improvement initiatives."
-  - question: "Can takt time be used in non-manufacturing environments?"
-    answer: "Yes, takt time principles apply to any process with customer demand and capacity constraints. Service industries, healthcare facilities, software development teams, and logistics operations can all benefit from understanding the pace needed to meet customer requirements."
-  - question: "Which industries can use takt time?"
-    answer: "Takt time applies to any industry with repetitive processes and measurable demand. This includes automotive, electronics, aerospace, pharmaceuticals, food and beverage, consumer goods, healthcare, logistics, construction, and service industries."
-  - question: "Can I use takt time for batch production?"
-    answer: "Yes, but you'll need to adjust your calculation. For batch production, consider the total units in a batch and the frequency of batch production. Calculate how many batches you need within your available time to meet customer demand, then determine the takt time per batch."
-  - question: "How do digital tools change the way takt time is managed?"
-    answer: "Digital tools like IoT sensors and manufacturing execution systems automate takt time tracking with real-time monitoring instead of manual calculations. They provide instant alerts when production falls behind, track performance at each workstation, and enable immediate corrective action through dashboards and predictive analytics."
+    answer: "Takt time is the required production rate based on customer demand, while throughput is the actual number of units produced in a given time period. Takt time defines the goal; throughput shows whether the production system is meeting it."
+
+  - question: "How do you calculate takt time when demand fluctuates?"
+    answer: "When demand fluctuates, calculate takt time for shorter intervals such as hourly, per shift, or daily, or use average demand over a meaningful timeframe. Many manufacturers calculate multiple takt times for different shifts. Digital tools like FlowFuse help monitor and adjust takt time in real time."
+
+  - question: "Does takt time include breaks, maintenance, or downtime?"
+    answer: "No. Takt time is calculated using available production time, which excludes planned downtime such as breaks, meetings, maintenance, and shift changes. This ensures the takt time reflects realistic working conditions."
+
+  - question: "How often should takt time be recalculated?"
+    answer: "Takt time should be recalculated whenever customer demand changes significantly or when available production time is modified. In modern digital factories, takt time can be updated automatically in real time to stay aligned with demand."
+
+  - question: "How often should takt time be monitored during production?"
+    answer: "Takt time should be monitored continuously during production using visual management boards or digital dashboards. Even if the takt calculation does not change frequently, real-time monitoring helps identify delays, bottlenecks, and performance gaps early."
 ---
 
-Understanding takt time is the cornerstone of production success in modern manufacturing. As we move into 2026, when you properly define takt time and apply the takt time formula, you create the difference between operations that consistently meet customer demand and those struggling with chronic delays, excess inventory, and inefficient resource allocation. Leading manufacturers—from automotive giants to precision electronics producers—have built their competitive advantage on mastering this fundamental principle.
+Understanding what takt time is is essential for any manufacturer trying to meet customer demand without overproduction, delays, or excess inventory. In lean manufacturing, takt time defines the exact pace at which products must be completed so production stays synchronized with real customer demand. When manufacturers clearly understand the takt time definition and apply the takt time formula correctly, they gain control over flow, capacity, and operational efficiency.
 
 <!--more-->
 
-In this comprehensive 2026 edition guide, I'll walk you through everything you need to master the meaning of takt time in your operations. Drawing from established lean manufacturing principles and real-world case studies across industries, I'll provide you with precise calculation methodologies using the takt formula, proven implementation frameworks, and systematic approaches to common challenges. You'll discover how top manufacturers synchronize production flow, eliminate bottlenecks, and achieve measurable efficiency gains through proper takt time application. Whether you're optimizing an existing production line or designing a new operation from the ground up, this guide delivers the practical insights and actionable strategies you need to drive operational excellence.
+In simple terms, takt time is the maximum allowable time to produce one unit based on available production time and customer demand. It acts as the “heartbeat” of production, ensuring every workstation operates at a rhythm aligned with orders—not guesses. Companies that ignore takt time often run too fast (causing overproduction) or too slow (missing deliveries). Those that master it build stable, predictable, and scalable operations.
+
+This 2026 edition guide explains what takt time means, how to calculate it using the takt time formula, and how to apply it in real manufacturing environments. You’ll learn the precise definition of takt time, step-by-step calculation methods, and practical examples across industries. We’ll also cover common mistakes, bottlenecks, and how modern digital tools like FlowFuse help track and manage takt time in real time.
+
+Whether you’re balancing an assembly line, responding to fluctuating demand, or designing a new production system, this guide gives you everything you need to define takt time correctly, apply the takt formula with confidence, and use takt time as a foundation for lean manufacturing success.
 
 ## What is Takt Time: Definition and Meaning
 
@@ -79,7 +73,7 @@ This **formula of takt time** contains two critical components that require care
 
 ### Available Production Time
 
-This is the net time available for production during your planning period (typically one shift or one day). When applying the takt formula, available production time includes actual running time and expected downtime such as machine breakdowns and minor stoppages. It excludes scheduled breaks and lunch periods, shift changeovers, planned maintenance windows, and scheduled meetings or training.
+This is the net time available for production during your planning period (typically one shift or one day). When applying the takt formula, available production time includes only planned production time. It excludes planned breaks, meetings, shift changes, and scheduled maintenance, but does not include unplanned downtime such as breakdowns or minor stoppages. It excludes scheduled breaks and lunch periods, shift changeovers, planned maintenance windows, and scheduled meetings or training.
 
 Consider an example calculation of takt time. An eight-hour shift equals 480 minutes. Subtract a 10-minute break to yield 470 minutes. Subtract a 20-minute lunch to yield 450 minutes. Subtract a 30-minute planned changeover to yield 420 minutes. The available production time equals 420 minutes.
 
@@ -347,6 +341,6 @@ While the **takt formula** (Takt Time = Available Production Time ÷ Customer De
 
 By learning to define takt time properly and applying the takt time formula in the right contexts, you expose bottlenecks, balance workloads, and create a predictable flow that maximizes resource utilization. However, manual tracking often leads to lagging data and missed opportunities. Modern industrial platforms like **FlowFuse** bridge this gap, providing the real-time visibility needed to monitor Takt Time, Cycle Time, and Lead Time automatically across your entire value stream.
 
-Mastering the meaning of takt time isn't just about working faster—it's about working smarter by ensuring every minute on the shop floor creates value for the customer. When you truly understand what it means to define takt time and calculate takt time correctly using the proper formula, you unlock the foundation of lean manufacturing excellence.
+Mastering takt time isn’t about working faster—it’s about working at the right pace. When production is synchronized with demand, every minute on the shop floor creates customer value instead of waste. When you truly understand what it means to define takt time and calculate takt time correctly using the proper formula, you unlock the foundation of lean manufacturing excellence.
 
-**[Book your demo](https://www.google.com/search?q=/book-demo/) today to see how FlowFuse can automate your production metrics and help you eliminate waste through real-time data visibility.**
+**[Book your demo](/book-demo/) today to see how FlowFuse can automate your production metrics and help you eliminate waste through real-time data visibility.**


### PR DESCRIPTION
## Description

Optimize the takt time article to move it from the second page to the first page. We’re getting very high impressions for ‘takt time,’ but because the page ranks on the second page, it isn’t converting those impressions into clicks.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

