### PR TITLE
/webinars: Only show excerpt for upcoming sessions

### DIFF
--- a/src/webinars.njk
+++ b/src/webinars.njk
@@ -85,9 +85,6 @@ meta:
                             </div>
                             <h3 class="mt-1 mb-0 font-medium group-hover:underline">{{ item.data.title }}</h3>
                         </div>
-                        <div class="text-sm prose prose-blue md:prose-md py-1">
-                            {% include "summary.njk" %}
-                        </div>
                     </a>
                 </li>
             {%- endfor -%}


### PR DESCRIPTION
## Description

This PRs reverts a change introduced in https://github.com/FlowFuse/website/pull/4709 where excerpts started to show under pasts webinars instead of only the upcoming sessions.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

