### PR TITLE
Fix release blog

### DIFF
--- a/src/blog/2026/03/flowfuse-release-2-28.md
+++ b/src/blog/2026/03/flowfuse-release-2-28.md
@@ -64,7 +64,7 @@ The latest Device Agent lets you set Node.js command line arguments for Remote I
 
 ### Set API Payload Limits from the UI
 
-If your Remote Instances handle large MQTT messages or file uploads, you may have hit the default API payload size limit. You can now configure the maximum API payload length directly in FlowFuse under **Remote Instance → Settings → Editor**.
+If your Remote Instances handle large file uploads, you may have hit the default API payload size limit. You can now configure the maximum API payload length directly in FlowFuse under **Remote Instance → Settings → Editor**.
 
 ## More Flexibility for Self-Hosted Deployments
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

- Removes mention of MQTT in the API size change section as it has nothing to do with MQTT message sizes only incoming HTTP messages
- Remove mention of Valkey reconnect fixes, no need to know the reconnect logic was broken, especially as horizontal scaling is still broken for device editor access and has been disabled.
- Fix scheduled maintenance description
- Update device agent nodejs cli argument description
- Fix Team NPM registry description, why are we calling out a setting that 99.9% users shouldn't touch
- Remove K8s PVC access mode change, changing this WILL break HA mode

