### PR TITLE
Track Expert prompt pill clicks

### DIFF
--- a/src/js/ai-expert-modal.js
+++ b/src/js/ai-expert-modal.js
@@ -165,6 +165,7 @@ document.addEventListener('DOMContentLoaded', function() {
         if (e.target.classList.contains('prompt-pill') && e.target.dataset.prompt) {
             e.preventDefault();
             const promptText = e.target.dataset.prompt;
+            if (typeof capture === 'function') capture('expert-prompt-pill-clicked', { prompt_title: e.target.textContent.trim(), page: location.pathname });
             openModal(promptText);
         }
     });


### PR DESCRIPTION
## Description

Fires `expert-prompt-pill-clicked` when a user clicks one of the suggested prompt pills on the homepage. Captures:
- `prompt_title`: the visible label text (e.g. "Build a UNS with MQTT")
- `page`: the page where it was clicked

Helps identify which pre-built prompts drive the most engagement and whether the prompt suggestions are effective entry points to Expert.

**PostHog setup (Production):**
- Action created: Expert Prompt Pill Clicked
- Insight: [Expert Prompt Pills by Title](https://eu.posthog.com/project/2209/insights/71AbvJtl)

## Related Issue(s)

Findings from FlowFuse Expert tracking audit (internal research). Builds on #4755.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))