### PR TITLE
Restore image optimization caching for Nuxt builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
         "old_dev:eleventy": "dotenv -v NODE_ENV=development -- ELEVENTY_ENV=development npx @11ty/eleventy --serve --quiet",
         "prod:eleventy": "npx @11ty/eleventy",
         "prod:postcss": "postcss ./src/css/style.css -o ./_site/css/style.css --config ./postcss.config.js",
-        "clean:nuxt": "npx del-cli 'nuxt/public' 'nuxt/.output' && npx mkdirp 'nuxt/public/js' 'nuxt/public/css'",
+        "clean:nuxt": "npx del-cli 'nuxt/public/!(img)' 'nuxt/.output' && npx mkdirp 'nuxt/public/js' 'nuxt/public/css'",
         "build:js:nuxt": "terser -c -m -o nuxt/public/js/cc.min.js node_modules/vanilla-cookieconsent/dist/cookieconsent.umd.js src/js/cookieconsent-config.js && cp node_modules/@flowfuse/flow-renderer/index.min.js nuxt/public/js/flowrenderer.min.js",
         "prod:postcss-nuxt": "postcss ./src/css/style.css -o ./nuxt/public/css/style.css --config ./postcss.config.js",
         "prod:eleventy-nuxt": "npx @11ty/eleventy --output=./nuxt/public/",
         "prod:nuxt": "npm run generate --workspace=nuxt",
-        "build:nuxt": "dotenv -v NODE_ENV=production -v SKIP_IMAGES=true -- npm-run-all2 clean:nuxt build:js:nuxt docs blueprints prod:postcss-nuxt prod:eleventy-nuxt prod:nuxt"
+        "build:nuxt": "dotenv -v NODE_ENV=production -- npm-run-all2 clean:nuxt build:js:nuxt docs blueprints prod:postcss-nuxt prod:eleventy-nuxt prod:nuxt"
     },
     "devDependencies": {
         "@11ty/eleventy": "^3.1.2",


### PR DESCRIPTION
## Summary

- Preserve `nuxt/public/img` during Nuxt build cleanup so restored Netlify cache is not deleted before Eleventy runs.
- Re-enable Eleventy image optimization in the Nuxt production build by removing `SKIP_IMAGES=true`.

## Notes

The first build after this change is expected to be slow because it needs to regenerate optimized images. After Netlify caches `nuxt/public/img`, subsequent builds should reuse the generated image outputs instead of recompressing everything.

For the first deploy, use **Clear cache and deploy site** in Netlify to avoid carrying over unoptimized images from previous `SKIP_IMAGES` builds.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

