### PR TITLE
Add redirect for updated flowfuse expert link

### DIFF
--- a/src/_includes/core-nodes/comment-use-case.md
+++ b/src/_includes/core-nodes/comment-use-case.md
@@ -4,7 +4,7 @@ Adds documentation and explanatory notes directly within your flows.
 
 The Comment node helps document your flows by adding explanatory text that appears on the canvas. This is essential for maintaining flows over time, especially when working in teams or returning to flows after extended periods. By documenting the purpose, requirements, and logic of flow sections, you make flows more understandable, reduce interpretation errors, and speed up troubleshooting and modifications. Comments are particularly valuable for complex flows with link nodes, multi-tab workflows, or business logic that isn't obvious from the nodes alone.
 
-> If you need help documenting your flows, [FlowFuse Assistant](/docs/user/assistant/) can automatically generate documentation with Comment nodes. Simply select your flow and click the "Explain Flow" button, the AI will analyze your flow and create comprehensive documentation that you can add directly to your canvas.
+> If you need help documenting your flows, [FlowFuse Assistant](/docs/user/expert/) can automatically generate documentation with Comment nodes. Simply select your flow and click the "Explain Flow" button, the AI will analyze your flow and create comprehensive documentation that you can add directly to your canvas.
 
 ## Modes of operation
 

--- a/src/blog/2023/02/3-quick-node-red-tips-2.md
+++ b/src/blog/2023/02/3-quick-node-red-tips-2.md
@@ -43,7 +43,7 @@ We hope you found these tips useful, if you'd like to suggest some of your own t
 
 ## Enhance Efficiency with FlowFuse
 
-FlowFuse is a cloud-based platform designed to boost collaboration, security, and scalability for your Node-RED applications. It features [numerous tools and functionalities](/platform/features/) that streamline the development-to-deployment process, including one-click deployment, the [FlowFuse Assistant](/docs/user/assistant/), and other capabilities that simplify managing your Node-RED environment.
+FlowFuse is a cloud-based platform designed to boost collaboration, security, and scalability for your Node-RED applications. It features [numerous tools and functionalities](/platform/features/) that streamline the development-to-deployment process, including one-click deployment, the [FlowFuse Assistant](/docs/user/expert/), and other capabilities that simplify managing your Node-RED environment.
 
 For more tips, tricks, and professional development techniques with Node-RED, check out our recommended eBook:
 

--- a/src/blog/2023/03/why-should-you-use-node-red-function-nodes.md
+++ b/src/blog/2023/03/why-should-you-use-node-red-function-nodes.md
@@ -50,7 +50,7 @@ FlowFuse offers a robust platform for building, scaling, and securing your Node-
 
 We are constantly adding new features to make it easy to use in the enterprise where you can rapidly improve your industrial processes. The **"FlowFuse Assistant."** for example is an AI-powered tool that simplifies the creation of Function nodes. You only need to provide a prompt, and the assistant generates the Function nodes for you.
 
-For more details on using the FlowFuse Assistant, visit [the Assistants Documentation](/docs/user/assistant/).
+For more details on using the FlowFuse Assistant, visit [the Assistants Documentation](/docs/user/expert/).
 
 ## Conclusion:
 

--- a/src/blog/2023/05/chatgpt-nodered-fcn-node.md
+++ b/src/blog/2023/05/chatgpt-nodered-fcn-node.md
@@ -76,7 +76,7 @@ user at the time of the call.
 
 ## FlowFuse Assistant - No API Keys Required!
 
-Great news! You no longer need to manage OpenAI API keys or configure ChatGPT nodes. The [FlowFuse Assistant](/docs/user/assistant/) is now built directly into Node-RED on FlowFuse Cloud, making AI-powered development even easier.
+Great news! You no longer need to manage OpenAI API keys or configure ChatGPT nodes. The [FlowFuse Assistant](/docs/user/expert/) is now built directly into Node-RED on FlowFuse Cloud, making AI-powered development even easier.
 
 Available on FlowFuse Cloud, the Assistant offers:
 

--- a/src/blog/2023/06/import-modules.md
+++ b/src/blog/2023/06/import-modules.md
@@ -64,4 +64,4 @@ Within two minutes, we could wire up a node to retrieve data from our API, and t
 
 With the FlowFuse Assistant, you can leverage AI to generate Function nodes effortlessly. Just input your prompt, and the Assistant will handle the creation for you, saving time and reducing manual coding.
 
-To explore how to make the most of the FlowFuse Assistant and its capabilities, check out the [Assistants Documentation](/docs/user/assistant/).
+To explore how to make the most of the FlowFuse Assistant and its capabilities, check out the [Assistants Documentation](/docs/user/expert/).

--- a/src/blog/2025/07/connect-legacy-equipment-serial-flowfuse.md
+++ b/src/blog/2025/07/connect-legacy-equipment-serial-flowfuse.md
@@ -175,7 +175,7 @@ This transforms the string into a JSON object like:
 ```
 
 > **Tip**: You do not need to know JavaScript to use the **function** node.
-> If you are using FlowFuse, the built-in [FlowFuse Assistant](https://www.google.com/search?q=/docs/user/assistant/) can help you write function code using natural language. Simply provide a sample of the data received from your machine and describe the output you expect — the Assistant will generate the function for you.
+> If you are using FlowFuse, the built-in [FlowFuse Assistant](https://www.google.com/search?q=/docs/user/expert/) can help you write function code using natural language. Simply provide a sample of the data received from your machine and describe the output you expect — the Assistant will generate the function for you.
 
 ### Handling Request-Response Serial Communication
 

--- a/src/blog/2025/12/flowfuse-release-2-25.md
+++ b/src/blog/2025/12/flowfuse-release-2-25.md
@@ -38,7 +38,7 @@ Previously, this was only available in Node-RED managed directly by the FlowFuse
 
 You will need an account on FlowFuse Cloud to connect it to, but for this release, it does *not* require a paid subscription to use.
 
-Check the FlowFuse Expert Assistant docs for [how to get started](https://flowfuse.com/docs/user/assistant/#flowfuse-assistant-plugin).
+Check the FlowFuse Expert Assistant docs for [how to get started](https://flowfuse.com/docs/user/expert/#flowfuse-assistant-plugin).
 
 ## Improved Update Scheduling
 ![Image of Scheduled Updates UI](./images/updates.png)

--- a/src/handbook/sales/customer-success.md
+++ b/src/handbook/sales/customer-success.md
@@ -350,7 +350,7 @@ should happen without customers even noticing.
    providing personalized help to ensure a smooth process.
 
 ## Handling Requests from Self-Hosted Customers to Enable FlowFuse Assistant
-The [FlowFuse Assistant](https://flowfuse.com/docs/user/assistant/#flowfuse-assistant-plugin) is enabled by default for Cloud customers. Self-hosted customers can use it, too, but must request access through support. 
+The [FlowFuse Assistant](https://flowfuse.com/docs/user/expert/#flowfuse-assistant-plugin) is enabled by default for Cloud customers. Self-hosted customers can use it, too, but must request access through support. 
 
 When a customer requests access to the FlowFuse Assistant, do the following:
 1. Route the request to Engineering

--- a/src/node-red/getting-started/programming/debugging-flows.md
+++ b/src/node-red/getting-started/programming/debugging-flows.md
@@ -14,7 +14,7 @@ When it comes to debugging application flows in Node-RED, the tool most Node-RED
 
 In these cases, using the **Node-RED Debugger** becomes invaluable. The debugger allows you to trace the execution of your flows interactively, set breakpoints, and gain deeper insights beyond what the Debug node offers. This Documentation will show you how to effectively use the Node-RED Debugger to pinpoint issues and fine-tune your applications.
 
-> **Tip:** If your flows aren’t named or formatted properly and you're finding it difficult to understand what they do, you can use the **[FlowFuse Assistant – Flow Explainer](/docs/user/assistant/#flow-explainer)** to automatically analyse the flow and generate clear documentation.
+> **Tip:** If your flows aren’t named or formatted properly and you're finding it difficult to understand what they do, you can use the **[FlowFuse Assistant – Flow Explainer](/docs/user/expert/#flow-explainer)** to automatically analyse the flow and generate clear documentation.
 
 ## What is Debugging, and Why is it crucial in Node-RED Flows?
 

--- a/src/redirects.njk
+++ b/src/redirects.njk
@@ -94,4 +94,4 @@ eleventyExcludeFromCollections: true
 /product/device-agent/ /platform/device-agent/ 301
 /product/dashboard/ /platform/dashboard/ 301
 https://app.flowfuse.com/account/create/ /get-started/ 301
-/docs/user/assistant/ /docs/user/expert/ 301
+/docs/user/expert/ /docs/user/expert/ 301


### PR DESCRIPTION
## Description

This PR adds a redirect for the FlowFuse Assistant link to the new URL. We made these changes in https://github.com/FlowFuse/flowfuse/pull/6571#event-22405926280.
It also updates all related links across the website. and this [PR](https://github.com/FlowFuse/flowfuse/pull/6596) specifically updates the links present in the FlowFuse documentation

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

