### PR TITLE
Refine tier badges for changelog and blog entries

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -733,24 +733,21 @@ module.exports = function(eleventyConfig) {
         if (!feature) return '';
         const cloudLabel = deriveTierLabel(feature.cloud);
         const selfHostedLabel = deriveTierLabel(feature.selfHosted);
-        if (!cloudLabel && !selfHostedLabel) return '';
-        const featureId = feature.id;
+        const showCloud = cloudLabel && cloudLabel !== 'Not available';
+        const showSelfHosted = selfHostedLabel && selfHostedLabel !== 'Not available';
+        if (!showCloud && !showSelfHosted) return '';
         let html = `<div class="ff-tier-badges">`;
-        if (cloudLabel) {
-            const unavailable = cloudLabel === 'Not available';
-            const anchor = featureId ? `#ff-feature--${featureId}-cloud` : '';
-            html += `<a href="/pricing/?hosting=cloud${anchor}" class="ff-tier-badge ${unavailable ? 'ff-tier--unavailable' : 'ff-tier--available'}">`;
+        if (showCloud) {
+            html += `<div class="ff-tier-badge ff-tier--available">`;
             html += `<span class="ff-tier-badge__label">Cloud</span>`;
             html += `<span class="ff-tier-badge__value">${cloudLabel}</span>`;
-            html += `</a>`;
+            html += `</div>`;
         }
-        if (selfHostedLabel) {
-            const unavailable = selfHostedLabel === 'Not available';
-            const anchor = featureId ? `#ff-feature--${featureId}-self-hosted` : '';
-            html += `<a href="/pricing/?hosting=self-hosted${anchor}" class="ff-tier-badge ${unavailable ? 'ff-tier--unavailable' : 'ff-tier--available'}">`;
+        if (showSelfHosted) {
+            html += `<div class="ff-tier-badge ff-tier--available">`;
             html += `<span class="ff-tier-badge__label">Self-Hosted</span>`;
             html += `<span class="ff-tier-badge__value">${selfHostedLabel}</span>`;
-            html += `</a>`;
+            html += `</div>`;
         }
         html += '</div>';
         return html;

--- a/src/_includes/components/tier-badges.njk
+++ b/src/_includes/components/tier-badges.njk
@@ -1,14 +1,18 @@
+{% set showTierCloud = tierCloud and tierCloud != 'Not available' %}
+{% set showTierSelfHosted = tierSelfHosted and tierSelfHosted != 'Not available' %}
+{% if showTierCloud or showTierSelfHosted %}
 <div class="ff-tier-badges">
-  {% if tierCloud %}
-    <a href="/pricing/?hosting=cloud{% if catalogFeature %}#ff-feature--{{ catalogFeature.id }}-cloud{% endif %}" class="ff-tier-badge {{ 'ff-tier--unavailable' if tierCloud == 'Not available' else 'ff-tier--available' }}">
+  {% if showTierCloud %}
+    <div class="ff-tier-badge ff-tier--available">
       <span class="ff-tier-badge__label">Cloud</span>
       <span class="ff-tier-badge__value">{{ tierCloud }}</span>
-    </a>
+    </div>
   {% endif %}
-  {% if tierSelfHosted %}
-    <a href="/pricing/?hosting=self-hosted{% if catalogFeature %}#ff-feature--{{ catalogFeature.id }}-self-hosted{% endif %}" class="ff-tier-badge {{ 'ff-tier--unavailable' if tierSelfHosted == 'Not available' else 'ff-tier--available' }}">
+  {% if showTierSelfHosted %}
+    <div class="ff-tier-badge ff-tier--available">
       <span class="ff-tier-badge__label">Self-Hosted</span>
       <span class="ff-tier-badge__value">{{ tierSelfHosted }}</span>
-    </a>
+    </div>
   {% endif %}
 </div>
+{% endif %}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1661,48 +1661,17 @@ h4:hover .header-anchor::before {
 }
 
 .ff-tier-badge {
-    display: inline-flex;
+    @apply inline-flex whitespace-nowrap text-current;
     font-size: 0.75rem;
     line-height: 1rem;
-    border-radius: 9999px;
-    overflow: hidden;
-    white-space: nowrap;
-    font-weight: 500;
-    text-decoration: none;
-    color: inherit;
-    transition: opacity 0.15s;
-}
-
-a.ff-tier-badge:hover {
-    opacity: 0.8;
 }
 
 .ff-tier-badge__label {
-    padding: 2px 8px 2px 10px;
+    @apply px-2.5 py-0.5 text-gray-500 font-medium bg-gray-100 border border-r-0 border-gray-200 rounded-l;
 }
 
 .ff-tier-badge__value {
-    padding: 2px 10px 2px 8px;
-}
-
-.ff-tier--available .ff-tier-badge__label {
-    color: #fff;
-    background-color: #6366f1;
-}
-
-.ff-tier--available .ff-tier-badge__value {
-    color: #4338ca;
-    background-color: #eef2ff;
-}
-
-.ff-tier--unavailable .ff-tier-badge__label {
-    color: #fff;
-    background-color: #9ca3af;
-}
-
-.ff-tier--unavailable .ff-tier-badge__value {
-    color: #6b7280;
-    background-color: #f3f4f6;
+    @apply px-2.5 py-0.5 text-gray-500 font-light bg-white border border-l-0 border-gray-200 rounded-r;
 }
 
 .ff-feature-info {


### PR DESCRIPTION
## Description

This PR updates tier badge rendering across changelog pages and blog articles to better match the intended UI and content behavior.

## Changes

- restyles `ff-tier-badge__label` and `ff-tier-badge__value` to use a neutral segmented badge design
- removes the clickable behavior from tier badges and renders them as static elements
- stops rendering badges for tiers marked as `Not available`
- removes the unused `unavailable` badge state styling

## Scope

This affects:
- changelog listing pages
- individual changelog pages
- blog articles that render tier badges through Eleventy feature injection

## Notes

Unavailable tiers are still represented in the pricing table as a dash, but they are no longer shown as badges in changelog or blog contexts.

## Related Issue(s)

https://github.com/FlowFuse/website/pull/4686

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

