### PR TITLE
Blog: Kepware Isn't the Only Option — And Now It's the Riskier One

### DIFF
--- a/src/blog/2026/01/kepware-opcua-better-alternative.md
+++ b/src/blog/2026/01/kepware-opcua-better-alternative.md
@@ -4,7 +4,7 @@ subtitle: "Why per-tag pricing, scale penalties, and private-equity ownership ch
 description: "Kepware became the default when industrial connectivity was hard. Today, its pricing model, scaling costs, and private-equity ownership make it a growing risk. Here's why it's time to re
 -evaluate."
 date: 2026-01-16
-keywords: 
+keywords: kepware alternatives, opc ua server, industrial connectivity, per-tag pricing, plc data integration, industrial middleware, ot-it convergence
 authors: ["sumit-shinde"]
 image: 
 tags:


### PR DESCRIPTION
## Description

This blog questions why industrial teams still default to Kepware when the technical barriers that made it necessary disappeared, while per-tag pricing and TPG's $600M acquisition added new costs and risks.

Pushes readers to re-evaluate based on changed fundamentals—not inertia—before losing negotiating leverage.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

