### PR TITLE
Follow-up: stabilize Netlify cold production builds with warm image profile

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -28,6 +28,9 @@ const eleventyNavigationPlugin = require("@11ty/eleventy-navigation");
 // Skip slow optimizations when developing i.e. serve/watch or Netlify deploy preview
 const DEV_MODE = process.env.ELEVENTY_RUN_MODE !== "build" || process.env.CONTEXT === "deploy-preview" || process.env.SKIP_IMAGES === 'true'
 const DEPLOY_PREVIEW = process.env.CONTEXT === "deploy-preview";
+const IMAGE_BUILD_PROFILE = process.env.IMAGE_BUILD_PROFILE || "full";
+
+console.info(`[11ty] Image build profile: ${IMAGE_BUILD_PROFILE}`)
 
 module.exports = function(eleventyConfig) {
     let searchIndexItems = [];

--- a/netlify.toml
+++ b/netlify.toml
@@ -74,6 +74,9 @@ command = "npm run build"
 [context.branch-deploy]
 command = "npm run build"
 
+[context.production.environment]
+IMAGE_BUILD_PROFILE = "warm"
+
 [[plugins]]
 package = "netlify-plugin-cache"
   [plugins.inputs]


### PR DESCRIPTION

## Description

Follow-up to fix Netlify production timeouts after cache loss/migration by reducing first-run image processing cost while still generating images (no `SKIP_IMAGES`).

## Rollout
1. Merge this PR and run production deploy(s) until cache is populated.
2. Confirm logs include `Image build profile: warm`.
3. Remove the production override (`IMAGE_BUILD_PROFILE = "warm"`) to return to default `full` generation behavior.

## Related Issue(s)

https://github.com/FlowFuse/website/pull/4571

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

