### PR TITLE
Fix double tier badges on release blog posts

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -917,7 +917,7 @@ module.exports = function(eleventyConfig) {
         const parentFeature = findFeatureByDocsLink(this.page.url);
         const subfeatures = findSubfeaturesForDocsPage(this.page.url);
 
-        // Parse frontmatter for features array (same format as changelog posts)
+        // Parse frontmatter for features array — but skip pages with `release` (handled by releaseFeatures)
         let fmFeatures = [];
         const inputPath = this.page.inputPath;
         if (inputPath && inputPath.endsWith('.md')) {
@@ -926,6 +926,7 @@ module.exports = function(eleventyConfig) {
                 const fmMatch = source.match(/^---\n([\s\S]*?)\n---/);
                 if (fmMatch) {
                     const fm = yaml.load(fmMatch[1]);
+                    if (fm.release) return content;
                     if (fm.features && Array.isArray(fm.features)) {
                         fmFeatures = fm.features;
                     }


### PR DESCRIPTION
## Description

The `docsFeatureBadges` transform was also processing release blog posts that have a `features` frontmatter array, duplicating badges already injected by the `releaseFeatures` transform. Now skips pages with `release` frontmatter since those are handled separately.

## Related Issue(s)

Regression from #4741

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))