### PR TITLE
Add tooltips to tier badges

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -738,13 +738,13 @@ module.exports = function(eleventyConfig) {
         if (!showCloud && !showSelfHosted) return '';
         let html = `<div class="ff-tier-badges">`;
         if (showCloud) {
-            html += `<div class="ff-tier-badge ff-tier--available">`;
+            html += `<div class="ff-tier-badge ff-tier--available ff-tooltip" data-tooltip="Available on FlowFuse Cloud: ${cloudLabel}">`;
             html += `<span class="ff-tier-badge__label">Cloud</span>`;
             html += `<span class="ff-tier-badge__value">${cloudLabel}</span>`;
             html += `</div>`;
         }
         if (showSelfHosted) {
-            html += `<div class="ff-tier-badge ff-tier--available">`;
+            html += `<div class="ff-tier-badge ff-tier--available ff-tooltip" data-tooltip="Available on FlowFuse Self-Hosted: ${selfHostedLabel}">`;
             html += `<span class="ff-tier-badge__label">Self-Hosted</span>`;
             html += `<span class="ff-tier-badge__value">${selfHostedLabel}</span>`;
             html += `</div>`;

--- a/src/_includes/components/tier-badges.njk
+++ b/src/_includes/components/tier-badges.njk
@@ -3,13 +3,13 @@
 {% if showTierCloud or showTierSelfHosted %}
 <div class="ff-tier-badges">
   {% if showTierCloud %}
-    <div class="ff-tier-badge ff-tier--available">
+    <div class="ff-tier-badge ff-tier--available ff-tooltip" data-tooltip="Available on FlowFuse Cloud: {{ tierCloud }}">
       <span class="ff-tier-badge__label">Cloud</span>
       <span class="ff-tier-badge__value">{{ tierCloud }}</span>
     </div>
   {% endif %}
   {% if showTierSelfHosted %}
-    <div class="ff-tier-badge ff-tier--available">
+    <div class="ff-tier-badge ff-tier--available ff-tooltip" data-tooltip="Available on FlowFuse Self-Hosted: {{ tierSelfHosted }}">
       <span class="ff-tier-badge__label">Self-Hosted</span>
       <span class="ff-tier-badge__value">{{ tierSelfHosted }}</span>
     </div>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1674,6 +1674,18 @@ h4:hover .header-anchor::before {
     line-height: 1rem;
 }
 
+.ff-tier-badge.ff-tooltip:hover:after,
+.ff-tier-badge.ff-tooltip:hover:before {
+    transition-delay: 0.5s;
+}
+
+.ff-tier-badge.ff-tooltip:hover:after {
+    font-size: 0.75rem;
+    min-width: auto;
+    white-space: nowrap;
+    padding: 4px 8px;
+}
+
 .ff-tier-badge__label {
     @apply px-2.5 py-0.5 text-gray-500 font-medium bg-gray-100 border border-r-0 border-gray-200 rounded-l;
 }


### PR DESCRIPTION
## Description

Adds native `title` tooltips to tier badges across the site (docs, changelog, blog posts). Hovering a badge shows e.g. "Available on FlowFuse Cloud — Enterprise" or "Available on FlowFuse Self-Hosted — All tiers".

Applies to both the JS-rendered badges (`.eleventy.js` `renderTierBadges`) and the Nunjucks template (`tier-badges.njk`).

<img width="784" height="208" alt="CleanShot 2026-03-24 at 19 16 25@2x" src="https://github.com/user-attachments/assets/efd47796-9a9e-4eba-a3a7-ca1058d669d0" />


## Related Issue(s)

Follows up on #4741

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))