### PR TITLE
Homepage: hero section bg update

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2096,7 +2096,7 @@ lite-youtube::before {
 }
 
 .raster-gradient-bg.red-blob {
-    background: radial-gradient(circle 60vw at 20% 40%, rgb(from theme(colors.red.50) r g b / 0.7), transparent);
+    background: radial-gradient(circle 40vw at 20% 40%, rgb(from theme(colors.red.50) r g b / 0.5), transparent);
     position: relative;
 }
 


### PR DESCRIPTION
## Description

This PR decreases the size and opacity of the red blob on the hero section to match the visual weight of the blue one

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

