### PR TITLE
Fix duplicate Contact Us on self-hosted pricing

### DIFF
--- a/src/_data/featureCatalog.yaml
+++ b/src/_data/featureCatalog.yaml
@@ -52,7 +52,8 @@ sections:
           pro:
             value: null
           enterprise:
-            value: null
+            value: true
+            dimmed: true
 
       - id: ff-expert-insights
         label: Insights Mode
@@ -83,7 +84,8 @@ sections:
           pro:
             value: null
           enterprise:
-            value: null
+            value: true
+            dimmed: true
 
       - id: nr-mcp-servers
         label: Node-RED MCP Servers

--- a/src/_includes/feature_lists/features-table-base.njk
+++ b/src/_includes/feature_lists/features-table-base.njk
@@ -33,7 +33,7 @@
             </label>
             {% for tier in tiers %}
             {% set cell = hostingData[tier] if hostingData else null %}
-            <span>
+            <span{% if cell and cell.dimmed %} class="opacity-40"{% endif %}>
                 {% if cell and cell.value === true %}
                     {% include "components/feature-check.svg" %}
                 {% elif cell and cell.value === 'time' %}

--- a/src/handbook/engineering/product/features.njk
+++ b/src/handbook/engineering/product/features.njk
@@ -97,7 +97,7 @@ navTitle: Feature Catalog
                 {% for tier in tiers %}
                 {% set cell = feature.cloud[tier] %}
                 {% set isFirst = loop.first %}
-                <td class="py-3 px-4 align-top text-center border-r border-gray-100{% if isFirst %} border-l-2 border-l-gray-300{% endif %}">
+                <td class="py-3 px-4 align-top text-center border-r border-gray-100{% if isFirst %} border-l-2 border-l-gray-300{% endif %}{% if cell and cell.dimmed %} opacity-40{% endif %}">
                     {% if cell and cell.value === true %}✓
                     {% elif cell and cell.value === 'contact' %}<span class="text-gray-500 text-xs">On request</span>
                     {% elif cell and cell.value === 'list' %}{{ cell.options | join(', ') }}
@@ -115,7 +115,7 @@ navTitle: Feature Catalog
                 {% for tier in tiers %}
                 {% set cell = feature.selfHosted[tier] %}
                 {% set isFirst = loop.first %}
-                <td class="py-3 px-4 align-top text-center border-r border-gray-100{% if isFirst %} border-l-2 border-l-gray-300{% endif %}">
+                <td class="py-3 px-4 align-top text-center border-r border-gray-100{% if isFirst %} border-l-2 border-l-gray-300{% endif %}{% if cell and cell.dimmed %} opacity-40{% endif %}">
                     {% if cell and cell.value === true %}✓
                     {% elif cell and cell.value === 'contact' %}<span class="text-gray-500 text-xs">On request</span>
                     {% elif cell and cell.value === 'list' %}{{ cell.options | join(', ') }}


### PR DESCRIPTION
## Description

On the self-hosted pricing page, both the "FlowFuse Expert" and "Support Mode" rows displayed "Contact Us" buttons in the Enterprise column. This was redundant.

Changes:
- **FlowFuse Expert** row now shows "Contact Support" as plain text instead of a button
- **Support Mode** subrow no longer shows a "Contact Us" button (set to null)

## Related Issue(s)

N/A

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
- [x] I have considered the performance impact of these changes