### PR TITLE
Revert: restore "Contact Us" CTA text in header

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -300,7 +300,7 @@ eleventyComputed:
 			            <li class="flex"><a href="{{ site.appURL }}">Sign In</a></li>
 			            <li class="hidden md:flex"><a href="{% include "sign-up-url.njk" %}" onclick="capture('cta-join', {'position': 'header'})">Free Trial</a></li>
                         <a class="ml-2 ff-btn ff-btn--primary uppercase text-sm inline-flex whitespace-nowrap" href="/contact-us" onclick="capture('cta-talk-us', {'position': 'header'})">
-                            Talk to Us
+                            Contact Us
                         </a>
                     </ul>
                 </nav>
@@ -310,7 +310,7 @@ eleventyComputed:
                         <a href="{{ site.appURL }}" class="ff-btn ff-btn--primary-outlined">Sign In</a>
                         <a href="{% include "sign-up-url.njk" %}" onclick="capture('cta-join', {'position': 'header'})" class="ff-btn ff-btn--primary-outlined">Free Trial</a>
                     </div>
-                    <a class="ff-btn ff-btn--primary" href="/contact-us" onclick="capture('cta-talk-to-sales', {'position': 'header'})">Talk to Us</a>
+                    <a class="ff-btn ff-btn--primary" href="/contact-us" onclick="capture('cta-talk-to-sales', {'position': 'header'})">Contact Us</a>
                 </div>    
             </header>
             <!-- Main Content -->


### PR DESCRIPTION
## Description

Reverts the changes introduced in #4854, restoring the original "Contact Us" text in both the desktop and mobile header CTAs.

## Related Issue(s)

Reverts #4854

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes