### PR TITLE
Switch search to new Algolia app and prevent oversized records

### DIFF
--- a/src/_includes/layouts/common-js.njk
+++ b/src/_includes/layouts/common-js.njk
@@ -23,7 +23,7 @@
 
     function initSearchBar() {
         const {autocomplete, getAlgoliaResults} = window['@algolia/autocomplete-js'];
-        const searchClient = algoliasearch('F3E37N84X4', '2e982df3f654e132b76a671c55c048df');
+        const searchClient = algoliasearch('ISKYOHIT7D', '68d4032f487d66423c37e6483e067272');
         const scopeTitles = {
             'ama': 'Ask Me Anything',
             'blog': 'Blog',
@@ -64,7 +64,7 @@
                     searchClient,
                     queries: [
                         {
-                            indexName            : 'netlify_prod',
+                            indexName            : 'prod_netlify',
                             params               : {
                                 query,
                                 hitsPerPage: hitsPerPageMap[scope], // Read specific count


### PR DESCRIPTION
## Description

This PR updates search to use the new Algolia application/index and adds protection against Algolia record-size limit errors during indexing.

- Updated frontend search client credentials to the new Algolia app
- Added record-size guard in the indexing script

## Related Issue(s)

follow up on https://github.com/FlowFuse/website/pull/4543/changes

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

