### PR TITLE
Experiment: Add solutions scaffolding showcase

### DIFF
--- a/src/_data/protocolPairs.js
+++ b/src/_data/protocolPairs.js
@@ -1,0 +1,34 @@
+const yaml = require("js-yaml");
+const fs = require("fs");
+const path = require("path");
+
+module.exports = () => {
+    const protocolsFile = path.join(__dirname, "protocols.yaml");
+    const protocolsData = yaml.load(fs.readFileSync(protocolsFile, "utf8"));
+    const protocols = protocolsData.protocols;
+
+    const pairs = [];
+
+    for (let i = 0; i < protocols.length; i++) {
+        for (let j = 0; j < protocols.length; j++) {
+            if (i !== j) {
+                const from = protocols[i];
+                const to = protocols[j];
+                pairs.push({
+                    slug: `${from.slug}-to-${to.slug}`,
+                    from: from,
+                    to: to,
+                    title: `Connect ${from.name} to ${to.name}`,
+                    description: `Learn how to connect ${from.name} to ${to.name} using FlowFuse and Node-RED. Bridge ${from.shortName} data to ${to.shortName} systems seamlessly.`,
+                    meta: {
+                        title: `Connect ${from.name} to ${to.name} | FlowFuse`,
+                        description: `How to connect ${from.name} to ${to.name} using FlowFuse. Build data pipelines between ${from.shortName} and ${to.shortName}.`,
+                        keywords: `${from.name}, ${to.name}, integration, FlowFuse, Node-RED, connect ${from.shortName} to ${to.shortName}`
+                    }
+                });
+            }
+        }
+    }
+
+    return pairs;
+};

--- a/src/_data/protocols.yaml
+++ b/src/_data/protocols.yaml
@@ -1,0 +1,132 @@
+# Industrial protocols that FlowFuse connects
+# Each protocol generates:
+#   - Individual page: /solutions/protocols/{slug}/
+#   - Pair pages:      /solutions/connect/{slug}-to-{other}/  (auto-generated)
+#
+# To add a new protocol, add an entry below. All "Connect X to Y" pages
+# are auto-generated from this list via protocolPairs.js.
+protocols:
+  - slug: opc-ua
+    name: OPC-UA
+    shortName: OPC-UA
+    category: industrial
+    description: >
+      OPC-UA (Open Platform Communications Unified Architecture) is the
+      industry standard for secure, reliable machine-to-machine communication
+      in industrial automation.
+    heroDescription: >
+      Connect your OPC-UA enabled devices and systems with FlowFuse.
+      Collect, transform, and route data from any OPC-UA server to
+      enterprise systems, databases, and cloud platforms.
+    useCases:
+      - data-acquisition
+      - machine-monitoring
+    relatedIntegrations:
+      - node-red-contrib-opcua
+    meta:
+      title: "FlowFuse for OPC-UA Integration"
+      description: "Connect OPC-UA devices to any system with FlowFuse. Bridge industrial OPC-UA data to MQTT, REST APIs, databases, and more."
+      keywords: "OPC-UA, industrial automation, FlowFuse, Node-RED, OPC UA client, OPC UA server"
+
+  - slug: mqtt
+    name: MQTT
+    shortName: MQTT
+    category: messaging
+    description: >
+      MQTT is a lightweight publish-subscribe messaging protocol designed
+      for constrained devices and low-bandwidth, high-latency networks,
+      widely used in IoT and industrial applications.
+    heroDescription: >
+      Build MQTT-powered data pipelines with FlowFuse. Connect MQTT
+      brokers, transform messages, and route data to any destination.
+    useCases:
+      - data-acquisition
+      - real-time-monitoring
+    relatedIntegrations:
+      - node-red-contrib-aedes
+    meta:
+      title: "FlowFuse for MQTT Integration"
+      description: "Build MQTT integrations with FlowFuse. Connect brokers, transform data, and bridge MQTT to enterprise systems."
+      keywords: "MQTT, IoT, FlowFuse, Node-RED, MQTT broker, publish subscribe"
+
+  - slug: ethernet-ip
+    name: Ethernet/IP
+    shortName: EtherNet/IP
+    category: industrial
+    description: >
+      Ethernet/IP (Industrial Protocol) is an industrial network protocol
+      for real-time I/O control and information exchange, commonly used
+      with Allen-Bradley and Rockwell Automation equipment.
+    heroDescription: >
+      Connect Ethernet/IP devices to your enterprise systems with FlowFuse.
+      Bridge shop floor data from Allen-Bradley PLCs to IT systems.
+    useCases:
+      - machine-monitoring
+      - data-acquisition
+    relatedIntegrations: []
+    meta:
+      title: "FlowFuse for Ethernet/IP Integration"
+      description: "Connect Ethernet/IP devices with FlowFuse. Bridge Allen-Bradley and Rockwell Automation data to enterprise systems."
+      keywords: "Ethernet/IP, EtherNet/IP, Allen-Bradley, Rockwell Automation, FlowFuse, industrial protocol"
+
+  - slug: modbus
+    name: Modbus
+    shortName: Modbus
+    category: industrial
+    description: >
+      Modbus is a serial communication protocol widely used in industrial
+      electronics for connecting electronic devices, supporting both
+      RTU (serial) and TCP (Ethernet) variants.
+    heroDescription: >
+      Integrate Modbus devices into modern data workflows with FlowFuse.
+      Read registers, coils, and inputs from any Modbus device.
+    useCases:
+      - data-acquisition
+      - legacy-modernization
+    relatedIntegrations:
+      - node-red-contrib-modbus
+    meta:
+      title: "FlowFuse for Modbus Integration"
+      description: "Connect Modbus RTU and TCP devices with FlowFuse. Bridge legacy equipment to modern systems."
+      keywords: "Modbus, Modbus TCP, Modbus RTU, industrial communication, FlowFuse"
+
+  - slug: s7
+    name: Siemens S7
+    shortName: S7
+    category: industrial
+    description: >
+      The Siemens S7 protocol enables direct communication with Siemens
+      S7-300, S7-400, S7-1200, and S7-1500 PLCs without additional
+      middleware.
+    heroDescription: >
+      Connect Siemens S7 PLCs directly to any system with FlowFuse.
+      Read and write PLC data, build dashboards, and automate workflows.
+    useCases:
+      - machine-monitoring
+      - scada-modernization
+    relatedIntegrations:
+      - node-red-contrib-s7
+    meta:
+      title: "FlowFuse for Siemens S7 Integration"
+      description: "Connect Siemens S7 PLCs with FlowFuse. Bridge S7-1200 and S7-1500 data to enterprise systems."
+      keywords: "Siemens S7, PLC, S7-1500, S7-1200, FlowFuse, industrial automation"
+
+  - slug: http-rest
+    name: HTTP/REST APIs
+    shortName: REST
+    category: it
+    description: >
+      HTTP/REST APIs enable integration with web services, cloud platforms,
+      ERP systems, MES solutions, and any system that exposes a REST
+      interface.
+    heroDescription: >
+      Bridge industrial data to any REST API with FlowFuse. Connect
+      your shop floor to cloud services, databases, and business systems.
+    useCases:
+      - data-integration
+      - cloud-connectivity
+    relatedIntegrations: []
+    meta:
+      title: "FlowFuse for HTTP/REST Integration"
+      description: "Connect REST APIs with FlowFuse. Bridge industrial data to cloud platforms, ERPs, and web services."
+      keywords: "REST API, HTTP, FlowFuse, integration, web services, cloud"

--- a/src/_data/teams.yaml
+++ b/src/_data/teams.yaml
@@ -1,0 +1,104 @@
+# Target teams/personas for FlowFuse
+# Each generates a page at: /solutions/teams/{slug}/
+#
+# To add a new team, add an entry below.
+teams:
+  - slug: operations-engineers
+    name: Operations Engineers
+    description: >
+      Operations engineers manage and optimize manufacturing processes,
+      ensuring equipment runs efficiently and production targets are met.
+    heroDescription: >
+      FlowFuse empowers operations engineers to build custom monitoring
+      and control solutions without writing code. Connect any machine,
+      build dashboards, and automate workflows.
+    painPoints:
+      - "Disconnected systems make it hard to get a unified view of operations"
+      - "Manual data collection from equipment is time-consuming and error-prone"
+      - "Legacy equipment lacks modern connectivity options"
+    relatedUseCases:
+      - machine-monitoring
+      - data-acquisition
+    relatedProtocols:
+      - opc-ua
+      - s7
+      - ethernet-ip
+    meta:
+      title: "FlowFuse for Operations Engineers"
+      description: "How FlowFuse helps operations engineers connect machines, build dashboards, and automate workflows."
+      keywords: "operations engineers, manufacturing, FlowFuse, industrial automation"
+
+  - slug: it-teams
+    name: IT Teams
+    description: >
+      IT teams manage enterprise infrastructure, ensure security and
+      compliance, and bridge the gap between operational technology
+      and information technology.
+    heroDescription: >
+      FlowFuse provides IT teams with enterprise-grade security,
+      governance, and audit trails for industrial applications.
+      Manage Node-RED deployments at scale with SSO, RBAC, and
+      centralized control.
+    painPoints:
+      - "Shadow IT from OT departments creates security blind spots"
+      - "Lack of visibility and governance over industrial integration tools"
+      - "Difficulty maintaining compliance when connecting OT to IT networks"
+    relatedUseCases:
+      - data-acquisition
+      - protocol-conversion
+    relatedProtocols:
+      - http-rest
+      - mqtt
+    meta:
+      title: "FlowFuse for IT Teams"
+      description: "How FlowFuse helps IT teams govern industrial integrations with enterprise-grade security."
+      keywords: "IT teams, enterprise security, governance, FlowFuse, RBAC, SSO"
+
+  - slug: maintenance-teams
+    name: Maintenance Teams
+    description: >
+      Maintenance teams keep equipment running, minimize downtime, and
+      transition from reactive to predictive maintenance strategies.
+    heroDescription: >
+      FlowFuse helps maintenance teams implement condition-based and
+      predictive maintenance. Monitor equipment health, detect anomalies,
+      and schedule maintenance before failures occur.
+    painPoints:
+      - "Reactive maintenance leads to costly unplanned downtime"
+      - "No easy way to track equipment health trends over time"
+      - "Difficulty integrating CMMS with shop floor sensor data"
+    relatedUseCases:
+      - predictive-maintenance
+      - machine-monitoring
+    relatedProtocols:
+      - opc-ua
+      - modbus
+    meta:
+      title: "FlowFuse for Maintenance Teams"
+      description: "How FlowFuse helps maintenance teams implement predictive maintenance and reduce downtime."
+      keywords: "maintenance teams, predictive maintenance, condition monitoring, FlowFuse"
+
+  - slug: data-engineers
+    name: Data Engineers
+    description: >
+      Data engineers build and maintain data pipelines and infrastructure,
+      ensuring industrial data flows reliably from source to analytics.
+    heroDescription: >
+      FlowFuse enables data engineers to build robust industrial data
+      pipelines without deep OT expertise. Connect any protocol,
+      transform data, and deliver to any data platform.
+    painPoints:
+      - "Industrial data is hard to access and normalize across different protocols"
+      - "Multiple proprietary protocols require specialized knowledge"
+      - "No standard tooling for OT data engineering workflows"
+    relatedUseCases:
+      - data-acquisition
+      - protocol-conversion
+    relatedProtocols:
+      - mqtt
+      - http-rest
+      - opc-ua
+    meta:
+      title: "FlowFuse for Data Engineers"
+      description: "How FlowFuse helps data engineers build industrial data pipelines across any protocol."
+      keywords: "data engineers, data pipelines, industrial data, FlowFuse, ETL"

--- a/src/_data/useCases.yaml
+++ b/src/_data/useCases.yaml
@@ -23,60 +23,75 @@ useCases:
       description: "Collect industrial data from any source with FlowFuse. Support for OPC-UA, MQTT, Modbus, and more."
       keywords: "data acquisition, industrial data, FlowFuse, IoT data collection"
 
-  - slug: machine-monitoring
-    name: Machine Monitoring
+  - slug: data-transformation
+    name: Data Transformation
     description: >
-      Monitor machine health, performance, and status in real time. Build
-      dashboards, set up alerts, and track OEE across your entire
-      production floor.
+      Transform, enrich, and normalize data between industrial systems.
+      Convert protocols, reshape payloads, and apply business logic to
+      raw machine data before it reaches downstream systems.
     heroDescription: >
-      Build real-time machine monitoring dashboards with FlowFuse.
-      Connect any equipment, visualize KPIs, and get alerted to
-      issues before they cause downtime.
-    relatedProtocols:
-      - opc-ua
-      - s7
-      - ethernet-ip
-    meta:
-      title: "Machine Monitoring with FlowFuse"
-      description: "Monitor machines in real time with FlowFuse. Build dashboards, track OEE, and reduce downtime."
-      keywords: "machine monitoring, industrial IoT, real-time dashboards, OEE, FlowFuse"
-
-  - slug: predictive-maintenance
-    name: Predictive Maintenance
-    description: >
-      Use data-driven insights to predict equipment failures before they
-      occur. Collect vibration, temperature, and operational data to build
-      maintenance models.
-    heroDescription: >
-      Implement predictive maintenance workflows with FlowFuse. Collect
-      sensor data, detect anomalies, and prevent unplanned downtime.
+      Transform industrial data with FlowFuse. Convert formats, enrich
+      payloads, and apply business logic — all with low-code flows.
     relatedProtocols:
       - opc-ua
       - mqtt
       - modbus
-    meta:
-      title: "Predictive Maintenance with FlowFuse"
-      description: "Implement predictive maintenance with FlowFuse. Collect sensor data and detect anomalies early."
-      keywords: "predictive maintenance, condition monitoring, FlowFuse, industrial IoT"
-
-  - slug: protocol-conversion
-    name: Protocol Conversion
-    description: >
-      Translate between different industrial protocols to unify your data
-      infrastructure. Bridge OT and IT networks without replacing existing
-      equipment.
-    heroDescription: >
-      Convert between any industrial protocols with FlowFuse. Bridge
-      legacy equipment to modern systems without middleware complexity.
-    relatedProtocols:
-      - opc-ua
-      - modbus
-      - s7
-      - mqtt
-      - ethernet-ip
       - http-rest
     meta:
-      title: "Protocol Conversion with FlowFuse"
-      description: "Convert between industrial protocols with FlowFuse. Bridge OPC-UA, Modbus, MQTT, and more."
-      keywords: "protocol conversion, protocol gateway, industrial integration, FlowFuse"
+      title: "Data Transformation with FlowFuse"
+      description: "Transform and normalize industrial data with FlowFuse. Protocol conversion, payload reshaping, and more."
+      keywords: "data transformation, protocol conversion, industrial data, FlowFuse"
+
+  - slug: data-deployment
+    name: Data Deployment
+    description: >
+      Deploy data flows and applications to edge devices and remote sites
+      at scale. Manage, update, and monitor deployments across your entire
+      fleet from a central platform.
+    heroDescription: >
+      Deploy industrial data flows at scale with FlowFuse. Push to edge
+      devices, manage remote sites, and keep your fleet in sync.
+    relatedProtocols:
+      - mqtt
+      - http-rest
+    meta:
+      title: "Data Deployment with FlowFuse"
+      description: "Deploy data flows to edge devices at scale with FlowFuse. Centralized management for distributed architectures."
+      keywords: "data deployment, edge deployment, fleet management, FlowFuse, IoT"
+
+  - slug: data-storage
+    name: Data Storage
+    description: >
+      Route industrial data to databases, historians, and data lakes.
+      Connect to time-series databases, SQL stores, cloud storage, and
+      enterprise data platforms.
+    heroDescription: >
+      Store industrial data anywhere with FlowFuse. Connect to databases,
+      historians, and cloud platforms with pre-built integrations.
+    relatedProtocols:
+      - mqtt
+      - http-rest
+      - opc-ua
+    meta:
+      title: "Data Storage with FlowFuse"
+      description: "Route industrial data to any storage with FlowFuse. Databases, historians, cloud platforms, and more."
+      keywords: "data storage, industrial data, time-series database, data historian, FlowFuse"
+
+  - slug: data-visualisation
+    name: Data Visualisation
+    description: >
+      Build real-time dashboards and visualisations for industrial data.
+      Monitor machine health, track KPIs, and display production metrics
+      with customisable, low-code interfaces.
+    heroDescription: >
+      Visualise industrial data in real time with FlowFuse. Build
+      dashboards, monitor KPIs, and share insights across your organisation.
+    relatedProtocols:
+      - opc-ua
+      - mqtt
+      - modbus
+      - s7
+    meta:
+      title: "Data Visualisation with FlowFuse"
+      description: "Build real-time industrial dashboards with FlowFuse. Monitor machines, track KPIs, and visualise production data."
+      keywords: "data visualisation, industrial dashboards, real-time monitoring, FlowFuse, IoT"

--- a/src/_data/useCases.yaml
+++ b/src/_data/useCases.yaml
@@ -1,0 +1,82 @@
+# Industrial use cases for FlowFuse
+# Each generates a page at: /solutions/use-cases/{slug}/
+#
+# To add a new use case, add an entry below.
+useCases:
+  - slug: data-acquisition
+    name: Data Acquisition
+    description: >
+      Collect data from diverse industrial sources including PLCs, sensors,
+      and legacy equipment. Normalize and route data to databases, cloud
+      platforms, and analytics tools.
+    heroDescription: >
+      FlowFuse makes industrial data acquisition simple. Connect any
+      device, transform any protocol, and deliver data anywhere — all
+      from a single platform.
+    relatedProtocols:
+      - opc-ua
+      - mqtt
+      - modbus
+      - ethernet-ip
+    meta:
+      title: "Data Acquisition with FlowFuse"
+      description: "Collect industrial data from any source with FlowFuse. Support for OPC-UA, MQTT, Modbus, and more."
+      keywords: "data acquisition, industrial data, FlowFuse, IoT data collection"
+
+  - slug: machine-monitoring
+    name: Machine Monitoring
+    description: >
+      Monitor machine health, performance, and status in real time. Build
+      dashboards, set up alerts, and track OEE across your entire
+      production floor.
+    heroDescription: >
+      Build real-time machine monitoring dashboards with FlowFuse.
+      Connect any equipment, visualize KPIs, and get alerted to
+      issues before they cause downtime.
+    relatedProtocols:
+      - opc-ua
+      - s7
+      - ethernet-ip
+    meta:
+      title: "Machine Monitoring with FlowFuse"
+      description: "Monitor machines in real time with FlowFuse. Build dashboards, track OEE, and reduce downtime."
+      keywords: "machine monitoring, industrial IoT, real-time dashboards, OEE, FlowFuse"
+
+  - slug: predictive-maintenance
+    name: Predictive Maintenance
+    description: >
+      Use data-driven insights to predict equipment failures before they
+      occur. Collect vibration, temperature, and operational data to build
+      maintenance models.
+    heroDescription: >
+      Implement predictive maintenance workflows with FlowFuse. Collect
+      sensor data, detect anomalies, and prevent unplanned downtime.
+    relatedProtocols:
+      - opc-ua
+      - mqtt
+      - modbus
+    meta:
+      title: "Predictive Maintenance with FlowFuse"
+      description: "Implement predictive maintenance with FlowFuse. Collect sensor data and detect anomalies early."
+      keywords: "predictive maintenance, condition monitoring, FlowFuse, industrial IoT"
+
+  - slug: protocol-conversion
+    name: Protocol Conversion
+    description: >
+      Translate between different industrial protocols to unify your data
+      infrastructure. Bridge OT and IT networks without replacing existing
+      equipment.
+    heroDescription: >
+      Convert between any industrial protocols with FlowFuse. Bridge
+      legacy equipment to modern systems without middleware complexity.
+    relatedProtocols:
+      - opc-ua
+      - modbus
+      - s7
+      - mqtt
+      - ethernet-ip
+      - http-rest
+    meta:
+      title: "Protocol Conversion with FlowFuse"
+      description: "Convert between industrial protocols with FlowFuse. Bridge OPC-UA, Modbus, MQTT, and more."
+      keywords: "protocol conversion, protocol gateway, industrial integration, FlowFuse"

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -261,18 +261,23 @@ eleventyComputed:
                         </ul>
                         {% endnavoption %}
                         {% navoption "Solutions", null, 0 %}
-                        <ul class="narrow sm:grid sm:grid-flow-col sm:grid-rows-5 sm:grid-cols-3 sm:pr-1 align-left sm:auto-rows-auto items-center">
-                            {% navoption "Use Cases", null, 1, null, true, "pl-3 title border-l-2" %}{% endnavoption %}
+                        <ul class="narrow sm:grid sm:grid-flow-col sm:grid-rows-8 sm:grid-cols-3 sm:pr-1 align-left sm:auto-rows-auto items-center">
+                            {% navoption "By Use Case", null, 1, null, true, "pl-3 title border-l-2" %}{% endnavoption %}
                             <ul class="sub-menu grid grid-rows-subgrid row-span-4 ml-7 auto-rows-auto border-l-2">
                                 {% navoption "IT/OT Middleware", "/solutions/it-ot-middleware/", 1, "cog" %}{% endnavoption %}
                                 {% navoption "Unified Namespace", "/solutions/uns/", 1, "uns" %}{% endnavoption %}
                                 {% navoption "SCADA", "/solutions/scada/", 1, "adjustments-horizontal" %}{% endnavoption %}
                                 {% navoption "MES", "/solutions/mes/", 1, "chart" %}{% endnavoption %}
                             </ul>
-                            {% navoption "Protocols", null, 1, null, true, "pl-3 title border-l-2" %}{% endnavoption %}
-                            <ul class="sub-menu grid grid-rows-subgrid row-span-2 ml-7 auto-rows-auto border-l-2">
+                            {% navoption "By Protocol", null, 1, null, true, "pl-3 title border-l-2" %}{% endnavoption %}
+                            <ul class="sub-menu grid grid-rows-subgrid row-span-7 ml-7 auto-rows-auto border-l-2">
                                 {% navoption "Browse All", "/solutions/protocols/", 1, "chip" %}{% endnavoption %}
                                 {% navoption "Connect X to Y", "/solutions/connect/", 1, "squares-plus" %}{% endnavoption %}
+                                {% navoption "Data Acquisition", "/solutions/use-cases/data-acquisition/", 1, "arrow-small-down" %}{% endnavoption %}
+                                {% navoption "Data Transformation", "/solutions/use-cases/data-transformation/", 1, "arrows-right-left" %}{% endnavoption %}
+                                {% navoption "Data Deployment", "/solutions/use-cases/data-deployment/", 1, "rocket-launch" %}{% endnavoption %}
+                                {% navoption "Data Storage", "/solutions/use-cases/data-storage/", 1, "circle-stack" %}{% endnavoption %}
+                                {% navoption "Data Visualisation", "/solutions/use-cases/data-visualisation/", 1, "chart" %}{% endnavoption %}
                             </ul>
                             {% navoption "By Team", null, 1, null, true, "pl-3 title border-l-2" %}{% endnavoption %}
                             <ul class="sub-menu grid grid-rows-subgrid row-span-4 ml-7 auto-rows-auto border-l-2">

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -261,14 +261,22 @@ eleventyComputed:
                         </ul>
                         {% endnavoption %}
                         {% navoption "Solutions", null, 0 %}
-                            <ul class="sm:grid sm:grid-flow-col sm:grid-rows-3 sm:grid-cols-1 sm:pr-9 align-left">
-                                {% navoption "IT/OT middleware", "/solutions/it-ot-middleware/", 1, "cog" %}{% endnavoption %}
+                        <ul class="narrow sm:grid sm:grid-flow-col sm:grid-rows-6 sm:pr-1 align-left sm:auto-rows-auto items-center">
+                            {% navoption "By Application", null, 1, null, true, "pl-3 title border-l-2" %}{% endnavoption %}
+                            <ul class="sub-menu grid grid-rows-subgrid row-span-4 ml-7 auto-rows-auto border-l-2">
+                                {% navoption "IT/OT Middleware", "/solutions/it-ot-middleware/", 1, "cog" %}{% endnavoption %}
                                 {% navoption "Unified Namespace", "/solutions/uns/", 1, "uns" %}{% endnavoption %}
                                 {% navoption "SCADA", "/solutions/scada/", 1, "adjustments-horizontal" %}{% endnavoption %}
                                 {% navoption "MES", "/solutions/mes/", 1, "chart" %}{% endnavoption %}
-                                {% navoption "Edge Connectivity", "/solutions/edge-connectivity/", 1, "chip" %}{% endnavoption %}
-                                {% navoption "Data integration", "/solutions/data-integration/", 1, "db" %}{% endnavoption %}
                             </ul>
+                            {% navoption "By Protocol", null, 1, null, true, "pl-3 title border-l-2" %}{% endnavoption %}
+                            <ul class="sub-menu grid grid-rows-subgrid row-span-2 ml-7 auto-rows-auto border-l-2">
+                                {% navoption "Browse Protocols", "/solutions/protocols/", 1, "chip" %}{% endnavoption %}
+                                {% navoption "Connect X to Y", "/solutions/connect/", 1, "squares-plus" %}{% endnavoption %}
+                            </ul>
+                            {% navoption "By Team", "/solutions/teams/", 1, "user-group" %}{% endnavoption %}
+                            {% navoption "By Use Case", "/solutions/use-cases/", 1, "chart" %}{% endnavoption %}
+                        </ul>
                         {% endnavoption %}
                         {% navoption "Resources", null, 0 %}
                             <ul class="sm:grid sm:grid-flow-col sm:grid-rows-5 sm:grid-cols-1 sm:pr-9 align-left">

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -261,26 +261,27 @@ eleventyComputed:
                         </ul>
                         {% endnavoption %}
                         {% navoption "Solutions", null, 0 %}
-                        <ul class="narrow sm:grid sm:grid-flow-col sm:grid-rows-8 sm:grid-cols-3 sm:pr-1 align-left sm:auto-rows-auto items-center">
-                            {% navoption "By Use Case", null, 1, null, true, "pl-3 title border-l-2" %}{% endnavoption %}
-                            <ul class="sub-menu grid grid-rows-subgrid row-span-4 ml-7 auto-rows-auto border-l-2">
+                        <ul class="narrow sm:grid sm:grid-cols-3 sm:pr-1 align-left sm:auto-rows-auto items-start gap-x-4">
+                            <li class="pl-3 title border-l-2"><span class="flex items-center gap-2">By Use Case</span></li>
+                            <li class="pl-3 title border-l-2"><span class="flex items-center gap-2">By Protocol</span></li>
+                            <li class="pl-3 title border-l-2"><span class="flex items-center gap-2">By Team</span></li>
+                            <ul class="ml-7 auto-rows-auto border-l-2">
                                 {% navoption "IT/OT Middleware", "/solutions/it-ot-middleware/", 1, "cog" %}{% endnavoption %}
                                 {% navoption "Unified Namespace", "/solutions/uns/", 1, "uns" %}{% endnavoption %}
                                 {% navoption "SCADA", "/solutions/scada/", 1, "adjustments-horizontal" %}{% endnavoption %}
                                 {% navoption "MES", "/solutions/mes/", 1, "chart" %}{% endnavoption %}
                             </ul>
-                            {% navoption "By Protocol", null, 1, null, true, "pl-3 title border-l-2" %}{% endnavoption %}
-                            <ul class="sub-menu grid grid-rows-subgrid row-span-7 ml-7 auto-rows-auto border-l-2">
-                                {% navoption "Browse All", "/solutions/protocols/", 1, "chip" %}{% endnavoption %}
-                                {% navoption "Connect X to Y", "/solutions/connect/", 1, "squares-plus" %}{% endnavoption %}
+                            <ul class="ml-7 auto-rows-auto border-l-2">
                                 {% navoption "Data Acquisition", "/solutions/use-cases/data-acquisition/", 1, "arrow-small-down" %}{% endnavoption %}
                                 {% navoption "Data Transformation", "/solutions/use-cases/data-transformation/", 1, "arrows-right-left" %}{% endnavoption %}
                                 {% navoption "Data Deployment", "/solutions/use-cases/data-deployment/", 1, "rocket-launch" %}{% endnavoption %}
                                 {% navoption "Data Storage", "/solutions/use-cases/data-storage/", 1, "circle-stack" %}{% endnavoption %}
                                 {% navoption "Data Visualisation", "/solutions/use-cases/data-visualisation/", 1, "chart" %}{% endnavoption %}
+                                <li class="my-2"><hr class="border-gray-300"></li>
+                                {% navoption "Browse All Protocols", "/solutions/protocols/", 1, "chip" %}{% endnavoption %}
+                                {% navoption "Connect X to Y", "/solutions/connect/", 1, "squares-plus" %}{% endnavoption %}
                             </ul>
-                            {% navoption "By Team", null, 1, null, true, "pl-3 title border-l-2" %}{% endnavoption %}
-                            <ul class="sub-menu grid grid-rows-subgrid row-span-4 ml-7 auto-rows-auto border-l-2">
+                            <ul class="ml-7 auto-rows-auto border-l-2">
                                 {% navoption "Operations Engineers", "/solutions/teams/operations-engineers/", 1, "cog" %}{% endnavoption %}
                                 {% navoption "IT Teams", "/solutions/teams/it-teams/", 1, "chip" %}{% endnavoption %}
                                 {% navoption "Maintenance Teams", "/solutions/teams/maintenance-teams/", 1, "adjustments-horizontal" %}{% endnavoption %}

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -261,21 +261,26 @@ eleventyComputed:
                         </ul>
                         {% endnavoption %}
                         {% navoption "Solutions", null, 0 %}
-                        <ul class="narrow sm:grid sm:grid-flow-col sm:grid-rows-6 sm:pr-1 align-left sm:auto-rows-auto items-center">
-                            {% navoption "By Application", null, 1, null, true, "pl-3 title border-l-2" %}{% endnavoption %}
+                        <ul class="narrow sm:grid sm:grid-flow-col sm:grid-rows-5 sm:grid-cols-3 sm:pr-1 align-left sm:auto-rows-auto items-center">
+                            {% navoption "Use Cases", null, 1, null, true, "pl-3 title border-l-2" %}{% endnavoption %}
                             <ul class="sub-menu grid grid-rows-subgrid row-span-4 ml-7 auto-rows-auto border-l-2">
                                 {% navoption "IT/OT Middleware", "/solutions/it-ot-middleware/", 1, "cog" %}{% endnavoption %}
                                 {% navoption "Unified Namespace", "/solutions/uns/", 1, "uns" %}{% endnavoption %}
                                 {% navoption "SCADA", "/solutions/scada/", 1, "adjustments-horizontal" %}{% endnavoption %}
                                 {% navoption "MES", "/solutions/mes/", 1, "chart" %}{% endnavoption %}
                             </ul>
-                            {% navoption "By Protocol", null, 1, null, true, "pl-3 title border-l-2" %}{% endnavoption %}
+                            {% navoption "Protocols", null, 1, null, true, "pl-3 title border-l-2" %}{% endnavoption %}
                             <ul class="sub-menu grid grid-rows-subgrid row-span-2 ml-7 auto-rows-auto border-l-2">
-                                {% navoption "Browse Protocols", "/solutions/protocols/", 1, "chip" %}{% endnavoption %}
+                                {% navoption "Browse All", "/solutions/protocols/", 1, "chip" %}{% endnavoption %}
                                 {% navoption "Connect X to Y", "/solutions/connect/", 1, "squares-plus" %}{% endnavoption %}
                             </ul>
-                            {% navoption "By Team", "/solutions/teams/", 1, "user-group" %}{% endnavoption %}
-                            {% navoption "By Use Case", "/solutions/use-cases/", 1, "chart" %}{% endnavoption %}
+                            {% navoption "By Team", null, 1, null, true, "pl-3 title border-l-2" %}{% endnavoption %}
+                            <ul class="sub-menu grid grid-rows-subgrid row-span-4 ml-7 auto-rows-auto border-l-2">
+                                {% navoption "Operations Engineers", "/solutions/teams/operations-engineers/", 1, "cog" %}{% endnavoption %}
+                                {% navoption "IT Teams", "/solutions/teams/it-teams/", 1, "chip" %}{% endnavoption %}
+                                {% navoption "Maintenance Teams", "/solutions/teams/maintenance-teams/", 1, "adjustments-horizontal" %}{% endnavoption %}
+                                {% navoption "Data Engineers", "/solutions/teams/data-engineers/", 1, "chart" %}{% endnavoption %}
+                            </ul>
                         </ul>
                         {% endnavoption %}
                         {% navoption "Resources", null, 0 %}

--- a/src/_includes/layouts/connect.njk
+++ b/src/_includes/layouts/connect.njk
@@ -1,0 +1,77 @@
+---
+layout: layouts/base.njk
+sitemapPriority: 0.7
+---
+<!-- Connect X to Y Page Layout -->
+<div class="w-full page hero">
+    <div class="w-full pt-12 pb-12 md:pt-6 md:pb-8">
+        <div class="px-6 container mx-auto text-center md:max-w-screen-lg">
+            <p class="text-indigo-600 font-semibold uppercase tracking-wide text-sm mb-2">Protocol Integration</p>
+            <h1 class="mt-0 m-auto font-medium max-w-2xl">
+                Connect <span class="text-indigo-600">{{ fromName }}</span>
+                to <span class="text-indigo-600">{{ toName }}</span>
+            </h1>
+            <p class="mb-10 max-w-2xl mx-auto">{{ pairDescription }}</p>
+
+            <!-- Visual connection diagram -->
+            <div class="flex items-center justify-center gap-2 sm:gap-4 my-8 flex-wrap sm:flex-nowrap">
+                <div class="bg-white border-2 border-indigo-200 rounded-lg p-3 sm:p-4 text-center min-w-[100px]">
+                    <span class="font-bold text-base sm:text-lg">{{ fromShortName }}</span>
+                </div>
+                <div class="text-indigo-400 text-xl sm:text-2xl">&rarr;</div>
+                <div class="bg-indigo-50 border-2 border-indigo-300 rounded-lg p-3 sm:p-4 text-center min-w-[100px]">
+                    <span class="font-bold text-base sm:text-lg text-indigo-700">FlowFuse</span>
+                </div>
+                <div class="text-indigo-400 text-xl sm:text-2xl">&rarr;</div>
+                <div class="bg-white border-2 border-indigo-200 rounded-lg p-3 sm:p-4 text-center min-w-[100px]">
+                    <span class="font-bold text-base sm:text-lg">{{ toShortName }}</span>
+                </div>
+            </div>
+
+            <div class="flex gap-3 justify-center">
+                <a class="ff-btn ff-btn--primary min-h-[40px]" href="/contact-us/" onclick="capture('cta-talk-to-an-expert', {'position': 'primary'}, {'page': 'connect-{{ fromSlug }}-to-{{ toSlug }}'})">TALK TO AN EXPERT</a>
+                <a class="ff-btn ff-btn--primary-outlined min-h-[40px]" href="{% include 'sign-up-url.njk' %}" onclick="capture('cta-get-started', {'position': 'primary'}, {'page': 'connect-{{ fromSlug }}-to-{{ toSlug }}'})">GET STARTED</a>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Content body -->
+<div class="w-full px-6">
+    <div class="max-w-screen-lg mx-auto">
+        {{ content | safe }}
+    </div>
+</div>
+
+<!-- Reverse direction link -->
+<div class="w-full py-8 px-6 text-center">
+    <div class="max-w-screen-lg mx-auto">
+        <p class="text-gray-600">
+            Looking for the other direction?
+            <a href="/solutions/connect/{{ toSlug }}-to-{{ fromSlug }}/" class="text-indigo-600 font-semibold">
+                Connect {{ toName }} to {{ fromName }} &rarr;
+            </a>
+        </p>
+    </div>
+</div>
+
+<!-- Related Protocol Pages -->
+<div class="w-full bg-indigo-50/50 py-12 px-6">
+    <div class="max-w-screen-lg mx-auto">
+        <h2 class="font-bold text-center mb-8">Learn More</h2>
+        <div class="grid sm:grid-cols-2 gap-4 max-w-xl mx-auto">
+            <a href="/solutions/protocols/{{ fromSlug }}/"
+               class="block p-4 bg-white rounded-lg border border-gray-200 hover:border-indigo-300 hover:shadow-md transition-all hover:no-underline group">
+                <span class="font-semibold text-indigo-600 group-hover:text-indigo-800">{{ fromName }}</span>
+                <p class="text-sm text-gray-600 mt-1 mb-0">All {{ fromShortName }} integrations</p>
+            </a>
+            <a href="/solutions/protocols/{{ toSlug }}/"
+               class="block p-4 bg-white rounded-lg border border-gray-200 hover:border-indigo-300 hover:shadow-md transition-all hover:no-underline group">
+                <span class="font-semibold text-indigo-600 group-hover:text-indigo-800">{{ toName }}</span>
+                <p class="text-sm text-gray-600 mt-1 mb-0">All {{ toShortName }} integrations</p>
+            </a>
+        </div>
+    </div>
+</div>
+
+{% include "common-cta.njk" %}

--- a/src/_includes/layouts/protocol.njk
+++ b/src/_includes/layouts/protocol.njk
@@ -1,0 +1,51 @@
+---
+layout: layouts/base.njk
+sitemapPriority: 0.8
+---
+<!-- Protocol Page Layout -->
+<div class="w-full page hero">
+    <div class="w-full pt-12 pb-12 md:pt-6 md:pb-8">
+        <div class="md:flex px-6 md:my-16 items-center md:flex-row md:justify-between container mx-auto text-center md:text-left md:max-w-screen-lg gap-8">
+            <div class="my-auto max-md:mx-auto md:w-1/2 lg:w-7/12 max-w-lg">
+                <p class="text-indigo-600 font-semibold uppercase tracking-wide text-sm mb-2">Protocol</p>
+                <h1 class="w-full mt-0 md:px-0 m-auto font-medium">
+                    FlowFuse for <span class="text-indigo-600 inline-block">{{ protocolName }}</span>
+                </h1>
+                <p class="mb-10">{{ heroDescription }}</p>
+                <div class="flex gap-3 max-md:max-w-sm max-md:mx-auto max-sm:flex-col max-md:justify-center">
+                    <a class="ff-btn ff-btn--primary min-h-[40px]" href="/contact-us/" onclick="capture('cta-talk-to-an-expert', {'position': 'primary'}, {'page': 'protocol-{{ protocolSlug }}'})">TALK TO AN EXPERT</a>
+                    <a class="ff-btn ff-btn--primary-outlined min-h-[40px]" href="{% include 'sign-up-url.njk' %}" onclick="capture('cta-get-started', {'position': 'primary'}, {'page': 'protocol-{{ protocolSlug }}'})">GET STARTED</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Main Content -->
+<div class="w-full px-6">
+    <div class="max-w-screen-lg mx-auto">
+        {{ content | safe }}
+    </div>
+</div>
+
+<!-- Connect to Other Protocols Section -->
+<div class="w-full bg-indigo-50/50 py-12 mt-12 px-6">
+    <div class="max-w-screen-lg mx-auto">
+        <h2 class="font-bold text-center mb-8">Connect {{ protocolName }} to Other Protocols</h2>
+        <div class="grid sm:grid-cols-2 md:grid-cols-3 gap-4">
+            {% for p in protocols.protocols %}
+                {% if p.slug != protocolSlug %}
+                <a href="/solutions/connect/{{ protocolSlug }}-to-{{ p.slug }}/"
+                   class="block p-4 bg-white rounded-lg border border-gray-200 hover:border-indigo-300 hover:shadow-md transition-all hover:no-underline">
+                    <span class="font-semibold text-gray-800">{{ protocolName }}</span>
+                    <span class="text-gray-400 mx-2">&rarr;</span>
+                    <span class="font-semibold text-indigo-600">{{ p.name }}</span>
+                </a>
+                {% endif %}
+            {% endfor %}
+        </div>
+    </div>
+</div>
+
+<!-- CTA -->
+{% include "common-cta.njk" %}

--- a/src/_includes/layouts/team.njk
+++ b/src/_includes/layouts/team.njk
@@ -1,0 +1,68 @@
+---
+layout: layouts/base.njk
+sitemapPriority: 0.8
+---
+<!-- Team Page Layout -->
+<div class="w-full page hero">
+    <div class="w-full pt-12 pb-12 md:pt-6 md:pb-8">
+        <div class="md:flex px-6 md:my-16 items-center container mx-auto text-center md:text-left md:max-w-screen-lg gap-8">
+            <div class="my-auto max-md:mx-auto md:w-1/2 lg:w-7/12 max-w-lg">
+                <p class="text-indigo-600 font-semibold uppercase tracking-wide text-sm mb-2">Solutions by Team</p>
+                <h1 class="w-full mt-0 md:px-0 m-auto font-medium">
+                    FlowFuse for <span class="text-indigo-600 inline-block">{{ teamName }}</span>
+                </h1>
+                <p class="mb-10">{{ heroDescription }}</p>
+                <div class="flex gap-3 max-md:max-w-sm max-md:mx-auto max-sm:flex-col max-md:justify-center">
+                    <a class="ff-btn ff-btn--primary min-h-[40px]" href="/contact-us/" onclick="capture('cta-talk-to-an-expert', {'position': 'primary'}, {'page': 'team-{{ teamSlug }}'})">TALK TO AN EXPERT</a>
+                    <a class="ff-btn ff-btn--primary-outlined min-h-[40px]" href="{% include 'sign-up-url.njk' %}" onclick="capture('cta-get-started', {'position': 'primary'}, {'page': 'team-{{ teamSlug }}'})">GET STARTED</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="w-full px-6">
+    <div class="max-w-screen-lg mx-auto">
+        {{ content | safe }}
+    </div>
+</div>
+
+<!-- Pain Points -->
+{% if teamPainPoints | length %}
+<div class="w-full bg-indigo-50/50 py-12 mt-12 px-6">
+    <div class="max-w-screen-lg mx-auto">
+        <h2 class="font-bold text-center mb-8">Challenges {{ teamName }} Face</h2>
+        <div class="grid sm:grid-cols-1 md:grid-cols-3 gap-6">
+            {% for pain in teamPainPoints %}
+            <div class="bg-white p-6 rounded-lg border border-gray-200">
+                <p class="mb-0">{{ pain }}</p>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+</div>
+{% endif %}
+
+<!-- Related Use Cases -->
+{% if relatedUseCaseSlugs | length %}
+<div class="w-full py-12 px-6">
+    <div class="max-w-screen-lg mx-auto">
+        <h2 class="font-bold text-center mb-8">Recommended Use Cases</h2>
+        <div class="grid sm:grid-cols-2 gap-4 max-w-2xl mx-auto">
+            {% for ucSlug in relatedUseCaseSlugs %}
+                {% for uc in useCases.useCases %}
+                    {% if uc.slug == ucSlug %}
+                    <a href="/solutions/use-cases/{{ uc.slug }}/"
+                       class="block p-6 bg-white rounded-lg border border-gray-200 hover:border-indigo-300 hover:shadow-md transition-all hover:no-underline group">
+                        <span class="font-semibold text-indigo-600 group-hover:text-indigo-800">{{ uc.name }}</span>
+                        <p class="text-sm text-gray-600 mt-1 mb-0">{{ uc.description | truncate(15) }}</p>
+                    </a>
+                    {% endif %}
+                {% endfor %}
+            {% endfor %}
+        </div>
+    </div>
+</div>
+{% endif %}
+
+{% include "common-cta.njk" %}

--- a/src/_includes/layouts/use-case.njk
+++ b/src/_includes/layouts/use-case.njk
@@ -1,0 +1,52 @@
+---
+layout: layouts/base.njk
+sitemapPriority: 0.8
+---
+<!-- Use Case Page Layout -->
+<div class="w-full page hero">
+    <div class="w-full pt-12 pb-12 md:pt-6 md:pb-8">
+        <div class="md:flex px-6 md:my-16 items-center container mx-auto text-center md:text-left md:max-w-screen-lg gap-8">
+            <div class="my-auto max-md:mx-auto md:w-1/2 lg:w-7/12 max-w-lg">
+                <p class="text-indigo-600 font-semibold uppercase tracking-wide text-sm mb-2">Use Case</p>
+                <h1 class="w-full mt-0 md:px-0 m-auto font-medium">
+                    {{ useCaseName }}
+                </h1>
+                <p class="mb-10">{{ heroDescription }}</p>
+                <div class="flex gap-3 max-md:max-w-sm max-md:mx-auto max-sm:flex-col max-md:justify-center">
+                    <a class="ff-btn ff-btn--primary min-h-[40px]" href="/contact-us/" onclick="capture('cta-talk-to-an-expert', {'position': 'primary'}, {'page': 'usecase-{{ useCaseSlug }}'})">TALK TO AN EXPERT</a>
+                    <a class="ff-btn ff-btn--primary-outlined min-h-[40px]" href="{% include 'sign-up-url.njk' %}" onclick="capture('cta-get-started', {'position': 'primary'}, {'page': 'usecase-{{ useCaseSlug }}'})">GET STARTED</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="w-full px-6">
+    <div class="max-w-screen-lg mx-auto">
+        {{ content | safe }}
+    </div>
+</div>
+
+<!-- Related Protocols -->
+{% if relatedProtocolSlugs | length %}
+<div class="w-full bg-indigo-50/50 py-12 mt-12 px-6">
+    <div class="max-w-screen-lg mx-auto">
+        <h2 class="font-bold text-center mb-8">Protocols for {{ useCaseName }}</h2>
+        <div class="grid sm:grid-cols-2 md:grid-cols-3 gap-4">
+            {% for pSlug in relatedProtocolSlugs %}
+                {% for p in protocols.protocols %}
+                    {% if p.slug == pSlug %}
+                    <a href="/solutions/protocols/{{ p.slug }}/"
+                       class="block p-4 bg-white rounded-lg border border-gray-200 hover:border-indigo-300 hover:shadow-md transition-all hover:no-underline group">
+                        <span class="font-semibold text-indigo-600 group-hover:text-indigo-800">{{ p.name }}</span>
+                        <p class="text-sm text-gray-600 mt-1 mb-0">{{ p.description | truncate(15) }}</p>
+                    </a>
+                    {% endif %}
+                {% endfor %}
+            {% endfor %}
+        </div>
+    </div>
+</div>
+{% endif %}
+
+{% include "common-cta.njk" %}

--- a/src/solutions/connect/connect.njk
+++ b/src/solutions/connect/connect.njk
@@ -1,0 +1,65 @@
+---
+pagination:
+    data: protocolPairs
+    size: 1
+    alias: pair
+layout: layouts/connect.njk
+eleventyComputed:
+    permalink: /solutions/connect/{{ pair.slug }}/
+    title: "{{ pair.title }}"
+    fromName: "{{ pair.from.name }}"
+    fromShortName: "{{ pair.from.shortName }}"
+    fromSlug: "{{ pair.from.slug }}"
+    toName: "{{ pair.to.name }}"
+    toShortName: "{{ pair.to.shortName }}"
+    toSlug: "{{ pair.to.slug }}"
+    pairDescription: "{{ pair.description }}"
+    meta:
+        title: "{{ pair.meta.title }}"
+        description: "{{ pair.meta.description }}"
+        keywords: "{{ pair.meta.keywords }}"
+---
+<div class="mt-12 content">
+    <h2 class="mb-4">How to Connect {{ pair.from.name }} to {{ pair.to.name }}</h2>
+    <p>
+        FlowFuse makes it easy to bridge data from {{ pair.from.name }} to {{ pair.to.name }}
+        using Node-RED's visual flow editor. No custom code required.
+    </p>
+
+    <div class="mt-8">
+        <h3>Step-by-Step Guide</h3>
+        <div class="space-y-6">
+            <div class="flex gap-4 items-start">
+                <div class="bg-indigo-100 text-indigo-700 rounded-full w-8 h-8 flex items-center justify-center font-bold flex-shrink-0">1</div>
+                <div>
+                    <h4 class="mt-0">Set up your {{ pair.from.shortName }} connection</h4>
+                    <p>Install the {{ pair.from.shortName }} nodes from the FlowFuse integration catalog and configure your connection parameters.</p>
+                </div>
+            </div>
+            <div class="flex gap-4 items-start">
+                <div class="bg-indigo-100 text-indigo-700 rounded-full w-8 h-8 flex items-center justify-center font-bold flex-shrink-0">2</div>
+                <div>
+                    <h4 class="mt-0">Transform your data</h4>
+                    <p>Use function nodes or built-in transformers to reshape, filter, and enrich your data as it flows through the pipeline.</p>
+                </div>
+            </div>
+            <div class="flex gap-4 items-start">
+                <div class="bg-indigo-100 text-indigo-700 rounded-full w-8 h-8 flex items-center justify-center font-bold flex-shrink-0">3</div>
+                <div>
+                    <h4 class="mt-0">Send data to {{ pair.to.shortName }}</h4>
+                    <p>Configure the {{ pair.to.shortName }} output node to deliver data to your target system in the format it expects.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="mt-12 bg-indigo-50 border border-indigo-200 rounded-lg p-6">
+        <h3 class="mt-0">Why use FlowFuse for this integration?</h3>
+        <ul>
+            <li><strong>No middleware complexity</strong> &mdash; FlowFuse handles the protocol translation natively</li>
+            <li><strong>Scale to production</strong> &mdash; Deploy at the edge or in the cloud with fleet management</li>
+            <li><strong>Enterprise governance</strong> &mdash; SSO, RBAC, and audit trails for every change</li>
+            <li><strong>Professional support</strong> &mdash; FlowFuse certified nodes with guaranteed quality</li>
+        </ul>
+    </div>
+</div>

--- a/src/solutions/connect/index.njk
+++ b/src/solutions/connect/index.njk
@@ -1,0 +1,46 @@
+---
+layout: nohero
+meta:
+    title: "Connect Any Protocol to Any Protocol - FlowFuse"
+    description: "Browse all protocol connections: OPC-UA to MQTT, Modbus to REST, Ethernet/IP to S7, and more. FlowFuse bridges any industrial protocol."
+    keywords: "protocol connections, connect OPC-UA to MQTT, connect Modbus to REST, FlowFuse, industrial integration"
+---
+<div class="nohero w-full">
+    <div class="w-full pt-12 pb-8">
+        <div class="px-6 container mx-auto text-center md:max-w-screen-lg">
+            <h1 class="mt-0 m-auto font-medium">
+                Connect <span class="text-indigo-600">Any Protocol</span> to Any Other
+            </h1>
+            <p class="max-w-2xl mx-auto text-lg">
+                FlowFuse bridges data between any industrial protocols. Select a pair below
+                to learn how to connect them.
+            </p>
+        </div>
+    </div>
+
+    <div class="container m-auto max-w-screen-lg px-6 pb-12">
+        {% for protocol in protocols.protocols %}
+        <div class="mb-10">
+            <h3 class="mb-4 flex items-center gap-2">
+                <span>Connect</span>
+                <a href="/solutions/protocols/{{ protocol.slug }}/" class="text-indigo-600 hover:text-indigo-800">{{ protocol.name }}</a>
+                <span>to...</span>
+            </h3>
+            <div class="grid sm:grid-cols-2 md:grid-cols-3 gap-3">
+                {% for other in protocols.protocols %}
+                    {% if other.slug != protocol.slug %}
+                    <a href="/solutions/connect/{{ protocol.slug }}-to-{{ other.slug }}/"
+                       class="block p-3 bg-white rounded-lg border border-gray-200 hover:border-indigo-300 hover:shadow-md transition-all hover:no-underline text-sm">
+                        <span class="font-semibold text-gray-800">{{ protocol.shortName }}</span>
+                        <span class="text-gray-400 mx-1">&rarr;</span>
+                        <span class="font-semibold text-indigo-600">{{ other.shortName }}</span>
+                    </a>
+                    {% endif %}
+                {% endfor %}
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+</div>
+
+{% include "common-cta.njk" %}

--- a/src/solutions/protocols/index.njk
+++ b/src/solutions/protocols/index.njk
@@ -1,0 +1,59 @@
+---
+layout: nohero
+meta:
+    title: "Industrial Protocols - FlowFuse Solutions"
+    description: "Browse industrial protocols supported by FlowFuse: OPC-UA, MQTT, Modbus, Ethernet/IP, Siemens S7, and more."
+    keywords: "industrial protocols, OPC-UA, MQTT, Modbus, Ethernet/IP, FlowFuse, Node-RED"
+---
+<div class="nohero w-full">
+    <div class="w-full pt-12 pb-8">
+        <div class="px-6 container mx-auto text-center md:max-w-screen-lg">
+            <h1 class="mt-0 m-auto font-medium">
+                Industrial <span class="text-indigo-600">Protocols</span>
+            </h1>
+            <p class="max-w-2xl mx-auto text-lg">
+                Browse all industrial protocols that FlowFuse connects. Each protocol page shows
+                how FlowFuse bridges that protocol to your enterprise systems.
+            </p>
+        </div>
+    </div>
+
+    <div class="container m-auto max-w-screen-lg px-6 pb-12">
+        <div class="grid sm:grid-cols-2 md:grid-cols-3 gap-6 mt-8">
+            {% for protocol in protocols.protocols %}
+            <a href="/solutions/protocols/{{ protocol.slug }}/"
+               class="block p-6 bg-white rounded-lg border border-gray-200 hover:border-indigo-300 hover:shadow-md transition-all hover:no-underline group">
+                <h3 class="mt-0 mb-2 group-hover:text-indigo-600">{{ protocol.name }}</h3>
+                <span class="inline-block text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded mb-3">{{ protocol.category }}</span>
+                <p class="text-sm text-gray-600 mb-0">{{ protocol.description | truncate(20) }}</p>
+            </a>
+            {% endfor %}
+        </div>
+    </div>
+
+    <!-- Connect X to Y Teaser -->
+    <div class="w-full bg-indigo-50/50 py-12 px-6" id="connect">
+        <div class="max-w-screen-lg mx-auto text-center">
+            <h2 class="font-bold mb-4">Connect Any Protocol to Any Other</h2>
+            <p class="text-gray-600 max-w-2xl mx-auto mb-8">
+                FlowFuse makes it easy to bridge data between different industrial protocols.
+                Choose a pair below to learn how.
+            </p>
+            <div class="grid sm:grid-cols-2 md:grid-cols-3 gap-3 text-left">
+                {% for pair in protocolPairs | head(9) %}
+                <a href="/solutions/connect/{{ pair.slug }}/"
+                   class="block p-3 bg-white rounded-lg border border-gray-200 hover:border-indigo-300 hover:shadow-md transition-all hover:no-underline text-sm">
+                    <span class="font-semibold text-gray-800">{{ pair.from.shortName }}</span>
+                    <span class="text-gray-400 mx-1">&rarr;</span>
+                    <span class="font-semibold text-indigo-600">{{ pair.to.shortName }}</span>
+                </a>
+                {% endfor %}
+            </div>
+            <a href="/solutions/connect/" class="inline-block mt-6 text-indigo-600 font-semibold hover:text-indigo-800">
+                View all protocol connections &rarr;
+            </a>
+        </div>
+    </div>
+</div>
+
+{% include "common-cta.njk" %}

--- a/src/solutions/protocols/protocols.njk
+++ b/src/solutions/protocols/protocols.njk
@@ -1,0 +1,59 @@
+---
+pagination:
+    data: protocols.protocols
+    size: 1
+    alias: protocol
+layout: layouts/protocol.njk
+eleventyComputed:
+    permalink: /solutions/protocols/{{ protocol.slug }}/
+    title: "FlowFuse for {{ protocol.name }}"
+    protocolName: "{{ protocol.name }}"
+    protocolSlug: "{{ protocol.slug }}"
+    heroDescription: "{{ protocol.heroDescription }}"
+    meta:
+        title: "{{ protocol.meta.title }}"
+        description: "{{ protocol.meta.description }}"
+        keywords: "{{ protocol.meta.keywords }}"
+---
+<div class="mt-12 content">
+    <h2 class="mb-4">How FlowFuse Connects {{ protocol.name }}</h2>
+    <p>
+        FlowFuse, powered by Node-RED, provides native support for {{ protocol.name }} connectivity.
+        Whether you need to collect data, monitor equipment, or bridge {{ protocol.shortName }} to other systems,
+        FlowFuse makes it simple with a visual, low-code approach.
+    </p>
+
+    <div class="grid md:grid-cols-2 gap-8 mt-8">
+        <div class="bg-white border border-gray-200 rounded-lg p-6">
+            <h3 class="mt-0">Key Capabilities</h3>
+            <ul>
+                <li>Connect to {{ protocol.shortName }} devices with pre-built nodes</li>
+                <li>Transform and normalize data in real time</li>
+                <li>Route data to databases, dashboards, and cloud platforms</li>
+                <li>Deploy at the edge or in the cloud</li>
+                <li>Scale from one device to thousands with FlowFuse fleet management</li>
+            </ul>
+        </div>
+        <div class="bg-white border border-gray-200 rounded-lg p-6">
+            <h3 class="mt-0">Why FlowFuse?</h3>
+            <ul>
+                <li>Enterprise-grade security with SSO and RBAC</li>
+                <li>Visual, low-code development with Node-RED</li>
+                <li>Fleet management for edge deployments</li>
+                <li>Built-in MQTT broker for data routing</li>
+                <li>Professional support and certified nodes</li>
+            </ul>
+        </div>
+    </div>
+
+    {% if protocol.relatedIntegrations.length > 0 %}
+    <h2 class="mt-12 mb-4">Related Node-RED Integrations</h2>
+    <div class="grid sm:grid-cols-2 md:grid-cols-3 gap-4">
+        {% for nodeId in protocol.relatedIntegrations %}
+        <a href="/integrations/{{ nodeId }}/" class="block p-4 bg-white rounded-lg border border-gray-200 hover:border-indigo-300 hover:shadow-md transition-all hover:no-underline">
+            <span class="font-mono text-sm text-indigo-600">{{ nodeId }}</span>
+        </a>
+        {% endfor %}
+    </div>
+    {% endif %}
+</div>

--- a/src/solutions/teams/index.njk
+++ b/src/solutions/teams/index.njk
@@ -1,0 +1,43 @@
+---
+layout: nohero
+meta:
+    title: "Solutions by Team - FlowFuse"
+    description: "Discover how FlowFuse helps different teams: operations engineers, IT teams, maintenance teams, and data engineers."
+    keywords: "FlowFuse solutions, operations engineers, IT teams, maintenance teams, data engineers"
+---
+<div class="nohero w-full">
+    <div class="w-full pt-12 pb-8">
+        <div class="px-6 container mx-auto text-center md:max-w-screen-lg">
+            <h1 class="mt-0 m-auto font-medium">
+                Solutions by <span class="text-indigo-600">Team</span>
+            </h1>
+            <p class="max-w-2xl mx-auto text-lg">
+                Discover how FlowFuse helps different teams across your organization —
+                from operations engineers to data engineers.
+            </p>
+        </div>
+    </div>
+
+    <div class="container m-auto max-w-screen-lg px-6 pb-12">
+        <div class="grid sm:grid-cols-2 gap-6 mt-8">
+            {% for team in teams.teams %}
+            <a href="/solutions/teams/{{ team.slug }}/"
+               class="block p-6 bg-white rounded-lg border border-gray-200 hover:border-indigo-300 hover:shadow-md transition-all hover:no-underline group">
+                <h3 class="mt-0 mb-2 group-hover:text-indigo-600">{{ team.name }}</h3>
+                <p class="text-sm text-gray-600 mb-3">{{ team.description | truncate(20) }}</p>
+                <div class="flex flex-wrap gap-2">
+                    {% for ucSlug in team.relatedUseCases %}
+                        {% for uc in useCases.useCases %}
+                            {% if uc.slug == ucSlug %}
+                            <span class="text-xs bg-indigo-50 text-indigo-600 px-2 py-1 rounded">{{ uc.name }}</span>
+                            {% endif %}
+                        {% endfor %}
+                    {% endfor %}
+                </div>
+            </a>
+            {% endfor %}
+        </div>
+    </div>
+</div>
+
+{% include "common-cta.njk" %}

--- a/src/solutions/teams/teams.njk
+++ b/src/solutions/teams/teams.njk
@@ -1,0 +1,60 @@
+---
+pagination:
+    data: teams.teams
+    size: 1
+    alias: team
+layout: layouts/team.njk
+eleventyComputed:
+    permalink: /solutions/teams/{{ team.slug }}/
+    title: "FlowFuse for {{ team.name }}"
+    teamName: "{{ team.name }}"
+    teamSlug: "{{ team.slug }}"
+    heroDescription: "{{ team.heroDescription }}"
+    teamPainPoints: "{{ team.painPoints }}"
+    relatedUseCaseSlugs: "{{ team.relatedUseCases }}"
+    meta:
+        title: "{{ team.meta.title }}"
+        description: "{{ team.meta.description }}"
+        keywords: "{{ team.meta.keywords }}"
+---
+<div class="mt-12 content">
+    <h2 class="mb-4">How {{ team.name }} Use FlowFuse</h2>
+    <p>{{ team.description }}</p>
+
+    <div class="mt-8 grid md:grid-cols-2 gap-8">
+        <div class="bg-white border border-gray-200 rounded-lg p-6">
+            <h3 class="mt-0">What You Can Build</h3>
+            <ul>
+                <li>Custom dashboards for real-time visibility</li>
+                <li>Automated data pipelines across protocols</li>
+                <li>Alert systems for critical conditions</li>
+                <li>Integration workflows between OT and IT systems</li>
+            </ul>
+        </div>
+        <div class="bg-white border border-gray-200 rounded-lg p-6">
+            <h3 class="mt-0">Why FlowFuse</h3>
+            <ul>
+                <li>No deep programming expertise required</li>
+                <li>Thousands of pre-built Node-RED nodes</li>
+                <li>Enterprise security and governance</li>
+                <li>Scale from prototype to production</li>
+            </ul>
+        </div>
+    </div>
+
+    {% if team.relatedProtocols.length > 0 %}
+    <h2 class="mt-12 mb-4">Protocols You'll Work With</h2>
+    <div class="grid sm:grid-cols-2 md:grid-cols-3 gap-4">
+        {% for pSlug in team.relatedProtocols %}
+            {% for p in protocols.protocols %}
+                {% if p.slug == pSlug %}
+                <a href="/solutions/protocols/{{ p.slug }}/" class="block p-4 bg-white rounded-lg border border-gray-200 hover:border-indigo-300 hover:shadow-md transition-all hover:no-underline group">
+                    <span class="font-semibold text-indigo-600 group-hover:text-indigo-800">{{ p.name }}</span>
+                    <p class="text-sm text-gray-600 mt-1 mb-0">{{ p.description | truncate(12) }}</p>
+                </a>
+                {% endif %}
+            {% endfor %}
+        {% endfor %}
+    </div>
+    {% endif %}
+</div>

--- a/src/solutions/use-cases/index.njk
+++ b/src/solutions/use-cases/index.njk
@@ -1,0 +1,43 @@
+---
+layout: nohero
+meta:
+    title: "Industrial Use Cases - FlowFuse Solutions"
+    description: "Explore FlowFuse use cases: data acquisition, machine monitoring, predictive maintenance, protocol conversion, and more."
+    keywords: "industrial use cases, data acquisition, machine monitoring, predictive maintenance, FlowFuse"
+---
+<div class="nohero w-full">
+    <div class="w-full pt-12 pb-8">
+        <div class="px-6 container mx-auto text-center md:max-w-screen-lg">
+            <h1 class="mt-0 m-auto font-medium">
+                Industrial <span class="text-indigo-600">Use Cases</span>
+            </h1>
+            <p class="max-w-2xl mx-auto text-lg">
+                Explore how FlowFuse addresses common industrial automation use cases,
+                from data acquisition to predictive maintenance.
+            </p>
+        </div>
+    </div>
+
+    <div class="container m-auto max-w-screen-lg px-6 pb-12">
+        <div class="grid sm:grid-cols-2 gap-6 mt-8">
+            {% for useCase in useCases.useCases %}
+            <a href="/solutions/use-cases/{{ useCase.slug }}/"
+               class="block p-6 bg-white rounded-lg border border-gray-200 hover:border-indigo-300 hover:shadow-md transition-all hover:no-underline group">
+                <h3 class="mt-0 mb-2 group-hover:text-indigo-600">{{ useCase.name }}</h3>
+                <p class="text-sm text-gray-600 mb-3">{{ useCase.description | truncate(25) }}</p>
+                <div class="flex flex-wrap gap-2">
+                    {% for protocolSlug in useCase.relatedProtocols %}
+                        {% for protocol in protocols.protocols %}
+                            {% if protocol.slug == protocolSlug %}
+                            <span class="text-xs bg-indigo-50 text-indigo-600 px-2 py-1 rounded">{{ protocol.shortName }}</span>
+                            {% endif %}
+                        {% endfor %}
+                    {% endfor %}
+                </div>
+            </a>
+            {% endfor %}
+        </div>
+    </div>
+</div>
+
+{% include "common-cta.njk" %}

--- a/src/solutions/use-cases/use-cases.njk
+++ b/src/solutions/use-cases/use-cases.njk
@@ -1,0 +1,59 @@
+---
+pagination:
+    data: useCases.useCases
+    size: 1
+    alias: useCase
+layout: layouts/use-case.njk
+eleventyComputed:
+    permalink: /solutions/use-cases/{{ useCase.slug }}/
+    title: "{{ useCase.name }} with FlowFuse"
+    useCaseName: "{{ useCase.name }}"
+    useCaseSlug: "{{ useCase.slug }}"
+    heroDescription: "{{ useCase.heroDescription }}"
+    relatedProtocolSlugs: "{{ useCase.relatedProtocols }}"
+    meta:
+        title: "{{ useCase.meta.title }}"
+        description: "{{ useCase.meta.description }}"
+        keywords: "{{ useCase.meta.keywords }}"
+---
+<div class="mt-12 content">
+    <h2 class="mb-4">{{ useCase.name }} with FlowFuse</h2>
+    <p>{{ useCase.description }}</p>
+
+    <div class="mt-8 bg-white border border-gray-200 rounded-lg p-6">
+        <h3 class="mt-0">How It Works</h3>
+        <div class="space-y-6">
+            <div class="flex gap-4 items-start">
+                <div class="bg-indigo-100 text-indigo-700 rounded-full w-8 h-8 flex items-center justify-center font-bold flex-shrink-0">1</div>
+                <div>
+                    <h4 class="mt-0">Connect your data sources</h4>
+                    <p>Use Node-RED's extensive library of protocol nodes to connect to your equipment, sensors, and systems.</p>
+                </div>
+            </div>
+            <div class="flex gap-4 items-start">
+                <div class="bg-indigo-100 text-indigo-700 rounded-full w-8 h-8 flex items-center justify-center font-bold flex-shrink-0">2</div>
+                <div>
+                    <h4 class="mt-0">Transform and process</h4>
+                    <p>Use FlowFuse's visual flow editor to transform, filter, aggregate, and enrich your data in real time.</p>
+                </div>
+            </div>
+            <div class="flex gap-4 items-start">
+                <div class="bg-indigo-100 text-indigo-700 rounded-full w-8 h-8 flex items-center justify-center font-bold flex-shrink-0">3</div>
+                <div>
+                    <h4 class="mt-0">Deliver and act</h4>
+                    <p>Route data to dashboards, databases, cloud platforms, or trigger automated actions based on conditions.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="mt-8 bg-white border border-gray-200 rounded-lg p-6">
+        <h3 class="mt-0">Benefits</h3>
+        <ul>
+            <li>Reduce time-to-value with low-code development</li>
+            <li>Scale from proof-of-concept to production seamlessly</li>
+            <li>Enterprise-grade security and governance</li>
+            <li>Professional support and certified nodes</li>
+        </ul>
+    </div>
+</div>


### PR DESCRIPTION
Serves as prototype for showcasing to https://github.com/FlowFuse/product/issues/23

## Description

Introduces data-driven page generation for marketing solutions, organized by protocol, use case, and team. Includes:

- **Protocols**: 6 placeholder protocols with auto-generated "Connect X to Y" pages (30 pages via Eleventy pagination)
- **Use Cases**: IT/OT convergence, UNS, SCADA modernization, MES integration categories
- **Teams**: Engineering, Operations, IT, Management landing pages
- **Navigation**: Restructured Solutions nav dropdown into a categorized 3-column mega-menu (By Use Case, By Protocol, By Team)

Content is scaffolded with placeholder text — to be filled in later.

## Related Issue(s)

N/A — new scaffolding for solutions section

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
- [x] I have considered the performance impact of these changes
- [ ] Suitable unit/system level tests have been added and they pass
- [ ] Documentation has been updated
- [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))