### PR TITLE
Add Hannover Messe 2026 promotional banner

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -231,6 +231,7 @@ module.exports = function(eleventyConfig) {
     eleventyConfig.addPassthroughCopy("src/events/hm25-invite.ics");
     eleventyConfig.addPassthroughCopy("src/webinars/2025/simplifying-opc-ua/opc-ua-webinar-flows.zip");
     eleventyConfig.addPassthroughCopy("src/js/ai-expert-modal.js");
+    eleventyConfig.addPassthroughCopy("src/js/hm-promo-banner.js");
 
     // Watch content images for the image pipeline
     eleventyConfig.addWatchTarget("src/**/*.{svg,webp,png,jpeg,gif}");

--- a/src/_includes/components/hm-promo-banner.njk
+++ b/src/_includes/components/hm-promo-banner.njk
@@ -1,0 +1,42 @@
+<div id="hm-promo-banner"
+     class="hm-promo-banner fixed bottom-6 right-6 w-[340px] max-w-[calc(100vw-48px)] bg-gradient-to-tl from-gray-800 to-gray-600 rounded-xl border-1 border-gray-300 shadow-[0_8px_32px_rgba(0,0,0,0.28)] z-[9000] hidden md:block"
+     role="complementary" aria-label="Hannover Messe 2026 promotion">
+
+    <button id="hm-promo-banner-close"
+            class="absolute top-3 right-3 bg-transparent border-0 cursor-pointer text-gray-400 hover:text-white p-1 flex items-center justify-center"
+            aria-label="Close promotional banner">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M18 6L6 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M6 6l12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+    </button>
+
+    <div class="p-6">
+        <div class="flex items-start justify-between gap-3 mb-6">
+            <div class="shrink-0 hm-promo-banner__hm-logo">
+                {% image "./events/images/hm25/hm_logo.png", "Hannover Messe 2026", [80] %}
+            </div>
+            <h4 class="text-white">Join us at Hannover Messe 2026</h4>
+        </div>
+        <div>
+            <div class="prose ff-prose">
+                <ul>
+                    <li class="text-gray-200">Live <span class="font-medium">demos + hands-on workshop</span> with Nick O'Leary</li>
+                    <li class="text-gray-200"><span class="font-medium">12 short talks</span> on real industrial use cases</li>
+                    <li class="text-gray-200 italic mb-6">Limited spots</li>
+                </ul>
+            </div>
+        </div>
+
+        <div class="flex flex-col">
+            <a class="ff-btn ff-btn--highlight"
+               href="/events/hannover-messe-2026#special-sessions"
+               rel="noopener noreferrer"
+               onclick="if(typeof capture==='function') capture('hm-banner-click', {'target': 'cta-primary', 'label': 'save-your-spot', 'page': location.pathname, 'location': 'floating-banner'})">
+                SAVE YOUR SPOT
+            </a>
+        </div>
+    </div>
+</div>
+
+<script src="/js/hm-promo-banner.js" defer></script>

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -318,6 +318,8 @@ eleventyComputed:
             </main>
         </div>
     </div>
+    <!-- Hannover Messe 2026 Promo Banner -->
+    {% include "components/hm-promo-banner.njk" %}
     <!-- Footer -->
     <footer class="ff-footer bg-gray-100 w-full border-t border-white">
         <div class="py-8 px-10 md:px-6 md:pt-8 md:pb-10 max-w-md sm:max-w-screen-xl xl:mx-auto">

--- a/src/css/style.components.css
+++ b/src/css/style.components.css
@@ -329,3 +329,28 @@
 .rich-content li:only-child {
     margin-bottom: 0;
 }
+
+/* --- Hannover Messe 2026 Promo Banner --- */
+/* Only what can't be done with inline Tailwind: animation state + child element targeting + ff-btn override */
+.hm-promo-banner {
+    transform: translateX(calc(100% + 48px));
+    transition: transform 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+    pointer-events: none;
+}
+
+.hm-promo-banner--visible {
+    transform: translateX(0);
+    pointer-events: auto;
+}
+
+.hm-promo-banner__hm-logo picture,
+.hm-promo-banner__hm-logo img {
+    height: 54px;
+    width: auto;
+    display: block;
+    border-radius: 4px;
+}
+
+.hm-promo-banner__link:hover {
+    color: #fff;
+}

--- a/src/events/hannover-messe-2026.njk
+++ b/src/events/hannover-messe-2026.njk
@@ -30,6 +30,7 @@ specialSessions:
       imageClass: top
       labelClass: text-indigo-600
       label: Live at our booth
+      id: flowfuse-talks
       title: "FlowFuse Talks"
       date: "Monday, April 20 to Thursday, April 23 2026"
       location: "Hall 014 Stand K26"
@@ -161,7 +162,7 @@ bookDemo:
     <div id="special-sessions" class="container flex flex-col m-auto text-left items-stretch md:max-w-screen-lg scroll-mt-8 md:scroll-mt-12">
         <h2 class="text-gray-600 leading-snug mb-8 md:mb-10">Don't Miss our <span class="text-indigo-600">Special Sessions</span></h2>
         {% for session in specialSessions %}
-        <div class="rounded-xl border border-gray-200 bg-white p-4 sm:p-4 md:p-3 flex flex-col md:flex-row gap-5 items-center md:items-stretch drop-shadow-sm{% if not loop.first %} mt-6{% endif %}">
+        <div {% if session.id %}id="{{ session.id }}" {% endif %}class="rounded-xl border border-gray-200 bg-white p-4 sm:p-4 md:p-3 flex flex-col md:flex-row gap-5 items-center md:items-stretch drop-shadow-sm{% if not loop.first %} mt-6{% endif %} scroll-mt-8 md:scroll-mt-12">
             <div class="w-full h-[300px] ff-image-cover {{ session.imageClass or 'center' }} ff-image-rounded md:w-[240px] md:h-auto md:self-stretch shrink-0">
                 {% set imageSrc = ["./", session.image ] | join %}
                 {% set imageDescription = session.imgAlt %}

--- a/src/js/hm-promo-banner.js
+++ b/src/js/hm-promo-banner.js
@@ -1,0 +1,118 @@
+(function () {
+    'use strict';
+
+    var STORAGE_KEY      = 'hm_banner_dismissed';
+    var MOBILE_BP        = 768;
+    var SHOW_DELAY       = 3000;
+    var EXPIRY_DATE      = new Date('2026-04-20T14:00:00Z');
+
+    var chatObserver     = null;
+    var bannerWasShown   = false; // tracks whether the banner has been shown this session
+    var hasResizeListener = false;
+
+    function adjustForChat(banner) {
+        var chat = document.getElementById('hubspot-messages-iframe-container');
+        if (chat && chat.offsetHeight > 0) {
+            banner.style.bottom = (chat.offsetHeight + 16) + 'px';
+        } else {
+            banner.style.bottom = '';
+        }
+    }
+
+    function watchChatBubble(banner) {
+        var chat = document.getElementById('hubspot-messages-iframe-container');
+        if (chat) {
+            chatObserver = new MutationObserver(function () {
+                adjustForChat(banner);
+                setTimeout(function () { adjustForChat(banner); }, 500);
+            });
+            chatObserver.observe(chat, { attributes: true, attributeFilter: ['style', 'class'] });
+            adjustForChat(banner);
+            setTimeout(function () { adjustForChat(banner); }, 500);
+            return;
+        }
+
+        chatObserver = new MutationObserver(function (mutations) {
+            mutations.forEach(function (mutation) {
+                mutation.addedNodes.forEach(function (node) {
+                    // Guard against text nodes and other non-element nodes
+                    if (node.nodeType === 1 && node.id === 'hubspot-messages-iframe-container') {
+                        chatObserver.disconnect();
+                        chatObserver.observe(node, { attributes: true, attributeFilter: ['style', 'class'] });
+                        adjustForChat(banner);
+                        setTimeout(function () { adjustForChat(banner); }, 500);
+                    }
+                });
+            });
+        });
+        chatObserver.observe(document.body, { childList: true });
+    }
+
+    function showBanner(banner) {
+        if (banner.classList.contains('hm-promo-banner--visible')) return;
+        banner.classList.add('hm-promo-banner--visible');
+        bannerWasShown = true;
+        if (typeof capture === 'function') {
+            capture('hm-banner-shown', { page: location.pathname, location: 'floating-banner' });
+        }
+    }
+
+    function init() {
+        if (new Date() >= EXPIRY_DATE) return;
+        if (window.innerWidth < MOBILE_BP) return;
+        if (sessionStorage.getItem(STORAGE_KEY)) return;
+
+        var banner = document.getElementById('hm-promo-banner');
+        if (!banner) return;
+
+        // Resize: hide on mobile, restore on desktop if banner was shown and not dismissed
+        if (!hasResizeListener) {
+            window.addEventListener('resize', function () {
+                if (window.innerWidth < MOBILE_BP) {
+                    banner.classList.remove('hm-promo-banner--visible');
+                } else if (bannerWasShown && !sessionStorage.getItem(STORAGE_KEY)) {
+                    banner.classList.add('hm-promo-banner--visible');
+                }
+            });
+            hasResizeListener = true;
+        }
+
+        setTimeout(function () {
+            if (window.innerWidth < MOBILE_BP) return;
+            showBanner(banner);
+            adjustForChat(banner);
+            watchChatBubble(banner);
+        }, SHOW_DELAY);
+
+        var closeBtn = document.getElementById('hm-promo-banner-close');
+        if (closeBtn) {
+            closeBtn.addEventListener('click', function () {
+                dismiss(banner, 'close-button');
+            });
+        }
+
+        document.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape' && banner.classList.contains('hm-promo-banner--visible')) {
+                dismiss(banner, 'esc-key');
+            }
+        });
+    }
+
+    function dismiss(banner, method) {
+        banner.classList.remove('hm-promo-banner--visible');
+        sessionStorage.setItem(STORAGE_KEY, 'true');
+        if (chatObserver) {
+            chatObserver.disconnect();
+            chatObserver = null;
+        }
+        if (typeof capture === 'function') {
+            capture('hm-banner-dismissed', { page: location.pathname, method: method, location: 'floating-banner' });
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();


### PR DESCRIPTION
## Description

- Adds a reusable, session-gated promotional banner component for Hannover Messe 2026, shown globally across all pages via `base.njk`
- Banner slides in from the right to the bottom-right corner after a 3-second delay, desktop only (hidden below 768px)
- Automatically adjusts position when the HubSpot chat bubble is present, using a `MutationObserver` that dynamically watches for the widget being injected into the DOM
- Expires automatically after April 20, 2026 — no manual cleanup needed

## PostHog events

| Event | When | Key properties |
|---|---|---|
| `hm-banner-shown` | Banner slides into view | `page`, `location` |
| `hm-banner-click` | CTA clicked | `target`, `label`, `page`, `location` |
| `hm-banner-dismissed` | Closed via × or Esc | `method`, `page`, `location` |


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

