### PR TITLE
Add Snapshots feature to catalog under Manage section on pricing page/feature catalogue

### DIFF
--- a/src/_data/featureCatalog.yaml
+++ b/src/_data/featureCatalog.yaml
@@ -253,7 +253,7 @@ sections:
           starter:
             value: null
           pro:
-            value: null
+            value: true
           enterprise:
             value: true
 
@@ -277,7 +277,7 @@ sections:
           starter:
             value: null
           pro:
-            value: null
+            value: true
           enterprise:
             value: true
 


### PR DESCRIPTION
## Description

Adds Snapshots as a feature in `featureCatalog.yaml` under the Manage section.

Snapshots are a core FlowFuse capability documented at [/docs/user/snapshots/](https://flowfuse.com/docs/user/snapshots/) but were not previously listed in the feature catalog or pricing comparison. This adds them between Edge Devices and Installation Support.

## Tier coverage

Available to all tiers, both cloud and self-hosted:

| | Starter | Pro | Enterprise |
|---|---|---|---|
| Cloud | ✅ | ✅ | ✅ |
| Self-Hosted | ✅ | ✅ | ✅ |

Snapshots are a fundamental capability of every FlowFuse instance, so they should be visible across all tiers in the pricing comparison.

## Why now

The 2.29 release adds a property-level snapshot diff sidebar (FlowFuse/flowfuse#7025, PR #7026) that needs to attach to a catalog feature for tier badges to render in the release blog post and changelog page. This entry provides that anchor.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)