### PR TITLE
Replace youtube iframes for lite-youtube

### DIFF
--- a/src/_includes/layouts/webinar.njk
+++ b/src/_includes/layouts/webinar.njk
@@ -27,7 +27,7 @@ layout: layouts/base.njk
                     Back to Webinars
                 </a>
                 {% if video %}
-                    <iframe width="706" height="397" class="mb-4" src="https://www.youtube.com/embed/{{video}}?rel=0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                    <lite-youtube videoid="{{ video }}" params="rel=0" class="mb-4" style="width: 706px; max-width: 100%; height: 397px;" title="{{ title }} - YouTube video"></lite-youtube>
                 {% else %}
                     {% if image %}
                     <div class="max-w-[706px] mb-6">

--- a/src/blog/2022/01/flowforge-01-released.md
+++ b/src/blog/2022/01/flowforge-01-released.md
@@ -34,7 +34,7 @@ With the 0.1 release, we have the basic building blocks of the platform in place
 For a more complete walk-through of the platform in this early release, you can
 watch this video.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/YYZDx8n17Ys" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<lite-youtube videoid="YYZDx8n17Ys" params="rel=0" style="width: 100%; height: 315px;" title="YouTube video player"></lite-youtube>
 
 
 ### Getting started with FlowFuse

--- a/src/blog/2022/02/flowforge-02-released.md
+++ b/src/blog/2022/02/flowforge-02-released.md
@@ -42,7 +42,7 @@ The documentation provides a guide for [installing FlowFuse on a local server](h
 If you haven't played with FlowFuse 0.1 yet, here's a more complete walk-through
 of the platform:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/YYZDx8n17Ys" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<lite-youtube videoid="YYZDx8n17Ys" params="rel=0" style="width: 100%; height: 315px;" title="YouTube video player"></lite-youtube>
 
 ### Upgrading FlowFuse
 

--- a/src/blog/2022/03/flowforge-03-released.md
+++ b/src/blog/2022/03/flowforge-03-released.md
@@ -81,7 +81,7 @@ The documentation provides a guide for [installing FlowFuse on a local server](h
 If you haven't played with FlowFuse yet, here's a more complete walk-through
 of the platform:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/YYZDx8n17Ys" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<lite-youtube videoid="YYZDx8n17Ys" params="rel=0" style="width: 100%; height: 315px;" title="YouTube video player"></lite-youtube>
 
 ### Upgrading FlowFuse
 

--- a/src/blog/2022/04/flowforge-04-released.md
+++ b/src/blog/2022/04/flowforge-04-released.md
@@ -54,7 +54,7 @@ The documentation provides a guide for [installing FlowFuse on a local server](/
 If you haven't played with FlowFuse yet, here's a more complete walk-through
 of the platform:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/YYZDx8n17Ys" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<lite-youtube videoid="YYZDx8n17Ys" params="rel=0" style="width: 100%; height: 315px;" title="YouTube video player"></lite-youtube>
 
 ### Upgrading FlowFuse
 

--- a/src/blog/2023/01/flowforge-1-3-0-released.md
+++ b/src/blog/2023/01/flowforge-1-3-0-released.md
@@ -25,17 +25,17 @@ To make it easy for everyone to experience FlowFuse, we are introducing a new [f
 [Share your flows via team libraries](https://github.com/FlowFuse/flowfuse/issues/237) \
 FlowFuse has now added the ability for you to share your flows via the import and export features in Node-RED. Once you export a flow everyone else in your FlowFuse team will be able to import your work into their projects. You can see a demonstration of this new feature in [the video](https://youtu.be/B7XK3TUklUU) below.
 
-<div><iframe width="560" height="315" src="https://www.youtube.com/embed/B7XK3TUklUU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<div><lite-youtube videoid="B7XK3TUklUU" params="rel=0" style="width: 100%; height: 315px;" title="YouTube video player"></lite-youtube>
 
 [Control access to your Node-RED dashboards using FlowFuse credentials](https://github.com/FlowFuse/flowfuse/issues/1325) \
 In FlowFuse 0.10 we added the ability to secure endpoints created within your FlowFuse projects. This allows you to create dashboards or APIs and limit who can access them. In 1.3 we've added the ability for you to limit access to those same resources based on the visitor having a user account on your FlowFuse team. You can see a demonstration of this new feature in [the video](https://youtu.be/JRk-Cf7eNIo) below.
 
-<div><iframe width="560" height="315" src="https://www.youtube.com/embed/JRk-Cf7eNIo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<div><lite-youtube videoid="JRk-Cf7eNIo" params="rel=0" style="width: 100%; height: 315px;" title="YouTube video player"></lite-youtube>
 
 [Filter your audit logs for easier reading](https://github.com/FlowFuse/flowfuse/issues/1448) \
 In FlowFuse 1.3 we’ve added the ability to filter your admin logs by user or action type. We think this is a great new feature which will help admins have confidence that they will be able to review the audit logs quickly when needed. You can see a demonstration of this new feature in [the video](https://youtu.be/p0Vuy5x42Go) below.
 
-<div><iframe width="560" height="315" src="https://www.youtube.com/embed/p0Vuy5x42Go" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<div><lite-youtube videoid="p0Vuy5x42Go" params="rel=0" style="width: 100%; height: 315px;" title="YouTube video player"></lite-youtube>
 
 ## Improvements
 

--- a/src/blog/2023/02/flowforge-1-4-0-released.md
+++ b/src/blog/2023/02/flowforge-1-4-0-released.md
@@ -28,14 +28,14 @@ To make it easy for everyone to experience FlowFuse, we are introducing a new fr
 Most prominently, FlowFuse 1.4 features automatic device onboarding for fleets. Simply download a FlowFuse device provisioning credential to allow quick roll-out to a whole fleet, without the need to have device specific configuration. When the agent starts, the FlowFuse agent and the Node-RED snapshot will automatically be provisioned to the device and start operations. [Issue #1212](https://github.com/FlowFuse/flowfuse/issues/1212)
 
 
-<div><iframe width="560" height="315" src="https://www.youtube.com/embed/XTVw4O4-Crg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<div><lite-youtube videoid="XTVw4O4-Crg" params="rel=0" style="width: 100%; height: 315px;" title="YouTube video player"></lite-youtube>
 
 **Support for Staged Development**
 
 A new feature of 1.4 is the ability to setup staged deployments. This makes it possible to simply move a project between a Development > Test > Production for your Node-RED application delivery. [Issue #1580](https://github.com/FlowFuse/flowfuse/issues/1580)
 
 
-<div><iframe width="560" height="315" src="https://www.youtube.com/embed/6QOmotlrwWw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<div><lite-youtube videoid="6QOmotlrwWw" params="rel=0" style="width: 100%; height: 315px;" title="YouTube video player"></lite-youtube>
 
 ## Improvements
 

--- a/src/blog/2023/04/flowforge-1-6-released.md
+++ b/src/blog/2023/04/flowforge-1-6-released.md
@@ -19,13 +19,13 @@ The new FlowFuse 1.6 adds new support for multi-instance Node-RED within a singl
 
 FlowFuse 1.6 expands the scope of applications to now allow for multiple instances of Node-RED. For complex Node-RED applications, it is common to have different flows interacting with other flows or flows deployed to different target environments. The ability to associate all these different flows with a single application makes it easier for the development, test and deployment of these types of complex applications.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/OHChdWeRI9Q" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<lite-youtube videoid="OHChdWeRI9Q" params="rel=0" style="width: 100%; height: 315px;" title="YouTube video player"></lite-youtube>
 
 ## Access Node-RED logs from remote devices
 
 FlowFuse makes it easy to deploy Node-RED out to remote devices. However, once Node-RED has been deployed to the remote device it is often difficult to troubleshoot or debug. Now with FlowFuse 1.6, you can get access to the Node-RED logs from remote devices. This makes it much easier to understand and debug the behavior of a remote device.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/yW1zxwiCmto" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<lite-youtube videoid="yW1zxwiCmto" params="rel=0" style="width: 100%; height: 315px;" title="YouTube video player"></lite-youtube>
 
 ## Other Improvements
 

--- a/src/blog/2023/05/flowforge-1-7-released.md
+++ b/src/blog/2023/05/flowforge-1-7-released.md
@@ -21,13 +21,13 @@ We are excited to introduce a new feature that will simplify the process of debu
 
 This update is a part of our ongoing commitment to making FlowFuse the best possible solution for developing your Node-RED flows, no matter where they're running. In fact, as part of our last release 1.6, we already introduced the feature: ["Access Node-RED logs from remote devices"](../../04/flowforge-1-6-released/#access-node-red-logs-from-remote-devices). This feature made it easy for users to troubleshoot and debug. Building on that, we've taken the next step, and it's now possible to access the Device Editor.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/zS6P3RR86vE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<lite-youtube videoid="zS6P3RR86vE" params="rel=0" style="width: 100%; height: 315px;" title="YouTube video player"></lite-youtube>
 
 ## Device Status Visualisation
 
 This FlowFuse version upgrades device monitoring. It's made easier to manage your devices effectively, especially when there's many of them. Now we offer an intuitive, user-friendly method for users to keep an eye on their devices' status and evaluate the health of their team's devices overall. Creating an overview of your fleet's health, however large your fleet might be.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/S--viuPhrS8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<lite-youtube videoid="S--viuPhrS8" params="rel=0" style="width: 100%; height: 315px;" title="YouTube video player"></lite-youtube>
 
 ## Auto Restart for Hung Node-RED Instances
 

--- a/src/blog/2023/06/flowforge-1-8-released.md
+++ b/src/blog/2023/06/flowforge-1-8-released.md
@@ -22,7 +22,7 @@ Additionally, we're pleased to offer a 30-day premium trial license for self-man
 
 High Availability is our first [preview feature](/handbook/engineering/product/versioning/#preview-features), and your feedback is crucial. We encourage you to try out HA in your Node-RED instances and share your experiences with us. Your feedback will help us refine this feature and make it even better.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/mbDkjKhVwIw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<lite-youtube videoid="mbDkjKhVwIw" params="rel=0" style="width: 100%; height: 315px;" title="YouTube video player"></lite-youtube>
 
 ## DevOps Pipelines
 
@@ -30,7 +30,7 @@ FlowFuse 1.8 introduces the concept of Pipelines to better organize your Node-RE
 
 The new Pipelines feature builds upon the Staged Development support that we introduced in[FlowFuse Version 1.4](../../02/flowforge-1-4-0-released). We highly recommend that development teams avoid developing their flows directly in production instances. This approach fosters a more reliable and robust development process, reducing the risks associated with production environment modifications. Instead, start your development in a dedicated development or test instance and then deploy your Node-RED instance to production once they have been thoroughly tested and reviewed. 
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/Pbql22f3vqY" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<lite-youtube videoid="Pbql22f3vqY" params="rel=0" style="width: 100%; height: 315px;" title="YouTube video player"></lite-youtube>
 
 ## User interface for Device Agent
 

--- a/src/blog/2024/11/esp32-with-node-red.md
+++ b/src/blog/2024/11/esp32-with-node-red.md
@@ -16,7 +16,7 @@ The ESP32 is an affordable and powerful microchip that combines Wi-Fi and Blueto
 
 <!--more-->
 
-<iframe width="100%" height="315" src="https://www.youtube.com/embed/ecfJ-9MxyVE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<lite-youtube videoid="ecfJ-9MxyVE" params="rel=0" style="width: 100%; height: 315px;" title="YouTube video player"></lite-youtube>
 
 ## Prerequisites
 

--- a/src/blog/2025/01/integrating-siemens-s7-plcs-with-node-red-guide.md
+++ b/src/blog/2025/01/integrating-siemens-s7-plcs-with-node-red-guide.md
@@ -163,7 +163,7 @@ _Configuring S7-out Node to write data to plc_
 
 6. Once your flow is set up and the s7-out node for each variable is configured, click Deploy in the top-right corner to activate the flow.
 
-<iframe width="100%" height="315" src="https://www.youtube.com/embed/AilWMNPzP1Q" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<lite-youtube videoid="AilWMNPzP1Q" params="rel=0" style="width: 100%; height: 315px;" title="YouTube video player"></lite-youtube>
 
 In the video above, the dashboard interface is built to control the stack light. At the end of this article, I will provide the complete flow for you to download.
 
@@ -204,7 +204,7 @@ Now that you have the desired format for your output data, you may want to build
 
 The video below shows the updated dashboard interface used to monitor the stack light LED status:
 
-<iframe width="100%" height="315" src="https://www.youtube.com/embed/Nlyk_BATKGE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<lite-youtube videoid="Nlyk_BATKGE" params="rel=0" style="width: 100%; height: 315px;" title="YouTube video player"></lite-youtube>
 
 Here is the flow you can import into your FlowFuse remote instance and deploy. Ensure that you have installed `node-red-contrib-s7` and `node-red-contrib-buffer-parser`. This flow includes S7 nodes for interacting with the S7 PLC and Project nodes for communicating with the FlowFuse hosted instance, where you will build the dashboard.
 

--- a/src/blog/2025/02/interacting-with-arduino-using-node-red.md
+++ b/src/blog/2025/02/interacting-with-arduino-using-node-red.md
@@ -17,7 +17,7 @@ Arduino is a popular open-source platform that lets you build cool electronics p
 
 In this guide, I’ll show you how to control and automate your Arduino remotely using Node-RED and FlowFuse, all without writing any code. We’ll use the Firmata protocol to make it easy to send commands and get data from your Arduino. By the end of this tutorial, you’ll have a simple automation setup that you can control from anywhere. Just keep in mind, the Arduino will need to be connected to the device running Node-RED!
 
-<iframe width="100%" height="315" src="https://www.youtube.com/embed/FTuxOy16nwo?si=i7wds6zH0Hpo0TTM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<lite-youtube videoid="FTuxOy16nwo" params="rel=0" style="width: 100%; height: 315px;" title="YouTube video player"></lite-youtube>
 
 ## Prerequisites
 
@@ -176,7 +176,7 @@ Below, I have provided the complete flow of how we read the IR object detection 
 [{"id":"2b871fb5d0923355","type":"arduino in","z":"FFF0000000000001","name":"Read Sensor Data","pin":"9","state":"INPUT","arduino":"d7663aaf.47194","x":130,"y":460,"wires":[["8ad3d1504ba05942"]]},{"id":"49b04d8b6f015846","type":"change","z":"FFF0000000000001","name":"","rules":[{"t":"set","p":"payload","pt":"msg","to":"true","tot":"bool"}],"action":"","property":"","from":"","to":"","reg":false,"x":530,"y":480,"wires":[["d6e251e983f908ac"]]},{"id":"8f56a3d6ac64e87c","type":"change","z":"FFF0000000000001","name":"","rules":[{"t":"set","p":"payload","pt":"msg","to":"false","tot":"bool"}],"action":"","property":"","from":"","to":"","reg":false,"x":530,"y":440,"wires":[["d6e251e983f908ac"]]},{"id":"8ad3d1504ba05942","type":"switch","z":"FFF0000000000001","name":"","property":"payload","propertyType":"msg","rules":[{"t":"eq","v":"1","vt":"num"},{"t":"else"}],"checkall":"true","repair":false,"outputs":2,"x":330,"y":460,"wires":[["8f56a3d6ac64e87c"],["49b04d8b6f015846"]]},{"id":"d6e251e983f908ac","type":"arduino out","z":"FFF0000000000001","name":"Control LED","pin":"13","state":"OUTPUT","arduino":"d7663aaf.47194","x":770,"y":460,"wires":[]},{"id":"d7663aaf.47194","type":"arduino-board","device":"COM5"}]
 {% endrenderFlow %}
 
-<iframe width="100%" height="315" src="https://www.youtube.com/embed/FTuxOy16nwo?si=i7wds6zH0Hpo0TTM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<lite-youtube videoid="FTuxOy16nwo" params="rel=0" style="width: 100%; height: 315px;" title="YouTube video player"></lite-youtube>
 
 ## Conclusion
 

--- a/src/blog/2025/02/monitoring-system-health-performance-scale-flowfuse.md
+++ b/src/blog/2025/02/monitoring-system-health-performance-scale-flowfuse.md
@@ -17,7 +17,7 @@ Edge devices are everywhere, and their numbers are skyrocketing—from 2.7 billi
 
 Tracking CPU usage, memory, and system performance helps detect potential issues early, preventing downtime and optimizing operations. In this post, we will explore how to monitor devices using Node-RED and scale this process efficiently with FlowFuse.  
 
-<iframe width="100%" height="315" src="https://www.youtube.com/embed/43te5aD1RRw?si=5X2XbER_-ZQMLZOb" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<lite-youtube videoid="43te5aD1RRw" params="rel=0" style="width: 100%; height: 315px;" title="YouTube video player"></lite-youtube>
 
 ## What is Device Health Monitoring, and Why is it Important?  
 
@@ -323,7 +323,7 @@ To learn more about DevOps pipelines, read the article: [Creating and Automating
 
 Now, you have the system data of all devices broadcasted on the topic and the device name. To monitor each device, go to the dashboard instance, copy the flow, and create copies for each device. Ensure that you replace the topic with the corresponding device name. Additionally, create a separate page for each device, assign them to separate groups, and correctly move all copied widgets into the appropriate groups. Alternatively, follow [these steps](#visualizing-data-with-the-flowfuse-dashboard) again for each device, and you will have a centralized dashboard monitoring thousands of devices live.
 
-<iframe width="100%" height="315" src="https://www.youtube.com/embed/43te5aD1RRw?si=5X2XbER_-ZQMLZOb" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<lite-youtube videoid="43te5aD1RRw" params="rel=0" style="width: 100%; height: 315px;" title="YouTube video player"></lite-youtube>
 
 ## Conclusion
 

--- a/src/blog/2025/03/flowfuse-release-2-15.md
+++ b/src/blog/2025/03/flowfuse-release-2-15.md
@@ -40,7 +40,7 @@ This new feature also integrates seamlessly ith our [Bill of Materials](https://
 
 ### Smart Schema Suggestions
 
-<iframe width="100%" height="400" src="https://www.youtube.com/embed/bNeTDJUZ1So?si=LFKiLrCrH6JUq3DH" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen style="margin-bottom: 12px;"></iframe>
+<lite-youtube videoid="bNeTDJUZ1So" params="rel=0" style="margin-bottom: 12px; width: 100%; height: 400px;" title="YouTube video player"></lite-youtube>
 
 We are very pleased to announce our new "Smart Suggestions" feature. When working with an MQTT Broker for live data, it can be difficult to understand the structure of the data and topics that are being used. We recently released the new "Hierarchy" view, showing the topic structure present on a Broker, and we've now evolved that even further.
 

--- a/src/handbook/marketing/webinars.md
+++ b/src/handbook/marketing/webinars.md
@@ -90,8 +90,8 @@ I look forward to seeing you there!
 
 And here are a couple of samples of our past promo videos:
 
-<iframe width="560" height="315" class="mb-6" src="https://www.youtube.com/embed//mfihdh336bw?rel=0" frameborder="0" allowfullscreen></iframe>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/bgJNk0x_sMs?rel=0" frameborder="0" allowfullscreen></iframe>
+<lite-youtube videoid="mfihdh336bw" params="rel=0" style="width: 100%; height: 315px; margin-bottom: 1.5rem;" title="YouTube video player"></lite-youtube>
+<lite-youtube videoid="bgJNk0x_sMs" params="rel=0" style="width: 100%; height: 315px;" title="YouTube video player"></lite-youtube>
 
 ## Post Webinar
 


### PR DESCRIPTION
## Description

Raw `<iframe src="youtube.com/embed/...">` embeds load YouTube's scripts and set tracking cookies as soon as the page renders — before any user interaction or consent.

This affected all webinar pages and a number of blog post pages. The site already uses lite-youtube-embed on most pages (homepage, platform pages, customer stories, changelogs), so these were the remaining outliers.

**Going forward**
Raw YouTube <iframe> embeds should no longer be used on this site. Always use `<lite-youtube>` instead.

The handbook will be updated with this guidance as a follow-up.

## Related Issue(s)

https://github.com/FlowFuse/website/pull/4590

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

