### PR TITLE
Add support triage duty handbook page

### DIFF
--- a/src/handbook/development/support/index.md
+++ b/src/handbook/development/support/index.md
@@ -12,6 +12,10 @@ Support tickets can be opened via the [FlowFuse Support Portal](/support). FlowF
 
 For all FlowFuse customers, we have an [SLA](/handbook/sales/subscription-agreement-1.5) defined as part of the Subscription Agreement. Initial responses to support tickets must be sent within the SLA time frame defined in the Subscription Agreement.
 
+## Triage Duty
+
+For guidance on monitoring incoming tickets and routing them to the right person, see the [Triage Duty](triage.md) guide.
+
 ## Troubleshooting
 
 When trying to decipher a support ticket, you can follow the guides provided in the [Troubleshooting](troubleshooting.md) section of the handbook.

--- a/src/handbook/development/support/triage.md
+++ b/src/handbook/development/support/triage.md
@@ -1,0 +1,47 @@
+---
+navTitle: Triage Duty
+---
+
+# Support Triage Duty
+
+## Overview
+
+Support triage duty is a first-line monitoring role to ensure incoming support requests are promptly categorized and routed to the right person. The goal is not to solve every issue yourself, but to make sure nothing falls through the cracks and customers receive timely responses.
+
+## Where Tickets Come From
+
+- **Live chat** from the support widget on the website
+- **Emails** sent to support@flowfuse.com
+
+Both appear in the [HubSpot helpdesk](https://app-eu1.hubspot.com/help-desk/26586079/). For detailed HubSpot procedures, see the [Support Tickets section](/handbook/sales/customer-success/#support-tickets) of Customer Success.
+
+## Monitoring
+
+- **HubSpot**: Keep the helpdesk open in a browser tab
+- **Slack**: New tickets trigger a notification in [#support-tickets](https://flowforgeworkspace.slack.com/archives/C031K13FLDD)
+
+## Triage Categories
+
+When a new ticket comes in, categorize it, answer the question directly, or route accordingly. Some initial guidance:
+
+| Category | Action |
+|----------|--------|
+| Sales inquiry | Route to [#dept-sales](https://flowforgeworkspace.slack.com/archives/C05GYH95NJZ) team |
+| Billing inquiry | Route to DRI for Finance |
+| Product support | Route to [#dept-engineering](https://flowforgeworkspace.slack.com/archives/C032Q63FGG1) team |
+| Spam (e.g., booth design offers) | Close ticket without responding, delete Slack notification |
+
+## Key Points
+
+- **Check the content carefully**: Sales team members sometimes email support on behalf of customers. The "from" address may be internal, but the request is for a customer.
+- **Ticket ownership**: Whoever replies first becomes the ticket owner and receives future notifications for that ticket.
+- **Already assigned tickets**: If a ticket already has an owner, you don't need to intervene—unless it's been unresponded for 24+ hours, then give the owner a nudge.
+- **When unsure**: Ask in #engineering or #support-tickets for guidance.
+
+## Handling Spam
+
+Common spam includes booth design offers and unsolicited sales pitches. For these:
+
+1. Do not reply
+2. Close the ticket in HubSpot
+3. Delete the notification from #support-tickets to reduce noise


### PR DESCRIPTION
## Description

Add new handbook page documenting support triage duty procedures and update the support index page to link to it.

Documents the first-line monitoring role for incoming support requests.

## Related Issue(s)

N/A - internal documentation addition

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
- [x] I have considered the performance impact of these changes
- [ ] ~~Suitable unit/system level tests have been added and they pass~~ (not applicable - docs only)
- [x] Documentation has been updated
- [ ] ~~For blog PRs, an Art Request has been created~~ (not a blog PR)