### PR TITLE
Handbook: Update Google Ads consent configuration and trigger selection guidelines

### DIFF
--- a/src/handbook/marketing/programs.md
+++ b/src/handbook/marketing/programs.md
@@ -205,16 +205,14 @@ Use this sequence every time you create or update a tag:
 | Tag category | Required consent type |
 |---|---|
 | Analytics (e.g. Google Analytics, HubSpot, PostHog) | `analytics_storage` |
-| Advertising & remarketing (e.g. LinkedIn InsightTag, Conversion Linker, Meta Pixel) | `ad_storage` |
+| Advertising & remarketing (e.g. Google Tag AW (Google Ads base tag), LinkedIn InsightTag, Conversion Linker, Meta Pixel) | `ad_storage` |
 | Functional tools (non-essential UX features that do not perform analytics/advertising tracking) | `functionality_storage` |
 | Personalization & A/B testing (e.g. tools that remember user preferences or show tailored content) | `personalization_storage` |
 | Security (e.g. fraud prevention, bot detection) | `security_storage` — typically strictly necessary; no consent required in most cases |
-| Google Tag AW (Google Ads base tag) | **No consent requirement** — this tag uses Google Consent Mode v2 natively and must fire on all page loads (including denied-consent states) for cookieless modeling. |
 
 #### Primary trigger selection
 
-- **Google Tag type tags (Google Tag AW, Google Analytics 4)**: use `Initialization - All Pages`.
-- **Base tracking/pixel tags** (for example LinkedIn InsightTag): use `All Pages` (Page View), not `Initialization - All Pages`.
+- **Google Tag type tags (Google Tag AW, Google Analytics 4) and base tracking/pixel tags** (for example LinkedIn InsightTag): use `All Pages` (Page View), not `Initialization - All Pages`.
 - **Conversion tags** (thank-you page, button click, form submit, custom conversion event): use a scoped trigger tied to the conversion action.
 
 #### Shared consent-change trigger (`FF Consent Update`)


### PR DESCRIPTION
## Description

This PR updates the handbook's GTM guidelines to transition from "Advanced Consent Mode" to a stricter "Basic Consent Mode" for the Google Ads Tag.

**Reasoning & Legal Context**
While Google tags are designed to send "anonymous pings" without cookies when consent is denied, further research into GDPR compliance (specifically regarding the interpretation of IP addresses as personal data by EU regulators) suggests this still carries a moderate compliance risk.

To mitigate this and ensure a "Privacy by Design" approach, I have updated the GTM configuration and this documentation to:
- Switch from Initialization to Page View triggers: This ensures the GTM container has fully processed the "Denied" consent state before any tags attempt to load.
- Require explicit consent: Tags will now only fire once the user has proactively granted permission, preventing any network requests (pings) to Google or third-party servers during the pre-consent phase.

**Changes**

- Updated the Required consent type by tag category table to clarify mapping for Google Ads.
- Revised the Primary trigger selection rules to move base tracking/pixel tags from Initialization to the standard Page View trigger.

## Related Issue(s)

https://github.com/FlowFuse/customer/issues/504

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

