### PR TITLE
fix: restore DEV_MODE guard

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -153,6 +153,7 @@ eleventyComputed:
 
     <script type="module" src="/js/flowrenderer.min.js"></script>
 
+    {%- if not DEV_MODE -%}
     <!-- Google Consent -->
     <script>
         window.dataLayer = window.dataLayer || [];
@@ -221,6 +222,7 @@ eleventyComputed:
         var _hsq = window._hsq = window._hsq || [];
         _hsq.push(['doNotTrack']);
     </script>
+    {%- endif -%}
 </head>
 <body class="font-sans ff-website leading-normal tracking-normal gradient text-gray-500 min-h-screen flex flex-col">
     <!-- Google Tag Manager (noscript) -->
@@ -400,6 +402,7 @@ eleventyComputed:
 <script async src="https://cdn.jsdelivr.net/npm/lite-youtube-embed@0.2.0/src/lite-yt-embed.min.js"></script>
 <link rel="preload" href="https://cdn.jsdelivr.net/npm/lite-youtube-embed@0.2.0/src/lite-yt-embed.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
+{%- if not DEV_MODE -%}
 <!-- PostHog -->
 <script type="text/javascript">
     const getMyCookieValue = (name) => (
@@ -577,4 +580,5 @@ eleventyComputed:
         addHubSpotConsentListener();
     });
 </script>
+{%- endif -%}
 </html>


### PR DESCRIPTION
## Description

Tracking and consent scripts (GTM, Google Consent Mode, PostHog, HubSpot, Warmly) should not load in development mode. The guard was inadvertently dropped before merging the cookie consent PR.

## Related Issue(s)

https://github.com/FlowFuse/website/pull/4590

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

