### PR TITLE
fix: documentation sidebar items ordering

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -849,16 +849,20 @@ module.exports = function(eleventyConfig) {
                     return (a.order - b.order) || a.name.localeCompare(b.name)
                 }
 
+                function sortTree (node) {
+                    if (!node || !node.children || !Array.isArray(node.children)) {
+                        return
+                    }
+
+                    node.children.sort(sortChildren)
+                    node.children.forEach(sortTree)
+                }
+
                 nav[tag].groups = Object.values(groups).sort(sortChildren)
 
                 nav[tag].groups.forEach((group) => {
                     if (group.children) {
-                        group.children.forEach((child) => {
-                            if (child.children) {
-                                child.children.sort(sortChildren)
-                            }
-                        })
-                        group.children.sort(sortChildren)
+                        sortTree(group)
                     }
                 })
             }


### PR DESCRIPTION
## Description

This pull request adds a recursive sort step that walks the navigation tree and sorts every children array at every depth using the existing sort rule. This makes sidebar ordering deterministic for all nested levels.

## Related Issue(s)

Closes https://github.com/FlowFuse/website/issues/4592

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
