### PR TITLE
refactor: decouple SKIP_IMAGES from DEV_MODE in Eleventy config

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -36,7 +36,10 @@ function renderDocsAlertBox(content, tone = 'note', title = '') {
 }
 
 // Skip slow optimizations when developing i.e. serve/watch or Netlify deploy preview
-const DEV_MODE = process.env.ELEVENTY_RUN_MODE !== "build" || process.env.CONTEXT === "deploy-preview" || process.env.SKIP_IMAGES === 'true'
+const DEV_MODE = process.env.ELEVENTY_RUN_MODE !== "build" || process.env.CONTEXT === "deploy-preview"
+// Image processing is skipped in dev mode or when explicitly requested via SKIP_IMAGES.
+// Kept separate from DEV_MODE so build-time image flags never affect analytics/consent script inclusion.
+const SKIP_IMAGES = DEV_MODE || process.env.SKIP_IMAGES === 'true'
 const DEPLOY_PREVIEW = process.env.CONTEXT === "deploy-preview";
 const IMAGE_BUILD_PROFILE = process.env.IMAGE_BUILD_PROFILE || "full";
 
@@ -1062,7 +1065,7 @@ module.exports = function(eleventyConfig) {
     
     // Eleventy Image shortcode
     // https://www.11ty.dev/docs/plugins/image/
-    if (DEV_MODE) {
+    if (SKIP_IMAGES) {
         console.info(`[11ty] Image pipeline is enabled in dev mode, copying images without any conversion or resizing`)
     } else {
         console.info(`[11ty] Image pipeline is enabled in prod mode, expect a wait for first build while images are converted and resized`)
@@ -1072,7 +1075,7 @@ module.exports = function(eleventyConfig) {
         const title = null
         const currentWorkingFilePath = this.page.inputPath
 
-        return await imageHandler(src, alt, title, widths, sizes, currentWorkingFilePath, eleventyConfig, async=true, DEV_MODE)
+        return await imageHandler(src, alt, title, widths, sizes, currentWorkingFilePath, eleventyConfig, async=true, SKIP_IMAGES)
     });
 
     eleventyConfig.addAsyncShortcode("tileImage", async function(item, image, defaultImage, defaultDescription, imageSize, title = null, priority = false) {
@@ -1094,7 +1097,7 @@ module.exports = function(eleventyConfig) {
 
         const currentWorkingFilePath = this.page.inputPath;
 
-        return await imageHandler(imageSrc, imageDescription, title, [imageSize], null, currentWorkingFilePath, eleventyConfig, async=true, DEV_MODE, priority);
+        return await imageHandler(imageSrc, imageDescription, title, [imageSize], null, currentWorkingFilePath, eleventyConfig, async=true, SKIP_IMAGES, priority);
     });
     
     // Create a collection for sidebar navigation
@@ -1393,7 +1396,7 @@ module.exports = function(eleventyConfig) {
         const async = false // cannot run async inside markdown
 
         try {
-            let imageHtml = imageHandler(imgSrc, imgAlt, imgTitle, widths, htmlSizes, folderPath, eleventyConfig, async, DEV_MODE)
+            let imageHtml = imageHandler(imgSrc, imgAlt, imgTitle, widths, htmlSizes, folderPath, eleventyConfig, async, SKIP_IMAGES)
 
             // Add the additional attributes to the image
             for (let attr in attributes) {


### PR DESCRIPTION
## Summary

- \`DEV_MODE\` was incorrectly defined to include \`SKIP_IMAGES === 'true'\` as one of its conditions, meaning any build script passing that flag for performance reasons (e.g. \`build:nuxt\`) would silently disable analytics and cookie consent scripts in the output HTML.
- \`DEV_MODE\` now only reflects the actual runtime context (serve/watch mode or Netlify deploy preview).
- Image processing uses a dedicated \`SKIP_IMAGES\` variable that derives from \`DEV_MODE\` and the \`SKIP_IMAGES\` env var, keeping both concerns independent.

## Root cause

\`build:nuxt\` passes \`SKIP_IMAGES=true\` to speed up Eleventy image processing. Because the \`DEV_MODE\` condition included \`SKIP_IMAGES === 'true'\`, this caused the entire \`{%- if not DEV_MODE -%}\` block to be omitted from the rendered HTML — including \`cc.min.js\` (cookie consent), GTM, HubSpot, and PostHog scripts — on every production Netlify build.

## Test plan

- [ ] Verify cookie banner appears on production after deploy
- [ ] Verify \`cc.min.js\` is present in the production HTML
- [ ] Verify image processing still works correctly in dev mode and with \`SKIP_IMAGES=true\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)