### PR TITLE
Track CTA type in blog CTA PostHog event

### DIFF
--- a/src/_includes/cta/blog-post.njk
+++ b/src/_includes/cta/blog-post.njk
@@ -37,8 +37,11 @@
         <h3 class="mt-0 mb-0 !text-3xl text-indigo-800">{{ ctaData.title or currentCta.title }}</h3>
         <p class="mt-0 mb-0 max-w-4xl mx-auto sm:mx-0 leading-relaxed">{{ ctaData.description or currentCta.description }}</p>
         <div class="flex justify-center sm:justify-start">
-            <a class="ff-btn ff-btn--highlight uppercase items-center text-base no-underline" href="{{ buttonUrl }}" onclick="if (typeof capture !== 'undefined') { capture('blog-cta', {'reference': 'Blog: {{ title | escape }}'}); }">
-                {{ currentCta.buttonText }}
+            <a class="ff-btn ff-btn--highlight uppercase items-center text-base no-underline" href="{{ buttonUrl }}" onclick="if (typeof capture !== 'undefined')
+            { capture('blog-cta', {
+                reference: 'Blog: {{ title | escape }}',
+                cta_type: '{{ ctaType }}'}); }">
+            {{ currentCta.buttonText }}
             </a>
         </div>
     </div>


### PR DESCRIPTION
## Description

Adds `cta_type` as a property to the `blog-cta` PostHog event to improve visibility into CTA performance across blog articles.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

