### PR TITLE
Revert "Document HubSpot account github_issue property for feature requests"

### DIFF
--- a/src/handbook/sales/customer-success.md
+++ b/src/handbook/sales/customer-success.md
@@ -122,7 +122,6 @@ Customer success contacts FlowFuse customers and prospective customers (anyone w
 All team members are asked to identify customer and prospect requests in the following way:
 - On a GitHub issue, use the label Sales Request or Customer Request, as appropriate. (A request is a Sales Request when a member of the Sales team learns that a prospect is interested in a feature. It is a Customer Request when an existing customer makes a request. An issue can be both a Customer Request and a Sales Request.)
 - On the main issue, list the customer record in HubSpot. Do this on the main issue rather than a comment, as these can be lost.
-- On the HubSpot **account** record for the requesting organisation, add the GitHub issue URL to the `github_issue` property. This creates a direct link from the account to every feature they have requested.
 - If an issue already exists and a new request is made, add this information to the existing issue. This helps keep a comprehensive record of how many requests of a feature there are, and by whom.
 
 
@@ -130,8 +129,7 @@ All team members are asked to identify customer and prospect requests in the fol
 
 For FlowFuse Cloud customers, we add various useful data to our CRM records to
 help us better understand who each customer is and how they are using FlowFuse.
-
-#### Contact properties
+They are as follows:
 
 | Field name  | Description | 
 |----------- | ---- |
@@ -139,12 +137,6 @@ help us better understand who each customer is and how they are using FlowFuse.
 | FFC-Actions | This shows actions which have been taken by someone on a team this contact is on. To see a full list of available actions view [this report](https://app-eu1.hubspot.com/reports-list/26586079/182831966/){rel="nofollow"} in Hubspot |                                                                                                                               |
 | FFC-Usage | This field shows a contact's answer to how they are planning to use FlowFuse Cloud, you can view the options and current data on [this report](https://app-eu1.hubspot.com/reports-list/26586079/182851924/){rel="nofollow"}.|
 | FFC-Events (deprecated) | This legacy field showed email campaigns which had been triggered to be sent to each contact. For example, after 24 hours if a user had not used out snapshots feature the integration between FlowFuse Cloud and Hubspot would add the relevant tag to this user. Hubspot would in turn send the email to the contact. This way of working is being replaced by FFC-Actions as that field can triggered email campaigns based on action or inaction as well as adding value to our CRM. |
-
-#### Account properties
-
-| Field name | Description |
-| :--------- | :---------- |
-| `github_issue` | A list of GitHub issue URLs for feature requests made by this account. Add the relevant issue URL here whenever a customer or prospect from this organisation requests a feature. Customer Success uses this field to identify accounts to notify when a requested feature ships. |
 
 ## Inbound Support
 

--- a/src/handbook/sales/hubspot.md
+++ b/src/handbook/sales/hubspot.md
@@ -68,16 +68,6 @@ At this stage we're using the default set of status's in HubSpot:
 drip campaigns or other outbound lead-gen actions. This property will be set to `Yes` when the contact was in HubSpot
 through other marketing activities too, but wasn't nurtured to the point of a meeting yet.
 
-## Account Management
-
-HubSpot accounts (company records) represent a customer or prospect organisation. Account-level properties capture information that applies to the whole organisation rather than a specific contact.
-
-### Account Properties
-
-| Property | Description |
-| :------- | :---------- |
-| `github_issue` | A list of GitHub issue URLs for feature requests made by this account. Populated whenever a customer or prospect requests a feature; each entry links directly to the corresponding issue in the FlowFuse GitHub repository. Used by Customer Success to notify accounts when their requested features ship. |
-
 ## Importing Contacts Into HubSpot
 
 If you import contacts into HubSpot, it is important that the First Name and Last Name are populated correctly. Currently the FlowFuse Cloud database stores first and last name in a single field called Name. If you import this field into HubSpot the default is set to populate the Last Name field. The First Name field will not be populated so any email personalization with First Name will not be effective.  


### PR DESCRIPTION
## Description

Reverts ec14d1b68e29e6a1aa6d147d7ce7a98fc8e5db0f. The handbook addition incorrectly interpreted the process for capturing customer/prospect feature requests against HubSpot accounts; reverting until the actual process is agreed and the property is set up to match.

## Related Issue(s)

N/A

## Checklist

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))