### PR TITLE
Add PostHog tracking to Expert modal

### DIFF
--- a/src/js/ai-expert-modal.js
+++ b/src/js/ai-expert-modal.js
@@ -158,6 +158,11 @@ document.addEventListener('DOMContentLoaded', function() {
     }
     modal.addEventListener('click', function(e) {
         if (e.target === modal) closeModal();
+        // Track outbound link clicks within Expert modal
+        const link = e.target.closest('a[href]');
+        if (link && link.hostname !== location.hostname && typeof capture === 'function') {
+            capture('expert-app-link-clicked', { url: link.href, page: location.pathname });
+        }
     });
 
     // Handle prompt pill clicks
@@ -418,6 +423,8 @@ document.addEventListener('DOMContentLoaded', function() {
         sessionId = crypto.randomUUID();
         transferPayload = []
 
+        if (typeof capture === 'function') capture('expert-modal-opened', { has_prompt: !!userText, page: location.pathname });
+
         // Reset auto-scroll to enabled when opening modal
         autoScrollEnabled = true;
 
@@ -527,6 +534,9 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     function closeModal() {
+        const userMsgCount = messages.filter(m => m.role === 'human').length;
+        if (typeof capture === 'function') capture('expert-modal-closed', { messages_sent: userMsgCount, page: location.pathname });
+
         const homeTextarea = document.querySelector('textarea[aria-label="Describe your workflow"]');
         const homeTextareaWrapper = homeTextarea ? homeTextarea.closest('.textarea-wrapper') : null;
         const modalInputSection = modal.querySelector('.p-4.bg-white.rounded-b-none.md\\:rounded-b-lg');
@@ -1267,6 +1277,9 @@ document.addEventListener('DOMContentLoaded', function() {
         const message = modalInput.value.trim();
         if (!message) return; // Don't send empty messages
 
+        const msgIndex = messages.filter(m => m.role === 'human').length + 1;
+        if (typeof capture === 'function') capture('expert-message-sent', { message_index: msgIndex, page: location.pathname });
+
         // Clear the input
         modalInput.value = '';
 
@@ -1365,6 +1378,9 @@ document.addEventListener('DOMContentLoaded', function() {
             e.preventDefault();
             const message = modalInput.value.trim();
             if (message) {
+                const msgIndex = messages.filter(m => m.role === 'human').length + 1;
+                if (typeof capture === 'function') capture('expert-message-sent', { message_index: msgIndex, page: location.pathname });
+
                 modalInput.value = '';
 
 


### PR DESCRIPTION
## Description

Instruments the Expert AI chat modal (`ai-expert-modal.js`) with PostHog analytics. The modal currently has **zero** `capture()` calls despite being a key user touchpoint.

**Events added:**

| Event | When | Properties |
|-------|------|-----------|
| `expert-modal-opened` | Modal opens | `has_prompt`, `page` |
| `expert-modal-closed` | Modal closes | `messages_sent`, `page` |
| `expert-message-sent` | User sends a message (button or Enter) | `message_index`, `page` |
| `expert-app-link-clicked` | User clicks outbound link to app | `url`, `page` |

Uses the existing `capture()` wrapper from `base.njk`. No new dependencies or libraries.

**PostHog setup (Production):**
- Actions created for all 4 events
- Insight: [Expert Modal Engagement (Website)](https://eu.posthog.com/project/2209/insights/cjNEz4fe) — tracks the full modal funnel (opens → messages → app clicks → closes)

## Related Issue(s)

Findings from FlowFuse Expert tracking audit (internal research).

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))