### PR TITLE
Add 🎥 emoji convention for Google Meet calendar entries

### DIFF
--- a/src/handbook/operations/index.md
+++ b/src/handbook/operations/index.md
@@ -28,6 +28,19 @@ or go bankrupt a table is maintained with where to go in case of service disrupt
 | [Google Appointment Schedules](https://support.google.com/calendar/answer/10729749?hl=en) | Scheduling meetings with external parties | Calendly | - |
 | AWS | Hosting for FlowFuse Cloud | ? | - |
 
+## Calendar Conventions
+
+To help team members quickly identify meeting types in calendar apps and menubar tools, use these emoji conventions when creating calendar entries:
+
+- 🎥 - Google Meet meetings (add this emoji to the event title for quick visual identification)
+
+This convention is particularly helpful for:
+- Quick visual scanning in menubar calendar apps
+- Distinguishing Google Meet from Slack Huddles at a glance
+- Identifying external-facing meetings quickly
+
+**Note:** For internal face-to-face discussions, prefer Slack Huddles in public channels over Google Meet when possible, as noted in the services table above.
+
 ## Email
 
 While there are a number of email aliases and google groups used throughout the organization, there is some activities across operations, people operations, and finance management that requires that activities be done with external parties. As a redundancy, rather than use a person's individual email (e.g. zj@), we use a google group to avoid the risk of information getting lost. For example, for some government filings, we use ops@. 


### PR DESCRIPTION
## Description

Adds a new Calendar Conventions section to the operations handbook documenting the use of 🎥 emoji for Google Meet calendar entries. This helps team members quickly identify meeting types in menubar apps and calendar tools, and distinguishes Google Meet from Slack Huddles at a glance.

Following discussion in the engineering meeting on January 19, 2026, this standardizes our approach to calendar entry formatting.

## Related Issue(s)

N/A - Documentation improvement from engineering meeting discussion

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [x] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))