### PR TITLE
Improve support triage documentation

### DIFF
--- a/src/handbook/development/support/triage.md
+++ b/src/handbook/development/support/triage.md
@@ -19,6 +19,7 @@ Both appear in the [HubSpot helpdesk](https://app-eu1.hubspot.com/help-desk/2658
 
 - **HubSpot**: Keep the helpdesk open in a browser tab
 - **Slack**: New tickets trigger a notification in [#support-tickets](https://flowfuse.slack.com/archives/C031K13FLDD)
+  - **Note**: To get badge notifications (like mentions) for this channel, configure it in the channel's notification preferences—not just the bell icon button
 
 ## Triage Categories
 
@@ -37,6 +38,7 @@ When a new ticket comes in, categorize it, answer the question directly, or rout
 - **Ticket ownership**: Whoever replies first becomes the ticket owner and receives future notifications for that ticket.
 - **Already assigned tickets**: If a ticket already has an owner, you don't need to intervene—unless it's been unresponded for 24+ hours, then give the owner a nudge.
 - **When unsure**: Ask in #engineering or #support-tickets for guidance.
+- **Do NOT merge tickets in HubSpot**: Merged tickets become unsearchable and disappear from the inbox. They're only accessible via direct URL afterward. This is a [known HubSpot limitation](https://community.hubspot.com/t5/HubSpot-Ideas/Search-the-MERGED-Ticket-Data/idi-p/330641). Keep tickets separate to maintain searchability and visibility.
 
 ## Handling Spam
 


### PR DESCRIPTION
## Description

This PR improves the support triage documentation with two important additions:

1. **Slack notification configuration**: Added a note under the Monitoring section explaining that Slack badge notifications (like mentions) for the support tickets channel require configuration in the channel's notification preferences, not just the bell icon button.

2. **HubSpot ticket merging warning**: Added a warning in the Key Points section about the destructive nature of merging tickets in HubSpot. Merged tickets become unsearchable and disappear from the inbox, only accessible via direct URL. This is a [known HubSpot limitation](https://community.hubspot.com/t5/HubSpot-Ideas/Search-the-MERGED-Ticket-Data/idi-p/330641).

## Related Issue(s)

N/A - Documentation improvement based on team learnings

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))