### PR TITLE
fix: update liquidjs and uuid to patch CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10565,9 +10565,9 @@
             }
         },
         "node_modules/liquidjs": {
-            "version": "10.25.5",
-            "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.25.5.tgz",
-            "integrity": "sha512-GKiKeZjJDdVoQAu+S9rzkYsYnYhcep5W3WwZXgb5f+yq484P/k9JqamBbGYu+LBEixcUAXZr2jogdAIjB3ki1w==",
+            "version": "10.25.7",
+            "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.25.7.tgz",
+            "integrity": "sha512-rPCjJLiD4eDhQjvv964AeXFC+HbeYBbZrd7Z82Q6hqv1lX7G+5w4SJcKLn9CAAAwHI4aS3dTdo083UB79K3pDA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -17341,9 +17341,9 @@
             "license": "MIT"
         },
         "node_modules/uuid": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-            "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"


### PR DESCRIPTION
## Summary

- `liquidjs` 10.25.5 → 10.25.7: fixes CVE-2026-41311 (HIGH) — Denial of Service via circular block reference in layout
- `uuid` 11.1.0 → 11.1.1: fixes CVE-2026-41907 (MEDIUM)

Both were flagged by Trivy in [#4953](https://github.com/FlowFuse/website/pull/4953).

## Test plan

- [ ] Trivy check passes on this PR
- [ ] Site builds without errors (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)