### PR TITLE
GDPR: Remove GTM no script

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -221,10 +221,6 @@ eleventyComputed:
     {%- endif -%}
 </head>
 <body class="font-sans ff-website leading-normal tracking-normal gradient text-gray-500 min-h-screen flex flex-col">
-    <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-55L36797"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <!-- End Google Tag Manager (noscript) -->
     <div class="flex-grow base">
         <div class="w-full">
             <!-- Events Banner -->


### PR DESCRIPTION
## Description

This PR removes the Google Tag Manager `noscript` iframe fallback from the base layout to enforce a stricter **consent-first** behavior.

The `noscript` fallback can still trigger requests to Google even when no explicit consent has been given (in no-JS scenarios). Since our consent model is managed via CookieConsent + Consent Mode in JavaScript, this fallback is not required for our GDPR-first implementation.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

