### PR TITLE
 HubSpot meetings calendar consent gating

### DIFF
--- a/src/_includes/base.js
+++ b/src/_includes/base.js
@@ -72,8 +72,9 @@ function hsFallback (element) {
         errorSection.innerHTML = `
                 <p style="color: #6366f1;"><strong>Hmm… there was supposed to be a form here.</strong></p>
                 <p>
-                    If you’re using strict privacy settings or navigating in private mode, it might be blocked.
-                    Try adjusting your settings or switching browsers to continue.
+                    It might be blocked by your browser or privacy settings. Try
+                    <button onclick="if(window.CookieConsent){CookieConsent.showPreferences()}" style="background:none;border:none;color:#6366f1;cursor:pointer;padding:0;font-size:inherit;text-decoration:underline;">updating your cookie preferences</button>,
+                    adjusting your privacy settings, or switching browsers to continue.
                 </p>
             `;
         element.parentNode.insertBefore(errorSection, element.nextSibling);

--- a/src/_includes/hubspot/hs-book-meeting.njk
+++ b/src/_includes/hubspot/hs-book-meeting.njk
@@ -1,2 +1,33 @@
-<div class="meetings-iframe-container -mb-20 md:-mb-6" data-src="{{ hubspot.dataSrc }}"></div>
-<script type="text/javascript" src="https://static.hsappstatic.net/MeetingsEmbed/ex/MeetingsEmbedCode.js" onerror="hsFallback(this)"></script>
+<div id="meetings-consent-placeholder" class="text-center border border-indigo-300 rounded-lg bg-white px-4 py-10">
+    <p style="color: #6366f1;"><strong>Enable cookies to book a meeting</strong></p>
+    <p class="text-gray-600">To load the booking calendar, please accept <strong>Functional cookies</strong>.</p>
+    <p class="mt-4">
+        <button
+            onclick="CookieConsent.showPreferences()"
+            class="inline-block px-4 py-2 rounded-lg border border-indigo-400 text-indigo-600 hover:bg-indigo-50 transition-colors cursor-pointer bg-transparent text-sm font-medium"
+        >
+            Open cookie settings
+        </button>
+    </p>
+</div>
+<script>
+    window._ffLoadMeetings = function () {
+        var placeholder = document.getElementById('meetings-consent-placeholder');
+        if (!placeholder) return;
+
+        var parent = placeholder.parentNode;
+
+        var container = document.createElement('div');
+        container.className = 'meetings-iframe-container -mb-20 md:-mb-6';
+        container.setAttribute('data-src', '{{ hubspot.dataSrc }}');
+        parent.insertBefore(container, placeholder);
+
+        var script = document.createElement('script');
+        script.src = 'https://static.hsappstatic.net/MeetingsEmbed/ex/MeetingsEmbedCode.js';
+        script.onerror = function () { hsFallback(script); };
+        parent.insertBefore(script, placeholder);
+
+        placeholder.remove();
+        window._ffLoadMeetings = null;
+    };
+</script>

--- a/src/js/cookieconsent-config.js
+++ b/src/js/cookieconsent-config.js
@@ -90,8 +90,15 @@ CookieConsent.run({
                 'event_label': 'denied'
             });
         }
+
+        if(CookieConsent.acceptedCategory('functional')){
+            // Load HubSpot meetings embed if present on this page
+            if (typeof window._ffLoadMeetings === 'function') {
+                window._ffLoadMeetings();
+            }
+        }
     },
-    
+
     onChange: function({changedCategories}){
         if(changedCategories.includes('analytics')){
             if(CookieConsent.acceptedCategory('analytics')){
@@ -157,6 +164,15 @@ CookieConsent.run({
                 });
             }
         }
+
+        if(changedCategories.includes('functional')){
+            if(CookieConsent.acceptedCategory('functional')){
+                // Load HubSpot meetings embed if present on this page
+                if (typeof window._ffLoadMeetings === 'function') {
+                    window._ffLoadMeetings();
+                }
+            }
+        }
     },
 
     categories: {
@@ -199,7 +215,7 @@ CookieConsent.run({
                         },
                         {
                             title: "Functional Cookies",
-                            description: "These cookies enable functional features on our website, such as the live chat support widget. Enabling these cookies allows you to use the chat to get help from our team.",
+                            description: "These cookies enable functional features on our website, such as the live chat support widget and the booking calendar. Enabling these cookies allows you to chat with our team and schedule meetings directly on our site.",
                             linkedCategory: "functional"
                         },
                         {


### PR DESCRIPTION
## Description

The embed on /book-demo (and /landing/tulip) loads inside a HubSpot-owned iframe which fires its own tracking pixels regardless of our consent state. The fix is to conditionally render the iframe only when functional consent is accepted.

### Before accepting cookies (GDPR)
<img width="1250" height="1016" alt="HS_before-accepting" src="https://github.com/user-attachments/assets/8e98c00c-c762-4a91-94c9-3166caf12779" />
<img width="1222" height="496" alt="HS_before-accepting_network" src="https://github.com/user-attachments/assets/873840f7-ca32-48ba-a6f3-56d664b13d97" />


### After accepting cookies
<img width="1252" height="1081" alt="HS_after-accepting" src="https://github.com/user-attachments/assets/03b654c7-b5e1-466b-93b3-c517e241c8c0" />
<img width="1220" height="713" alt="HS_after-accepting_network" src="https://github.com/user-attachments/assets/732f0f7e-491b-4a62-a578-ce107bc1a067" />


## Related Issue(s)

https://github.com/FlowFuse/website/pull/4590

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

