### PR TITLE
Add GitHub Deployments sync for Netlify previews

### DIFF
--- a/.github/workflows/netlify-deployment-status.yml
+++ b/.github/workflows/netlify-deployment-status.yml
@@ -1,0 +1,45 @@
+name: Sync Netlify Deployments to GitHub
+
+on:
+  status
+
+permissions:
+  deployments: write
+  statuses: read
+  contents: read
+
+jobs:
+  sync-deployment:
+    # Only run for Netlify deploy-preview status on success
+    if: |
+      github.event.context == 'netlify/flowforge-website/deploy-preview' &&
+      github.event.state == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub Deployment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Create deployment object
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.sha,
+              environment: 'Preview',
+              description: 'Netlify Preview Deployment',
+              auto_merge: false,
+              required_contexts: [],
+              transient_environment: true,
+              production_environment: false
+            });
+
+            // Update deployment status
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.data.id,
+              state: 'success',
+              environment_url: '${{ github.event.target_url }}',
+              description: 'Deployed to Netlify',
+              auto_inactive: true
+            });


### PR DESCRIPTION
## Description

This PR adds a GitHub Actions workflow that syncs Netlify preview deployments to GitHub's native Deployments API.

### The Problem

Netlify does not natively create GitHub Deployment objects when deploying preview builds. While Netlify successfully posts PR comments and status checks, it does not use GitHub's Deployments API. This has been a [long-standing limitation](https://answers.netlify.com/t/deploy-preview-as-deployment-environments-on-github/93131) that Netlify has consistently declined to implement despite user requests since 2020.

As a result, GitHub's deployment UI shows "This branch has not been deployed" with "No deployments" on pull requests.

<img width="824" height="230" alt="CleanShot 2026-01-26 at 14 04 50@2x" src="https://github.com/user-attachments/assets/02eaed00-6c55-4581-9a5e-6de6a629665f" />

### How This Works

The workflow is **event-driven and automatic**:

1. Netlify deploys a preview → posts commit status to GitHub
2. GitHub fires a `status` event → triggers this workflow
3. Workflow creates a GitHub Deployment object → links to Netlify preview URL
4. GitHub UI updates → shows "Preview" environment with deployment link

**No polling, no periodic checks, no wasted Actions minutes.** The workflow only runs when Netlify posts a successful preview deployment status.

### No Conflicts

This workflow is safe and isolated:

- **Per-PR isolation**: Each PR gets its own deployment object based on unique commit SHAs
- **Multiple PRs**: Work independently without interference
- **Multiple commits**: Old deployments are automatically marked inactive
- **Existing workflows**: Uses separate `status` event trigger, doesn't affect other workflows
- **Production deployments**: Only affects preview deployments (filtered by Netlify context)

### Minimal Permissions

The workflow has restricted permissions:
- `deployments: write` - Only creates deployment metadata
- `statuses: read` - Only reads Netlify status checks
- `contents: read` - Only reads repository info

Cannot modify code, push commits, or access secrets.

## Related Issue(s)

Resolves the issue where GitHub's deployment UI shows "No deployments" despite Netlify successfully deploying preview builds.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))