### PR TITLE
Add redirects for development and all its child pages

### DIFF
--- a/src/redirects.njk
+++ b/src/redirects.njk
@@ -105,4 +105,30 @@ eleventyExcludeFromCollections: true
 /product/features/ /platform/features/ 301
 /product/device-agent/ /platform/device-agent/ 301
 /product/dashboard/ /platform/dashboard/ 301
+
 /docs/user/expert/ /docs/user/expert/ 301
+
+/handbook/development/ /handbook/engineering/
+/handbook/development/tools/ /handbook/engineering/tools/
+/handbook/development/support/ /handbook/engineering/support/
+/handbook/development/support/triage/ /handbook/engineering/support/triage/
+/handbook/development/support/troubleshooting/ /handbook/engineering/support/troubleshooting/
+/handbook/development/project-management/ /handbook/engineering/project-management/
+/handbook/development/ops/deployment/ /handbook/engineering/ops/deployment/
+/handbook/development/ops/dedicated/ /handbook/engineering/ops/dedicated/
+/handbook/development/ops/incident-response/ /handbook/engineering/ops/incident-response/
+/handbook/development/ops/production/ /handbook/engineering/ops/production/
+/handbook/development/ops/self-hosted-assistant/ /handbook/engineering/ops/self-hosted-assistant/
+/handbook/development/ops/production-stack-update/ /handbook/engineering/ops/production-stack-update/
+/handbook/development/frontend/ /handbook/engineering/frontend/
+/handbook/development/frontend/data-attributes/ /handbook/engineering/frontend/data-attributes/
+/handbook/development/frontend/layouts/ /handbook/engineering/frontend/layouts/
+/handbook/development/frontend/services/ /handbook/engineering/frontend/services/
+/handbook/development/frontend/testing/ /handbook/engineering/frontend/testing/
+/handbook/development/contributing/certified-nodes/ /handbook/engineering/contributing/certified-nodes/
+/handbook/development/contributing/ff-tables/ /handbook/engineering/contributing/ff-tables/
+/handbook/development/contributing/team-npm-registry/ /handbook/engineering/contributing/team-npm-registry/
+/handbook/development/ /handbook/engineering/
+/handbook/development/releases/dashboard-2/ /handbook/engineering/releases/dashboard-2/
+/handbook/development/releases/process/ /handbook/engineering/releases/process/
+/handbook/development/releases/digital-ocean/ /handbook/engineering/releases/digital-ocean/


### PR DESCRIPTION
## Description

This PR adds redirects for development and all its child pages. The development section from the handbook has been moved to engineering.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

