### PR TITLE
Fix mobile nav chevron spacing

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -654,7 +654,7 @@ h4:hover .header-anchor::before {
     }
 
     .ff-website header nav .ff-nav-chevron {
-        @apply block md:hidden transition-transform;
+        @apply block md:hidden transition-transform p-0 min-h-0 leading-none;
     }
 
     .ff-website header .ff-nav-dropdown:hover .ff-nav-chevron,


### PR DESCRIPTION
## Description

This PR fixes spacing in the mobile main navigation by resetting the chevron styles used in dropdown items.

Change included:
- Remove inherited padding and extra height from .ff-nav-chevron so items with chevrons match the height of standard nav items.

Result:
- Dropdown items like Platform, Solutions, and Resources have the same visual height as AI, Docs, and Pricing in the mobile menu.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

