### PR TITLE
fix: strip relative <link> and <script> tags from integration READMEs and flow templates 

### DIFF
--- a/src/_data/integrations.js
+++ b/src/_data/integrations.js
@@ -194,7 +194,11 @@ module.exports = async () => {
                                 // If no GitHub info, return the match as-is
                                 return match;
                             }
-                        );
+                        )
+                        // Strip <link> tags with relative href (e.g. CSS, icons) — they don't resolve on our site
+                        .replace(/<link\b[^>]*?\bhref=(?:["']|&quot;)(?!https?:\/\/)[^"'>&]*(?:["']|&quot;)[^>]*\/?>/gi, '')
+                        // Strip <script> tags with relative src — they don't resolve on our site
+                        .replace(/<script\b[^>]*?\bsrc=(?:["']|&quot;)(?!https?:\/\/)[^"'>&]*(?:["']|&quot;)[^>]*>(?:[\s\S]*?<\/script>)?/gi, '');
                 } else {
                     node.readme = "";
                 }

--- a/src/_data/integrations.js
+++ b/src/_data/integrations.js
@@ -66,6 +66,10 @@ module.exports = async () => {
                 node.categories.push("catalogue");
             }
 
+            const stripRelativeTags = (html) => html
+                .replace(/<link\b[^>]*?\bhref=(?:["']|&quot;)(?!https?:\/\/)[^"'>&]*(?:["']|&quot;)[^>]*\/?>/gi, '')
+                .replace(/<script\b[^>]*?\bsrc=(?:["']|&quot;)(?!https?:\/\/)[^"'>&]*(?:["']|&quot;)[^>]*>(?:[\s\S]*?<\/script>)?/gi, '');
+
             // Fetch full npm node details (readme, etc.)
             try {
                 const nodeDetails = await EleventyFetch(
@@ -133,14 +137,9 @@ module.exports = async () => {
                                                 }
                                             });
                                             
-                                            // Strip relative <link> and <script> tags from template fields
-                                            // to prevent the hyperlink checker from flagging them as broken links
                                             let sanitizedFlow = flowContent;
                                             try {
                                                 const flowJson = JSON.parse(flowContent);
-                                                const stripRelativeTags = (html) => html
-                                                    .replace(/<link\b[^>]*?\bhref=(?:["']|&quot;)(?!https?:\/\/)[^"'>&]*(?:["']|&quot;)[^>]*\/?>/gi, '')
-                                                    .replace(/<script\b[^>]*?\bsrc=(?:["']|&quot;)(?!https?:\/\/)[^"'>&]*(?:["']|&quot;)[^>]*>(?:[\s\S]*?<\/script>)?/gi, '');
                                                 const sanitizeNode = (n) => {
                                                     if (n && typeof n === 'object') {
                                                         if (typeof n.template === 'string') n.template = stripRelativeTags(n.template);
@@ -217,11 +216,8 @@ module.exports = async () => {
                                 // If no GitHub info, return the match as-is
                                 return match;
                             }
-                        )
-                        // Strip <link> tags with relative href (e.g. CSS, icons) — they don't resolve on our site
-                        .replace(/<link\b[^>]*?\bhref=(?:["']|&quot;)(?!https?:\/\/)[^"'>&]*(?:["']|&quot;)[^>]*\/?>/gi, '')
-                        // Strip <script> tags with relative src — they don't resolve on our site
-                        .replace(/<script\b[^>]*?\bsrc=(?:["']|&quot;)(?!https?:\/\/)[^"'>&]*(?:["']|&quot;)[^>]*>(?:[\s\S]*?<\/script>)?/gi, '');
+                        );
+                    node.readme = stripRelativeTags(node.readme);
                 } else {
                     node.readme = "";
                 }

--- a/src/_data/integrations.js
+++ b/src/_data/integrations.js
@@ -133,12 +133,35 @@ module.exports = async () => {
                                                 }
                                             });
                                             
+                                            // Strip relative <link> and <script> tags from template fields
+                                            // to prevent the hyperlink checker from flagging them as broken links
+                                            let sanitizedFlow = flowContent;
+                                            try {
+                                                const flowJson = JSON.parse(flowContent);
+                                                const stripRelativeTags = (html) => html
+                                                    .replace(/<link\b[^>]*?\bhref=(?:["']|&quot;)(?!https?:\/\/)[^"'>&]*(?:["']|&quot;)[^>]*\/?>/gi, '')
+                                                    .replace(/<script\b[^>]*?\bsrc=(?:["']|&quot;)(?!https?:\/\/)[^"'>&]*(?:["']|&quot;)[^>]*>(?:[\s\S]*?<\/script>)?/gi, '');
+                                                const sanitizeNode = (n) => {
+                                                    if (n && typeof n === 'object') {
+                                                        if (typeof n.template === 'string') n.template = stripRelativeTags(n.template);
+                                                        if (typeof n.html === 'string') n.html = stripRelativeTags(n.html);
+                                                    }
+                                                    return n;
+                                                };
+                                                if (Array.isArray(flowJson)) {
+                                                    flowJson.forEach(sanitizeNode);
+                                                } else {
+                                                    sanitizeNode(flowJson);
+                                                }
+                                                sanitizedFlow = JSON.stringify(flowJson);
+                                            } catch (_) { /* keep original if not valid JSON */ }
+
                                             return {
                                                 name: file.name.replace('.json', ''), // Remove .json extension for display
                                                 path: file.path,
                                                 url: file.html_url,
                                                 downloadUrl: file.download_url,
-                                                flow: flowContent // Store the actual flow JSON as string
+                                                flow: sanitizedFlow
                                             };
                                         } catch (err) {
                                             console.error(`Failed to fetch flow content for ${file.name}:`, err.message);


### PR DESCRIPTION
## Description

Relative `href`/`src` paths in npm package READMEs fetched for [integrations pages](https://flowfuse.com/integrations/) and Node-RED flow templates don’t resolve on our site and cause the hyperlink checker to flag them as broken links.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

