### PR TITLE
fix(handbook): correct Calendar Management link to absolute path

### DIFF
--- a/src/handbook/operations/ceo-ops/index.md
+++ b/src/handbook/operations/ceo-ops/index.md
@@ -12,7 +12,7 @@ The P.A.s tasks is to run complete certain tasks every day. For some, even
 multiple times a day.
  
 1. [Inbox Management](/handbook/operations/ceo-ops/inbox-management/)
-1. [Calendar Management](handbook/operations/ceo-ops/calendar-management/)
+1. [Calendar Management](/handbook/operations/ceo-ops/calendar-management/)
 1. [CEO Task Management](/handbook/operations/ceo-ops/task-managment/)
 1. Other tasks to pick up (Peopleops, bizops, etc)
 


### PR DESCRIPTION
## Description

This fixes a broken link introduced in https://github.com/FlowFuse/website/pull/4847/changes

## Related Issue(s)



## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

