### PR TITLE
Add PostHog tracking to pricing page

### DIFF
--- a/src/_includes/feature_lists/features-table-base.njk
+++ b/src/_includes/feature_lists/features-table-base.njk
@@ -111,7 +111,7 @@
                 {% endif %}
                 {% endfor %}
                 {% if row.docsLink %}
-                <p><a href="{{ row.docsLink }}" target="_blank" rel="noopener">Learn more</a></p>
+                <p><a href="{{ row.docsLink }}" target="_blank" rel="noopener" onclick="if(typeof capture==='function')capture('pricing-feature-docs-clicked',{feature:'{{ row.id }}',hosting:'{{ hosting }}'})">Learn more</a></p>
                 {% endif %}
             </div>
         </div>

--- a/src/pricing/index.njk
+++ b/src/pricing/index.njk
@@ -378,8 +378,12 @@ hubspot:
 
     // Scroll to hash target after hosting toggle (for tier badge links)
     if (window.location.hash) {
+        var hashTarget = window.location.hash;
+        if (typeof capture === 'function' && hashTarget.startsWith('#ff-feature--')) {
+            capture('pricing-deep-link-arrived', { hash: hashTarget, hosting: hosting, referrer: document.referrer });
+        }
         setTimeout(function() {
-            var el = document.querySelector(window.location.hash);
+            var el = document.querySelector(hashTarget);
             if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
         }, 100);
     }
@@ -403,7 +407,7 @@ hubspot:
         if (hosting === target) return;
         hosting = target;
         updateContentAndUrl(hosting);
-        capture(target);
+        if (typeof capture === 'function') capture('pricing-hosting-toggled', { hosting: target });
     });
 </script>
 
@@ -434,10 +438,11 @@ hubspot:
 <!-- Features info -->
 <script>
     function openInfo(id, hosting) {
-        if (typeof capture === 'function') { capture('info-feature', { feature: id }, { hosting: hosting }) }
+        if (typeof capture === 'function') capture('pricing-feature-info-opened', { feature: id, hosting: hosting });
         document.getElementById("ff-dialog--feature--" + id + "-" + hosting).classList.add('active')
     }
     function closeInfo(id, hosting) {
+        if (typeof capture === 'function') capture('pricing-feature-info-closed', { feature: id, hosting: hosting });
         document.getElementById("ff-dialog--feature--" + id + "-" + hosting).classList.remove('active')
     }
 </script>


### PR DESCRIPTION
## Description

Instruments the pricing page with PostHog events for feature interest signals.

**Changes:**

| Event | When | Properties | Status |
|-------|------|-----------|--------|
| `pricing-hosting-toggled` | User toggles Cloud/Self-Hosted | `hosting` | Replaces bare `capture("cloud")` |
| `pricing-feature-info-opened` | User clicks a feature row | `feature`, `hosting` | Replaces `info-feature` |
| `pricing-feature-info-closed` | User closes feature dialog | `feature`, `hosting` | New |
| `pricing-feature-docs-clicked` | User clicks "Learn more" in dialog | `feature`, `hosting` | New |
| `pricing-deep-link-arrived` | User arrives via tier badge deep link | `hash`, `hosting`, `referrer` | New |

The old `info-feature` event used inconsistent naming. Renamed to `pricing-feature-info-opened` for consistency with other pricing events.

The old hosting toggle fired `capture("cloud")` or `capture("self-hosted")` as bare event names — these collide with anything and are hard to find. Renamed to `pricing-hosting-toggled`.

**PostHog setup (Production):**
- 4 actions created
- Insight: [Pricing Feature Interest by Feature](https://eu.posthog.com/project/2209/insights/eehZb2ea) — shows which features users click on, broken down by feature ID

## Related Issue(s)

Part of website analytics instrumentation initiative.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))