### PR TITLE
handbook: Update Slack links to our rename workspace

### DIFF
--- a/src/handbook/development/support/index.md
+++ b/src/handbook/development/support/index.md
@@ -6,7 +6,7 @@ navTitle: Support
 
 ## Support Tickets 
 
-Support tickets can be opened via the [FlowFuse Support Portal](/support). FlowFuse employees will be notified of support ticket and chat traffic via the [FlowFuse Support Slack channel](https://flowforgeworkspace.slack.com/archives/C031K13FLDD).
+Support tickets can be opened via the [FlowFuse Support Portal](/support). FlowFuse employees will be notified of support ticket and chat traffic via the [FlowFuse Support Slack channel](https://flowfuse.slack.com/archives/C031K13FLDD).
 
 ## SLAs
 

--- a/src/handbook/development/support/triage.md
+++ b/src/handbook/development/support/triage.md
@@ -18,7 +18,7 @@ Both appear in the [HubSpot helpdesk](https://app-eu1.hubspot.com/help-desk/2658
 ## Monitoring
 
 - **HubSpot**: Keep the helpdesk open in a browser tab
-- **Slack**: New tickets trigger a notification in [#support-tickets](https://flowforgeworkspace.slack.com/archives/C031K13FLDD)
+- **Slack**: New tickets trigger a notification in [#support-tickets](https://flowfuse.slack.com/archives/C031K13FLDD)
 
 ## Triage Categories
 
@@ -26,9 +26,9 @@ When a new ticket comes in, categorize it, answer the question directly, or rout
 
 | Category | Action |
 |----------|--------|
-| Sales inquiry | Route to [#dept-sales](https://flowforgeworkspace.slack.com/archives/C05GYH95NJZ) team |
+| Sales inquiry | Route to [#dept-sales](https://flowfuse.slack.com/archives/C05GYH95NJZ) team |
 | Billing inquiry | Route to DRI for Finance |
-| Product support | Route to [#dept-engineering](https://flowforgeworkspace.slack.com/archives/C032Q63FGG1) team |
+| Product support | Route to [#dept-engineering](https://flowfuse.slack.com/archives/C032Q63FGG1) team |
 | Spam (e.g., booth design offers) | Close ticket without responding, delete Slack notification |
 
 ## Key Points

--- a/src/handbook/development/support/troubleshooting.md
+++ b/src/handbook/development/support/troubleshooting.md
@@ -14,7 +14,7 @@ Below are sections for common areas that we see in support tickets. Whilst it is
 
 #### FlowFuse Cloud
 
-Any outages or major issues on FlowFuse Cloud are tracked, and automatically logged in the [#ops-cloud](https://flowforgeworkspace.slack.com/archives/C03BXLH9HP1) Slack channel. You can then consult the [FlowFuse Cloud Incident Playbook](https://docs.google.com/document/d/1NMPWEFgHkVNN7RqHXUgijEGdNwZH-SlaAspOQr9Vg9k/edit?tab=t.0#heading=h.a7jq4bkz66hv) in order to take the relevant actions in debugging the raised issues.
+Any outages or major issues on FlowFuse Cloud are tracked, and automatically logged in the [#ops-cloud](https://flowfuse.slack.com/archives/C03BXLH9HP1) Slack channel. You can then consult the [FlowFuse Cloud Incident Playbook](https://docs.google.com/document/d/1NMPWEFgHkVNN7RqHXUgijEGdNwZH-SlaAspOQr9Vg9k/edit?tab=t.0#heading=h.a7jq4bkz66hv) in order to take the relevant actions in debugging the raised issues.
 
 #### FlowFuse Self-Hosted
 

--- a/src/handbook/marketing/index.md
+++ b/src/handbook/marketing/index.md
@@ -40,7 +40,7 @@ Each of these metrics is reported on weekly during our Marketing Team Meeting to
 
 ## Contact us
 
-Questions can be asked in the [#dept-marketing](https://flowforgeworkspace.slack.com/archives/C05GYH95NJZ).
+Questions can be asked in the [#dept-marketing](https://flowfuse.slack.com/archives/C05GYH95NJZ).
 
 ## Further Reading
 

--- a/src/handbook/peopleops/hiring/index.md
+++ b/src/handbook/peopleops/hiring/index.md
@@ -74,7 +74,7 @@ FlowFuse, and hurts our reputation.
 
 ## Internal Communication of the job
 
-Once a new headcount request has been approved, it must be announced in the company’s Slack channel [#announcements](https://flowforgeworkspace.slack.com/archives/C06EQCXUGA3) so that the entire team is aware of the open position and our current hiring needs. This ensures transparency and encourages involvement in the hiring process.
+Once a new headcount request has been approved, it must be announced in the company’s Slack channel [#announcements](https://flowfuse.slack.com/archives/C06EQCXUGA3) so that the entire team is aware of the open position and our current hiring needs. This ensures transparency and encourages involvement in the hiring process.
 Team members are invited to share the job posting within their personal networks if they know someone who matches the role’s requirements and embodies the FlowFuse culture. Referrals are highly encouraged and, if the recommended candidate is hired and successfully completes three months in the role, the referring employee [will earn a bonus](/handbook/peopleops/hiring/#referrals). 
 
 ## Advertising a Role
@@ -173,7 +173,7 @@ you should immediately:
    * Important note: If the EOR with Deel is a new one, we need to ask Deel to initiate the IP Transfer process. The existing EORs include: India, Germany, Canada, UK, and Spain. We also have it in place in the US, but as of October 1, 2025 US team members are employed via a PEO.
    * Add Equity to the offer according to [the Equity guidelines](/handbook/peopleops/compensation/#equity)
 1. Invite the prospective employee to join Deel, assign them to their designated department, and deliver their offer letters through the Deel platform.
-1. Announce it to the rest of the team on Slack in the [#announcements channel](https://flowforgeworkspace.slack.com/archives/C06EQCXUGA3)
+1. Announce it to the rest of the team on Slack in the [#announcements channel](https://flowfuse.slack.com/archives/C06EQCXUGA3)
 1. [Create an onboarding issue](https://github.com/FlowFuse/admin/issues/new/choose){rel="nofollow"} on the admin GitHub project
 1. Send the candidates the Modified PIIAA Agreement. It is stored in the FlowFuse Admin Drive in the Legal > IP Folder. There are different templates for different countries. If it is the first time hiring in the country, we will need to engage Legal to create the template. Make sure to ask them to have local counsel review.
   

--- a/src/handbook/sales/customer-success.md
+++ b/src/handbook/sales/customer-success.md
@@ -163,7 +163,7 @@ platform. We can give each FlowFuse team member access to HubSpot by assigning
 them a seat.
 
 If you wish to be granted access to HubSpot please post in the FlowFuse
-[#support-tickets](https://flowforgeworkspace.slack.com/archives/C031K13FLDD)
+[#support-tickets](https://flowfuse.slack.com/archives/C031K13FLDD)
 Slack channel.
 
 Whenever a customer raises a new ticket, a message is posted into slack

--- a/src/handbook/sales/index.md
+++ b/src/handbook/sales/index.md
@@ -31,7 +31,7 @@ customer expansion, and customer success. This includes:
 
 ## Contact us
 
-Questions can be asked in the [#dept-sales](https://flowforgeworkspace.slack.com/archives/C05GYH95NJZ).
+Questions can be asked in the [#dept-sales](https://flowfuse.slack.com/archives/C05GYH95NJZ).
 
 ## How we work
 


### PR DESCRIPTION
As Slack uses unique IDs per channel, only the first part of the URL needs updating.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

