### PR TITLE
feat: left-align pricing feature labels and add indigo divider

### DIFF
--- a/src/_includes/feature_lists/features-table-base.njk
+++ b/src/_includes/feature_lists/features-table-base.njk
@@ -16,7 +16,7 @@
     {% for section in featureCatalog.sections %}
     <ul class="{{ hosting }} ff-feature-table-section">
         <li class="ff-feature--header sticky top-[44px]">
-            <span style="padding-top: 12px; padding-bottom: 12px;" class="sticky left-0 h-full">{{ section.label }}</span>
+            <span class="sticky left-0 h-full">{{ section.label }}</span>
             <span></span>
             <span></span>
             <span></span>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1434,6 +1434,8 @@ h4:hover .header-anchor::before {
         height: 100%;
         display: flex;
         justify-content: left !important;
+        padding-top: 12px;
+        padding-bottom: 12px;
         @apply px-1 px-4 md:px-6;
     }
 


### PR DESCRIPTION
This is a small styling amendment on https://github.com/FlowFuse/website/pull/4607

## Description

Left-aligns feature row labels in the pricing comparison table and adds a subtle indigo divider between the label column and tier columns.

- **Left-aligned labels** — feature names now left-align to match section headers, improving readability
- **Indigo border divider** — `border-right: 1px solid indigo.100` on feature row labels separates the label column from tier data columns
- **Info icon repositioned** — pushed to the right edge of the label cell via `margin-left: auto`, with softer gray color
- **Label padding** — updated to responsive Tailwind spacing (`py-3 pr-3 px-4 md:px-6`)

CSS-only change — no template modifications.

<img width="2018" height="1172" alt="CleanShot 2026-03-03 at 10 55 14@2x" src="https://github.com/user-attachments/assets/e7178431-3b21-4c8a-8103-f4fa5d639b01" />


## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))