### PR TITLE
Track tier badge clicks via PostHog

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -738,13 +738,13 @@ module.exports = function(eleventyConfig) {
         if (!showCloud && !showSelfHosted) return '';
         let html = `<div class="ff-tier-badges">`;
         if (showCloud) {
-            html += `<div class="ff-tier-badge ff-tier--available">`;
+            html += `<div class="ff-tier-badge ff-tier--available" onclick="capture('tier-badge-click',{hosting:'cloud',tier:'${cloudLabel}',page:location.pathname})">`;
             html += `<span class="ff-tier-badge__label">Cloud</span>`;
             html += `<span class="ff-tier-badge__value">${cloudLabel}</span>`;
             html += `</div>`;
         }
         if (showSelfHosted) {
-            html += `<div class="ff-tier-badge ff-tier--available">`;
+            html += `<div class="ff-tier-badge ff-tier--available" onclick="capture('tier-badge-click',{hosting:'self-hosted',tier:'${selfHostedLabel}',page:location.pathname})">`;
             html += `<span class="ff-tier-badge__label">Self-Hosted</span>`;
             html += `<span class="ff-tier-badge__value">${selfHostedLabel}</span>`;
             html += `</div>`;

--- a/src/_includes/components/tier-badges.njk
+++ b/src/_includes/components/tier-badges.njk
@@ -3,13 +3,13 @@
 {% if showTierCloud or showTierSelfHosted %}
 <div class="ff-tier-badges">
   {% if showTierCloud %}
-    <div class="ff-tier-badge ff-tier--available">
+    <div class="ff-tier-badge ff-tier--available" onclick="capture('tier-badge-click',{hosting:'cloud',tier:'{{ tierCloud }}',page:location.pathname})">
       <span class="ff-tier-badge__label">Cloud</span>
       <span class="ff-tier-badge__value">{{ tierCloud }}</span>
     </div>
   {% endif %}
   {% if showTierSelfHosted %}
-    <div class="ff-tier-badge ff-tier--available">
+    <div class="ff-tier-badge ff-tier--available" onclick="capture('tier-badge-click',{hosting:'self-hosted',tier:'{{ tierSelfHosted }}',page:location.pathname})">
       <span class="ff-tier-badge__label">Self-Hosted</span>
       <span class="ff-tier-badge__value">{{ tierSelfHosted }}</span>
     </div>


### PR DESCRIPTION
## Description

Fires a `tier-badge-click` PostHog event when users click on pricing tier badges. Captures:
- `hosting`: "cloud" or "self-hosted"
- `tier`: the tier label (e.g. "Enterprise", "All tiers")
- `page`: the page path where the click occurred

Uses the existing `capture()` wrapper from `base.njk` — no new PostHog setup needed. Events appear automatically in PostHog's event explorer.

No visual changes — cursor intentionally stays default to avoid biasing click behavior. Goal is to measure organic intent to determine whether badges should link to the pricing page.

**PostHog setup (Production):**
- Action created: Tier Badge Click
- Insight: [Tier Badge Clicks by Page](https://eu.posthog.com/project/2209/insights/O50gqiKi)

## Related Issue(s)

Follow-up to #4741

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))