### PR TITLE
Remove temporary warm image override and restore default full image profile

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -74,9 +74,6 @@ command = "npm run build"
 [context.branch-deploy]
 command = "npm run build"
 
-[context.production.environment]
-IMAGE_BUILD_PROFILE = "warm"
-
 [[plugins]]
 package = "netlify-plugin-cache"
   [plugins.inputs]


### PR DESCRIPTION
## Description

This PR removes the temporary Netlify production override that forced `IMAGE_BUILD_PROFILE=warm`.

## Changes
- Removed:
  - `[context.production.environment]`
  - `IMAGE_BUILD_PROFILE = "warm"`
- Kept cache configuration unchanged:
  - `_site/img`
  - `.cache/images`

## Why
The warm profile was a temporary mitigation to survive cold-cache builds.  
Now that build limits/cache are stabilized, production should return to the default image behavior (`full`) without a hardcoded override in `netlify.toml`.

## Expected result
- Production builds use default `full` profile again.
- Existing image cache paths remain in place for faster subsequent builds.

## Related Issue(s)

https://github.com/FlowFuse/website/issues/4574

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

