### PR TITLE
Remove 'Product Areas' section from strategy.md

### DIFF
--- a/src/handbook/engineering/product/strategy.md
+++ b/src/handbook/engineering/product/strategy.md
@@ -53,9 +53,6 @@ These three pillars ensure we are aligned with our product mission statement and
 
 Any new feature requests, product improvements, or other changes to our product can be reflected back to these pillars to ensure they are in line with our product strategy.
 
-### Product Areas
-We can break down our product pillars into smaller "Areas", which are more specific focus areas on how to optimize the product pillar. You can see how these Areas are used in our product planning [here](../project-management.md).
-
 ### Build
 
 #### Simplified Hosting


### PR DESCRIPTION
Removed section on breaking down product pillars into Areas.

## Description

This removed "product areas" from the doc.

## Related Issue(s)

N/A

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

