### PR TITLE
Use deal-issue mirror for customer-deal linkage in handbook

### DIFF
--- a/src/handbook/sales/customer-success.md
+++ b/src/handbook/sales/customer-success.md
@@ -121,8 +121,7 @@ Customer success contacts FlowFuse customers and prospective customers (anyone w
 
 All team members are asked to identify customer and prospect requests in the following way:
 - On a GitHub issue, use the label Sales Request or Customer Request, as appropriate. (A request is a Sales Request when a member of the Sales team learns that a prospect is interested in a feature. It is a Customer Request when an existing customer makes a request. An issue can be both a Customer Request and a Sales Request.)
-- On the main issue, list the customer record in HubSpot. Do this on the main issue rather than a comment, as these can be lost.
-- If an issue already exists and a new request is made, add this information to the existing issue. This helps keep a comprehensive record of how many requests of a feature there are, and by whom.
+- Customer-specific context (which deal or account the request is tied to) does not go on the public issue. Mention the request on the deal's representative issue inside FlowFuse/product, and if a public issue already exists for the same request, reference that existing one from the deal issue rather than opening a new one. See [Deal Management](./hubspot.md#deal-management). Sales and Product share responsibility for maintaining this link, including for past requests, so any feature request can be traced back to the deals it pertains to.
 
 
 ### Hubspot Properties

--- a/src/handbook/sales/hubspot.md
+++ b/src/handbook/sales/hubspot.md
@@ -68,6 +68,16 @@ At this stage we're using the default set of status's in HubSpot:
 drip campaigns or other outbound lead-gen actions. This property will be set to `Yes` when the contact was in HubSpot
 through other marketing activities too, but wasn't nurtured to the point of a meeting yet.
 
+## Deal Management
+
+A HubSpot deal represents a specific revenue opportunity with a customer or prospect. Each deal is mirrored daily into a representative GitHub issue in the FlowFuse/product repository, with the deal owner assigned as the issue assignee. The deal issue is the discussion hub and collection point for everything tied to that deal: feature requests blocking or supporting it, customer-specific implementation discussions, and cross-references to the public Sales Request or Customer Request issues filed elsewhere in FlowFuse repositories. Because FlowFuse/product is private, this view is internal-only and lets the team see which feature requests pertain to which deal. Sales and Product share responsibility for maintaining this link.
+
+### Deal Properties
+
+| Property | Description |
+| :------- | :---------- |
+| `github_issue` | URL of the deal's representative GitHub issue in FlowFuse/product. Auto-populated and synced daily; do not edit manually. The linked issue is where deal-tied feature requests, blockers, and customer asks are discussed and cross-referenced. |
+
 ## Importing Contacts Into HubSpot
 
 If you import contacts into HubSpot, it is important that the First Name and Last Name are populated correctly. Currently the FlowFuse Cloud database stores first and last name in a single field called Name. If you import this field into HubSpot the default is set to populate the Last Name field. The First Name field will not be populated so any email personalization with First Name will not be effective.  


### PR DESCRIPTION
## Description

Pertains to https://flowfuse.slack.com/archives/C05GYH95NJZ/p1778077224089389 and documents the related process in the handbook.

Replaces the prior process where Sales annotated public feature-request issues with HubSpot records. Customer-deal linkage now lives on the deal's auto-synced representative issue in FlowFuse/product (private), not on the public issue. The public-facing process keeps the Sales Request / Customer Request labels.

Adds a neutral Deal Management section to \`hubspot.md\` documenting the \`github_issue\` deal property and how the mirror is used. Sales and Product share responsibility for maintaining the link, including for past requests.

Follow-up to #4982 (which removed the prior, incorrect handbook entry).

## Related Issue(s)

Follow-up to #4982.

## Checklist

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))