### PR TITLE
Add FlowFuse/product repository to operations index

### DIFF
--- a/src/handbook/operations/index.md
+++ b/src/handbook/operations/index.md
@@ -60,6 +60,7 @@ The Engineering team maintains a large number of repositories related to individ
 | FlowFuse/customer | Task management for events and customer-specific work; webinars, artwork requests | private |
 | FlowFuse/dev-env | FlowFuse development environment tooling | public |
 | FlowFuse/flowfuse | The core product code repository| public |
+| FlowFuse/product | A higher level planning and strategising repository for FlowFuse | private |
 | FlowFuse/node-red | A planning repository for upstream Node-RED tasks | private |
 
 To create a new repository, first open an issue in the [Admin](https://github.com/FlowFuse/admin) repository using the New Repository checklist. This ensures all required security controls are applied.


### PR DESCRIPTION
Add product to the list of core repos

## Description

Add FlowFuse/product repository to operations index

## Related Issue(s)

None, coming from product planning meeting and request from Nick: https://flowfuse.slack.com/archives/D09N2N8SMHA/p1769098790562319

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

