### PR TITLE
Update FlowFuse Talks agenda with confirmed speakers on Hannover Messe landing page

### DIFF
--- a/src/events/hannover-messe-2026.njk
+++ b/src/events/hannover-messe-2026.njk
@@ -62,7 +62,7 @@ flowFuseTalksAgenda:
                 speaker: "Kristopher Sandoval"
               - time: "15:00 - 16:00"
                 title: "FlowFuse & Tulip: Better Together - A Conversation on Modern Industrial Innovation"
-                speaker: "Tulip "
+                speaker: "Tulip"
         - dateLabel: "Wednesday, April 22"
           talks:
               - time: "10:00 - 11:00"


### PR DESCRIPTION
## Description

This PR updates the Hannover Messe 2026 landing page to reflect the confirmed FlowFuse Talks agenda.
@KristopherLeads, please review the speaker information, as some details were missing in the original documentation

<img width="1104" height="713" alt="screenshot" src="https://github.com/user-attachments/assets/a57bd390-de30-46f2-8f0d-4c5d53c00f26" />

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

