### PR TITLE
Add warm image build profile and align Netlify image cache paths

### DIFF
--- a/lib/image-handler.js
+++ b/lib/image-handler.js
@@ -4,6 +4,7 @@ const fs = require("fs")
 const eleventyImage = require("@11ty/eleventy-img")
 
 const processedImages = new Set()
+const IMAGE_BUILD_PROFILE = process.env.IMAGE_BUILD_PROFILE || "full"
 
 /**
  * Is a particular string a URL
@@ -150,8 +151,16 @@ module.exports = function imageHandler(
         }
     }
 
-    // Generate retina images
-    const imgWidths = widths.concat(widths.map((w) => (isNaN(w) ? w : w * 2))) // generate 2x sizes (retina)
+    // Warm profile for first cold builds: fewer variants, faster completion, cache still populated.
+    const warmBuild = IMAGE_BUILD_PROFILE === "warm"
+    if (warmBuild && !imgSrc.includes(".gif")) {
+        formats = ["webp", "jpeg"]
+    }
+
+    // Generate retina images in full profile only
+    const imgWidths = warmBuild
+        ? widths
+        : widths.concat(widths.map((w) => (isNaN(w) ? w : w * 2))) // generate 2x sizes (retina)
     const htmlSizes =
         sizes ||
         widths
@@ -191,6 +200,9 @@ module.exports = function imageHandler(
         widths: imgWidths,
         formats,
         outputDir: path.join(eleventyOutputFolderPath, "img"),
+        cacheOptions: {
+            directory: ".cache/images",
+        },
         filenameFormat: function (hash, src, width, format, options) {
             const { name } = path.parse(src)
             return `${name}-${hash}-${width}.${format}`

--- a/netlify.toml
+++ b/netlify.toml
@@ -79,6 +79,5 @@ package = "netlify-plugin-cache"
   [plugins.inputs]
   paths = [
     "_site/img", # Eleventy Image Disk Cache
-    ".cache" # Remote asset cache
+    ".cache/images" # Eleventy image processing cache
   ]
-


### PR DESCRIPTION
## Description

This PR reduces cold-start production build time (after cache loss/migration) without skipping image generation, so image cache can be rebuilt successfully within Netlify limits.

## Changes
- Added a temporary image build profile in `/lib/image-handler.js`:
  - `IMAGE_BUILD_PROFILE=warm` generates fewer variants:
    - formats: `webp`, `jpeg` (no `avif`)
    - widths: no retina `2x` expansion
  - default remains `full` (existing behavior unchanged).
- Aligned Eleventy image cache path with Netlify cache plugin:
  - `cacheOptions.directory = ".cache/images"` in `/lib/image-handler.js`.
- Updated Netlify cache plugin paths in `/netlify.toml`:
  - from `".cache"` to `".cache/images"` (plus existing `"_site/img"`).

## Why
After Netlify environment/cache reset, production builds start cold and image generation can exceed the 30-minute limit.  
`warm` profile keeps image pipeline enabled (so cache is populated) while reducing per-image processing cost enough to complete initial builds.

## Rollout plan
1. Merge this PR.
2. In Netlify production env vars, set:
   - `IMAGE_BUILD_PROFILE=warm`
3. Run 1–2 production deploys to repopulate cache.
4. Remove `IMAGE_BUILD_PROFILE` to return to default `full` quality/variants.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

