### PR TITLE
fix: Use correct commit SHA in Netlify deployment workflow

### DIFF
--- a/.github/workflows/netlify-deployment-status.yml
+++ b/.github/workflows/netlify-deployment-status.yml
@@ -24,7 +24,7 @@ jobs:
             const deployment = await github.rest.repos.createDeployment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: context.sha,
+              ref: '${{ github.event.sha }}',
               environment: 'Preview',
               description: 'Netlify Preview Deployment',
               auto_merge: false,


### PR DESCRIPTION
## Description

Fixes a critical bug in the Netlify deployment sync workflow introduced in #4459.

### Problem

The workflow was creating GitHub Deployment objects for the wrong commits. When a PR received a Netlify preview deployment, the workflow would create a deployment for the main branch commit instead of the PR's commit SHA.

### Root Cause

Line 27 used `context.sha` (the workflow run's SHA, always main for `status` events) instead of `github.event.sha` (the actual commit that received the status update).

### Impact

GitHub showed "No deployments" on PRs despite successful Netlify previews, making the feature completely ineffective.

### Fix

Changed `ref: context.sha` to `ref: '${{ github.event.sha }}'` so deployments are attached to the correct commits and appear on their respective PRs.

### Evidence of Bug

- Workflow triggered 3 times since merge
- All 3 deployments created for main branch commits (e.g., `595fa90`)
- Zero deployments appear on actual PRs (e.g., PR #4461 shows "No deployments")

## Related Issue(s)

Fixes the bug introduced in #4459. Related to the question raised in #4461.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))