### PR TITLE
ci: Remove 'ad-m/github-push-action' dependency from `Build site` workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,8 +62,5 @@ jobs:
           git add src/blueprints/* -A -f
           git commit -a -m "Bot: update blueprints"
       - name: Push to 'live' branch
-        uses: ad-m/github-push-action@77c5b412c50b723d2a4fbc6d71fb5723bcd439aa # v1.0.0
-        with:
-          directory: './website'
-          branch: live
-          force: true
+        run: git push --force origin HEAD:live
+        working-directory: './website'


### PR DESCRIPTION
## Description

This pull request removes the `ad-m/github-push-action` in a favor os single `git push` command - no need to use an external action for such simple work.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

