### PR TITLE
fix: use defer instead of async for cookie consent script

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -609,7 +609,7 @@ eleventyComputed:
 <script>{{ hubspotJS | jsmin | safe }}</script>
 
 <!-- Cookie banner (must load before any consent-gated scripts) -->
-<script async type="text/javascript" src="/js/cc.min.js"></script>
+<script defer type="text/javascript" src="/js/cc.min.js"></script>
 
 <!-- HS tracker - consent-gated (analytics: tracking + chat widget runtime) -->
 <script type="text/plain" data-category="analytics" async id="hs-script-loader" src="//js-eu1.hs-scripts.com/26586079.js"></script>


### PR DESCRIPTION
Switches cc.min.js from async to defer so CookieConsent initializes after the DOM is fully parsed, ensuring the banner appears for new visitors and data-cc click handlers are registered correctly.

## Description

<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

