### PR TITLE
Remove Warmly from the website and manage it through GTM

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -536,10 +536,6 @@ eleventyComputed:
 <!-- Cookie banner (must load before any consent-gated scripts) -->
 <script async type="text/javascript" src="/js/cc.min.js"></script>
 
-<!-- warmly.ai - consent-gated -->
-<script id="warmly-script-loader" type="text/plain" data-category="analytics" src="https://opps-widget.getwarmly.com/warmly.js?clientId=3657ad04e55b92ef0b5972fcfb0802d1"></script>
-<!-- End warmly.ai -->
-
 <!-- HS tracker - consent-gated (analytics: tracking + chat widget runtime) -->
 <script type="text/plain" data-category="analytics" async id="hs-script-loader" src="//js-eu1.hs-scripts.com/26586079.js"></script>
 


### PR DESCRIPTION
## Description

Followed this [quick tutorial from Warmly](https://www.loom.com/share/ae71c7ccb15643b8b73c002630b4ec28)
Implemented what was described in https://flowfuse.com/handbook/marketing/programs/#adding-tags-in-google-tag-manager-(gtm)
Set up the `Required consent type` to `analytics_storage`
Check the tag fires on local, but can't fully test Warmly until it's in production

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

