### PR TITLE
Revise access token creation process for customers

### DIFF
--- a/src/handbook/engineering/ops/self-hosted-assistant.md
+++ b/src/handbook/engineering/ops/self-hosted-assistant.md
@@ -15,12 +15,13 @@ The FlowFuse Expert consists of two internal components that each need to be ena
 ## Process
 
 1. Customer emails `support@flowfuse.com`
-2. Support needs to verify that the customer has a current Enterprise License
-3. Once confirmed, Engineering needs to create **two** access tokens for the customer.
+2. Support/Sales needs to verify that the customer has a current Enterprise License
+3. Once confirmed, they raise a [Production Change Request](https://github.com/FlowFuse/CloudProject/issues/new?assignees=&labels=change-request&projects=&template=change-request.yml&title=Change%3A+) providing details of the Customer and post a message to `#dept-engineering` with a link.
+4. Engineering needs to create **two** access tokens for the customer.
    1. **Assistant**: Open the Instance Settings for the `flow-gen` instance in the `Internal Tools` Application. Under the Security settings create a new HTTP Bearer Token using the customer name as the token name. The token will only be displayed once, so make a note of it - this is the **Assistant Token**.
    2. **Expert**: Open the Instance Settings for the `flowfuse-expert-api` instance in the `Internal Tools` Application. Under the Security settings create a new HTTP Bearer Token using the customer name as the token name. The token will only be displayed once, so make a note of it - this is the **Expert Token**.
-5. Provide the both tokens to the customer along with instructions on how and where to include this in the configuration - details below.
-
+5. Engineering will provide the tokens to the Support/Sales person who raised the request.
+6. Support/Sales then provide both tokens to the customer along with instructions on how and where to include this in the configuration - details below.
 
 ## Configuration
 


### PR DESCRIPTION
Adds clarity on handover between support and engineering around token creation.

The goal will be for Engineering *not* to be involved and for Sales/Support to be self-sufficient. But documenting it this way as we begin the roll out.