### PR TITLE
Add Slack emoji reaction conventions to support triage

### DIFF
--- a/src/handbook/development/support/triage.md
+++ b/src/handbook/development/support/triage.md
@@ -21,6 +21,15 @@ Both appear in the [HubSpot helpdesk](https://app-eu1.hubspot.com/help-desk/2658
 - **Slack**: New tickets trigger a notification in [#support-tickets](https://flowfuse.slack.com/archives/C031K13FLDD)
   - **Note**: To get badge notifications (like mentions) for this channel, configure it in the channel's notification preferences—not just the bell icon button
 
+## Slack Emoji Reactions
+
+When you see a ticket notification in [#support-tickets](https://flowfuse.slack.com/archives/C031K13FLDD), use emoji reactions to indicate status:
+
+- 👀 (`:eyes:`) - You're on it
+- ✅ (`:white_check_mark:`) - Issue has been dealt with
+
+This helps the team quickly see which tickets are being handled without cluttering the channel with status messages.
+
 ## Triage Categories
 
 When a new ticket comes in, categorize it, answer the question directly, or route accordingly. Some initial guidance:


### PR DESCRIPTION
## Description

Documents the emoji usage conventions for tracking ticket status in the #support-tickets Slack channel, as mentioned by Jamie in the retrospective:

- 👀 (`:eyes:`) - You're on it (indicates someone is handling the ticket)
- ✅ (`:white_check_mark:`) - Issue has been dealt with (ticket resolved)

This helps the team quickly see which tickets are being handled without cluttering the channel with status messages.

## Related Issue(s)

Came from team retrospective feedback.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))