### PR TITLE
ci: Use dedicated GitHub App to clone private repositories

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,13 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.GH_BOT_APP_ID }}
-          private-key: ${{ secrets.GH_BOT_APP_KEY }}
+          app-id: ${{ secrets.GH_CI_READONLY_APP_ID }}
+          private-key: ${{ secrets.GH_CI_READONLY_APP_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: |
+            website
+            flowfuse
+            blueprint-library
       - name: Check out website repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -50,4 +54,3 @@ jobs:
       - uses: untitaker/hyperlink@fb5bb9c5011a3d143a54b4b30aedc30ec5bc0f89 # 0.2.0
         with:
           args: website/_site/ --check-anchors --sources website/src
-


### PR DESCRIPTION
## Description

This pull request sets the ff-ci-readonly GitHub Application to be used as one to clone private repositories.

## Related Issue(s)

https://github.com/FlowFuse/website/pull/4917#issuecomment-4302116482

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

