### PR TITLE
Align "Talk to us" CTA with contact page copy

### DIFF
--- a/src/contact-us.njk
+++ b/src/contact-us.njk
@@ -1,20 +1,20 @@
 ---
 layout: layouts/mql-contact.njk
-title: Contact us
-description: <p>Have questions? Looking to use FlowFuse in your project? Fill out the form and we’ll connect you with someone from our team.</p>
-sitemapPriority: 0.8
+title: Tell us about your setup
+description: <p>Whether you're connecting systems, automating workflows, or scaling industrial data — we'll help you figure out the right approach for your environment.</p>
+sitemapPriority: 0.9
 meta:
-    description: Get in touch with FlowFuse
+    description: Whether you're connecting systems, automating workflows, or scaling industrial data — we'll help you figure out the right approach for your environment.
 hubspot:
     script: "hubspot/hs-form.njk"
     formId: 734455e5-4cda-4329-97da-07e40cda791c
     cta: "cta-contact-us"
     reference: "contact-us"
 otherChannels:
-  - title: Prefer to speak directly?
-    description: Book a call and we’ll show you how FlowFuse can support your project, step by step.
-    buttonText: BOOK A DEMO
-    buttonLink: /book-demo
+  - title: Want to talk it through live?
+    description: Book a session and we'll go through your setup together.
+    buttonText: BOOK A SESSION
+    buttonLink: https://meetings-eu1.hubspot.com/michael-davis/book-a-demo-omar-kasheef?embed=trueo
     image: ./images/pictograms/book-a-demo_blue.png
     imageAlt: "Graphics depicting a video call."
   - title: Need technical help instead?


### PR DESCRIPTION
## Description

This is a follow up to https://github.com/FlowFuse/website/pull/4854

After updating the main CTA to “Talk to us”, there was a mismatch between the intent of the CTA and the copy on the contact page.

This PR updates the page copy to better align with that intent, shifting the focus from a generic contact request to a more contextual, use-case-driven conversation.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

