### PR TITLE
Fix unintended tier badges on contact page

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -913,6 +913,7 @@ module.exports = function(eleventyConfig) {
     // Inject tier badges into docs pages: parent feature after H1, subfeatures after their headings
     eleventyConfig.addTransform("docsFeatureBadges", function(content) {
         if (!this.page.outputPath || !this.page.outputPath.endsWith(".html")) return content;
+        if (!this.page.url || !/^(\/docs\/|\/node-red\/|\/handbook\/)/.test(this.page.url)) return content;
 
         const parentFeature = findFeatureByDocsLink(this.page.url);
         const subfeatures = findSubfeaturesForDocsPage(this.page.url);


### PR DESCRIPTION
## Description

This PR fixes an issue where tier badges were being injected into `/contact-us/`.

<img width="662" height="218" alt="Screenshot 2026-04-08 at 16 30 00" src="https://github.com/user-attachments/assets/429cc2b1-fbb5-4d6b-8543-e209bb7400a7" />

The problem came from the `docsFeatureBadges` Eleventy transform matching non-doc pages through `docsLink` entries in the feature catalog. Because `volume-pricing` points to `/contact-us`, the transform incorrectly added documentation-style tier badges to the contact page hero.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

