### PR TITLE
feat: add alert boxes to use in FlowFuse documentation

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -24,6 +24,16 @@ const { isSearchPage, isSearchUrl, extractHeadingRecords } = require("./lib/sear
 const yaml = require("js-yaml");
 const eleventyNavigationPlugin = require("@11ty/eleventy-navigation");
 
+// Documentation alert boxes
+const shortcodeMarkdown = new markdownIt()
+
+function renderDocsAlertBox(content, tone = 'note', title = '') {
+    const normalizedTone = tone.toLowerCase();
+    const resolvedTitle = title
+    const markdownContent = shortcodeMarkdown.render(content)
+
+    return `<div class="ff-callout ff-callout--${normalizedTone}"><p class="ff-callout__title">${resolvedTitle}</p><div class="ff-callout__content">${markdownContent}</div></div>`
+}
 
 // Skip slow optimizations when developing i.e. serve/watch or Netlify deploy preview
 const DEV_MODE = process.env.ELEVENTY_RUN_MODE !== "build" || process.env.CONTEXT === "deploy-preview" || process.env.SKIP_IMAGES === 'true'
@@ -240,6 +250,20 @@ module.exports = function(eleventyConfig) {
         let markdownContent = md.render(content);
         return `<div class="ff-blue-card">${markdownContent}</div>`;
     });
+
+    // Documentation alert boxes
+    eleventyConfig.addPairedLiquidShortcode('note', function (content, title = '') {
+        return renderDocsAlertBox(content, 'note', "Note")
+    })
+
+    eleventyConfig.addPairedLiquidShortcode('warning', function (content, title = '') {
+        return renderDocsAlertBox(content, 'warning', "Warning")
+    })
+
+    eleventyConfig.addPairedLiquidShortcode('critical', function (content, title = '') {
+        return renderDocsAlertBox(content, 'critical', "Critical")
+    })
+
 
     let flowId = 0; // Keep a global counter to allow more than one 
     eleventyConfig.addPairedShortcode("renderFlow", function (flow, height = 200) {

--- a/src/css/style.docs.css
+++ b/src/css/style.docs.css
@@ -85,3 +85,54 @@
 .checklist-item .tooltip:hover:after {
     display:block;
 }
+
+.prose .ff-callout__content > :first-child {
+    margin-top: 0;
+}
+
+.prose .ff-callout__content > :last-child {
+    margin-bottom: 0;
+}
+
+.ff-callout {
+    @apply my-6 border-l-2 px-4 py-3;
+}
+
+.main-content .ff-callout {
+    @apply mb-6;
+}
+
+.ff-callout__title {
+    @apply mt-0 mb-1 text-sm font-bold uppercase tracking-wide;
+}
+
+.ff-callout__content > * {
+    @apply text-left;
+}
+
+.ff-callout--note {
+    background-color: theme(colors.blue.50);
+    border-left-color: theme(colors.blue.500);
+}
+
+.ff-callout--note .ff-callout__title {
+    color: theme(colors.blue.700);
+}
+
+.ff-callout--warning {
+    background-color: #fef3c7;
+    border-left-color: #f59e0b;
+}
+
+.ff-callout--warning .ff-callout__title {
+    color: #b45309;
+}
+
+.ff-callout--critical {
+    background-color: theme(colors.red.50);
+    border-left-color: theme(colors.red.500);
+}
+
+.ff-callout--critical .ff-callout__title {
+    color: theme(colors.red.700);
+}


### PR DESCRIPTION
## Description

This pull request introduces reusable documentation alert boxes rendered through Liquid shortcodes and styled in the docs stylesheet only. This standardises Note/Warning/Critical messaging in docs content and keeps callout concerns isolated from global site styles.

Examples:
<img width="1305" height="367" alt="Zrzut ekranu 2026-03-16 o 13 55 48" src="https://github.com/user-attachments/assets/24cfcb4d-b4df-4b24-94a0-d33b9e2e7200" />


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

