### PR TITLE
Remove low latency meeting section from discovery.md

### DIFF
--- a/src/handbook/sales/meetings/discovery.md
+++ b/src/handbook/sales/meetings/discovery.md
@@ -9,18 +9,3 @@ FlowFuse will use the "Discovery Call Playbook" in Hubspot, [Learn how to use
 playbooks](https://knowledge.hubspot.com/playbooks/use-playbooks#use-playbooks-in-contact-company-deal-ticket-or-custom-crm-records).
 
 The next step depends on the outcome of the call, but usually results in a more technical discussion, product demonstration, or sending relevant content to follow-up on at an appropriate time in the future.
-## Low Latency Meeting
-
-A "low-latency" meeting can be scheduled on our website to make sure customers
-can find help without much delay when they need it. When someone requests a call,
-it connects directly to our team’s calendars — meaning any of us may end up
-speaking with an interested prospect within minutes. Like if we were in an
-actual office and the phone rings, someone has to pick it up. 
-
-These calls are short (10–15 minutes) and are not about closing a deal. The goal
-is simply to have a friendly first conversation, capture who is having an issue,
-help them get the right help from the Company, and then pass the lead to the
-most relevant sales teammate.
-
-To make this easy, we’ve prepared a simple playbook with a step-by-step guide on how to handle these calls: [Discovery Call Playbook](https://docs.google.com/document/d/1mzv1c7qEHQ_Pg6tJVuMrRRxNTiDx_aeEW9052aSJVeo/edit?usp=sharing).
-


### PR DESCRIPTION
## Description

Removed section on low latency meetings from the discovery call documentation.


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

