### PR TITLE
Rename solution page CTAs to avoid FlowFuse Expert ambiguity

### DIFF
--- a/src/solutions/mes.njk
+++ b/src/solutions/mes.njk
@@ -69,7 +69,7 @@ meta:
                     {% image image, imageAlt, [400] %}
                 </div>
                 <div class="flex gap-3 max-md:max-w-sm max-md:mx-auto max-sm:flex-col max-md:justify-center">
-                    <a class="ff-btn ff-btn--primary min-h-[40px]" href="/contact-us/" onclick="capture('cta-talk-to-an-expert', {'position': 'primary'}, {'page': 'mes'})">TALK TO AN EXPERT</a>
+                    <a class="ff-btn ff-btn--primary min-h-[40px]" href="/contact-us/" onclick="capture('cta-contact-sales', {'position': 'primary'}, {'page': 'mes'})">SPEAK TO OUR TEAM</a>
                     <a class="ff-btn ff-btn--primary-outlined min-h-[40px]" href="{% include "sign-up-url.njk" %}" onclick="capture('cta-get-started', {'position': 'primary'}, {'page': 'mes'})">GET STARTED</a>
                 </div>
             </div>

--- a/src/solutions/scada.njk
+++ b/src/solutions/scada.njk
@@ -63,7 +63,7 @@ meta:
                     {% image image, imageAlt, [400] %}
                 </div>
                 <div class="flex gap-3 max-md:max-w-sm max-md:mx-auto max-sm:flex-col max-md:justify-center">
-                    <a class="ff-btn ff-btn--primary min-h-[40px]" href="/contact-us/" onclick="capture('cta-talk-to-an-expert', {'position': 'primary'}, {'page': 'scada'})">TALK TO AN EXPERT</a>
+                    <a class="ff-btn ff-btn--primary min-h-[40px]" href="/contact-us/" onclick="capture('cta-contact-sales', {'position': 'primary'}, {'page': 'scada'})">SPEAK TO OUR TEAM</a>
                     <a class="ff-btn ff-btn--primary-outlined min-h-[40px]" href="{% include "sign-up-url.njk" %}" onclick="capture('cta-get-started', {'position': 'primary'}, {'page': 'scada'})">GET STARTED</a>
                 </div>
             </div>

--- a/src/solutions/uns.njk
+++ b/src/solutions/uns.njk
@@ -22,7 +22,7 @@ meta:
                     {% image "./images/solutions/ff-uns.png", "FlowFuse hosting Node-RED connected to many devices", [400] %}
                 </div>
                 <div class="flex gap-3 max-md:max-w-sm max-md:mx-auto max-sm:flex-col max-md:justify-center">
-                    <a class="ff-btn ff-btn--primary min-h-[40px]" href="/contact-us/" onclick="capture('cta-talk-to-an-expert', {'position': 'primary'}, {'page': 'uns'})">TALK TO AN EXPERT</a>
+                    <a class="ff-btn ff-btn--primary min-h-[40px]" href="/contact-us/" onclick="capture('cta-contact-sales', {'position': 'primary'}, {'page': 'uns'})">SPEAK TO OUR TEAM</a>
                     <a class="ff-btn ff-btn--primary-outlined min-h-[40px]" href="{% include "sign-up-url.njk" %}" onclick="capture('cta-get-started', {'position': 'primary'}, {'page': 'uns'})">GET STARTED</a>
                 </div>
             </div>


### PR DESCRIPTION
## Description

The "TALK TO AN EXPERT" CTA on three solution pages (SCADA, UNS, MES) creates confusion with FlowFuse Expert — our AI chat feature. Visitors landing on these pages after seeing Expert elsewhere on the site may expect the AI assistant rather than a sales contact form.

Renaming to "SPEAK TO OUR TEAM" — consistent with how the edge-connectivity page already handles this.

**Changes:**
- CTA copy: "TALK TO AN EXPERT" → "SPEAK TO OUR TEAM" on `/solutions/scada/`, `/solutions/uns/`, `/solutions/mes/`
- PostHog event: `cta-talk-to-an-expert` → `cta-contact-sales` (clearer intent tracking)

## Related Issue(s)

Flagged during FlowFuse Expert tracking audit. The audit identified this naming collision as a UX issue — "expert" now has product meaning on our site that it didn't have before.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))