### PR TITLE
handbook: Expert Application Building soft-launch access process

### DIFF
--- a/src/handbook/engineering/ops/expert-agentic-application-building-access.md
+++ b/src/handbook/engineering/ops/expert-agentic-application-building-access.md
@@ -25,9 +25,10 @@ flowchart TD
     Contact["Contact submitted<br />HubSpot notification fires"]
     Identify["<b>[Triage]</b> Identify customer and team"]
 
-    AskUnknown["<b>[Triage] Reply: request all info</b><br />- Email tied to FlowFuse Cloud team<br />- Use case and reason<br />- Note: paid tier team required"]
-    AskFree["<b>[Triage] Reply: request info, note tier</b><br />- Use case and reason<br />- Note: paid tier team required"]
-    AskPaid["<b>[Triage] Reply: request info</b><br />- Use case and reason"]
+    AskSignup["<b>[Triage] Reply: not a customer yet</b><br />- Direct to sign-up on a paid plan<br />- Ask for use case for fit"]
+    AskRelated["<b>[Triage] Reply: clarify related team</b><br />- Which team should be enabled?<br />- Ask for use case"]
+    AskFreeOrExpired["<b>[Triage] Reply: free or inactive plan</b><br />- Upgrade or reactivate required<br />- Ask for use case"]
+    AskPaid["<b>[Triage] Reply: request info</b><br />- Ask for use case"]
 
     Receive["<b>[Triage]</b> Receive reply<br />Use case and reason on file<br />Paid tier path confirmed"]
     InformProduct["<b>Inform Product</b><br />Add note on HubSpot record<br />summarising the use case"]
@@ -39,11 +40,13 @@ flowchart TD
     Notify(["<b>[Triage]</b> Notify contact<br />Access is live"])
 
     Start --> Contact --> Identify
-    Identify -- "Not found" --> AskUnknown
-    Identify -- "Found, free tier" --> AskFree
-    Identify -- "Found, paid tier" --> AskPaid
-    AskUnknown --> Receive
-    AskFree --> Receive
+    Identify -- "Not a customer yet" --> AskSignup
+    Identify -- "Different email,<br />related team exists" --> AskRelated
+    Identify -- "Free plan or<br />plan no longer active" --> AskFreeOrExpired
+    Identify -- "Found, paid plan active" --> AskPaid
+    AskSignup --> Receive
+    AskRelated --> Receive
+    AskFreeOrExpired --> Receive
     AskPaid --> Receive
     Receive --> InformProduct --> Eligibility
     Eligibility -- "Not eligible" --> Decline
@@ -68,10 +71,11 @@ flowchart TD
 
 ## Step by step
 
-1. **[Triage] Identify customer and team in HubSpot** using the email from the contact submission. Three outcomes:
-   - **Not found**: no matching contact or FlowFuse Cloud team.
-   - **Found, free tier**: the team exists but is on the Free plan.
-   - **Found, paid tier**: the team is on Starter, Team, or Enterprise.
+1. **[Triage] Identify customer and team in HubSpot** using the email from the contact submission. Four outcomes:
+   - **Not a customer yet**: no FlowFuse Cloud team for this contact or their company.
+   - **Different email, related team exists**: the contact's email doesn't match, but a team at the same company exists under a different email (e.g. a colleague's Starter team).
+   - **Free plan or plan no longer active**: the team exists but is on the Free plan, or a previously paid plan / trial has expired or been cancelled.
+   - **Found, paid plan active**: the team is on Starter, Team, or Enterprise with an active subscription.
 
 2. **[Triage] Reply with an info ask, scoped to what is still missing.** The paid tier requirement always lands in this first reply so it never arrives late in the conversation. Use the relevant template below.
 
@@ -92,20 +96,28 @@ flowchart TD
 
 Adapt to tone and context. The shape of the ask is what matters.
 
-### A. Not found (no FlowFuse Cloud team matched)
+### A. Not a customer yet
 
 > Subject: FlowFuse Expert Agentic Application Building
 >
 > Hi [name],
 >
-> Thanks for your interest. We couldn't match the email you used to a FlowFuse Cloud team, so we'll need a couple of things from you:
+> Thanks for your interest. It looks like [company name] doesn't have a FlowFuse Cloud team yet. Expert Agentic Application Building runs on top of FlowFuse Cloud, so we'd need a team in place on a paid plan (Starter, Team, Enterprise) before we can enable the feature. Happy to walk through plan options and help get set up.
 >
-> - The email associated with the FlowFuse Cloud team that should receive access
-> - Your use case: what you want to build, why you need it, what you plan to do with it, plus any other context you'd like to share
->
-> One thing upfront: Expert Agentic Application Building is currently available on FlowFuse Cloud paid plans (Starter, Team, Enterprise). The team that gets enabled will need to be on one of these.
+> In the meantime, your use case helps us confirm fit: what you want to build, why you need it, what you plan to do with it, plus any other context you'd like to share.
 
-### B. Found, team is on the Free plan
+### B. Different email, related team exists
+
+> Subject: FlowFuse Expert Agentic Application Building
+>
+> Hi [name],
+>
+> Thanks for your interest. The email you used doesn't match a FlowFuse Cloud team directly, but I can see [company name] has a [Starter / Team / Enterprise] team active under a different email. A couple of things to sort out:
+>
+> - Should we enable Expert Agentic Application Building on that existing team, or are you looking to set up a separate one? Happy to walk through either path.
+> - Your use case: what you want to build, why you need it, what you plan to do with it, plus any other context you'd like to share.
+
+### C. Free plan or plan no longer active
 
 > Subject: FlowFuse Expert Agentic Application Building
 >
@@ -113,10 +125,10 @@ Adapt to tone and context. The shape of the ask is what matters.
 >
 > Thanks for your interest. We found your [team name] team on FlowFuse Cloud. Two things before we move forward:
 >
-> - Expert Agentic Application Building is currently available on FlowFuse Cloud paid plans (Starter, Team, Enterprise). Your team is on the Free plan today, so it'll need to be upgraded before we can enable the feature. Happy to walk through plan options.
+> - Expert Agentic Application Building is currently available on FlowFuse Cloud paid plans (Starter, Team, Enterprise). Your team is on the Free plan today / your previous plan is no longer active, so it'll need to be upgraded or reactivated before we can enable the feature. Happy to walk through plan options.
 > - Your use case: what you want to build, why you need it, what you plan to do with it, plus any other context you'd like to share.
 
-### C. Found, team is already on a paid plan
+### D. Found, team is already on a paid plan
 
 > Subject: FlowFuse Expert Agentic Application Building
 >
@@ -126,7 +138,7 @@ Adapt to tone and context. The shape of the ask is what matters.
 >
 > Once we have that we'll enable Expert Agentic Application Building on your team.
 
-### D. Decline (not eligible)
+### E. Decline (not eligible)
 
 > Subject: FlowFuse Expert Agentic Application Building
 >

--- a/src/handbook/engineering/ops/expert-agentic-application-building-access.md
+++ b/src/handbook/engineering/ops/expert-agentic-application-building-access.md
@@ -94,53 +94,45 @@ Adapt to tone and context. The shape of the ask is what matters.
 
 ### A. Not found (no FlowFuse Cloud team matched)
 
-> Subject: FlowFuse Expert Agentic Application Building, information needed
+> Subject: FlowFuse Expert Agentic Application Building
 >
 > Hi [name],
 >
-> Thanks for your interest in FlowFuse Expert Agentic Application Building. We couldn't match the email you used to a FlowFuse Cloud team. To take this further we'll need:
+> Thanks for your interest. We couldn't match the email you used to a FlowFuse Cloud team, so we'll need a couple of things from you:
 >
 > - The email associated with the FlowFuse Cloud team that should receive access
-> - A short description of your use case (the kind of application you're hoping Expert will help build)
-> - The reason you'd like to be part of the soft launch
+> - Your use case: what you want to build, why you need it, what you plan to do with it, plus any other context you'd like to share
 >
-> One thing to flag upfront: Expert Agentic Application Building is currently available on FlowFuse Cloud paid plans (Starter, Team, Enterprise). The team that gets enabled will need to be on one of these plans.
->
-> Looking forward to hearing back.
+> One thing upfront: Expert Agentic Application Building is currently available on FlowFuse Cloud paid plans (Starter, Team, Enterprise). The team that gets enabled will need to be on one of these.
 
 ### B. Found, team is on the Free plan
 
-> Subject: FlowFuse Expert Agentic Application Building, a couple of things
+> Subject: FlowFuse Expert Agentic Application Building
 >
 > Hi [name],
 >
-> Thanks for your interest in FlowFuse Expert Agentic Application Building. We found your [team name] team on FlowFuse Cloud. Two things before we move forward:
+> Thanks for your interest. We found your [team name] team on FlowFuse Cloud. Two things before we move forward:
 >
-> - Expert Agentic Application Building is currently available on FlowFuse Cloud paid plans (Starter, Team, Enterprise). Your team is on the Free plan today, so it'll need to be upgraded before we can enable the feature. Happy to walk through plan options if useful.
-> - We'd also like to learn more so we can confirm your team is a good fit for the soft launch:
->   - A short description of your use case
->   - The reason you'd like to be part of the soft launch
+> - Expert Agentic Application Building is currently available on FlowFuse Cloud paid plans (Starter, Team, Enterprise). Your team is on the Free plan today, so it'll need to be upgraded before we can enable the feature. Happy to walk through plan options.
+> - Your use case: what you want to build, why you need it, what you plan to do with it, plus any other context you'd like to share.
 
 ### C. Found, team is already on a paid plan
 
-> Subject: FlowFuse Expert Agentic Application Building, a couple of questions
+> Subject: FlowFuse Expert Agentic Application Building
 >
 > Hi [name],
 >
-> Thanks for your interest in FlowFuse Expert Agentic Application Building. We found your [team name] team on FlowFuse Cloud. To confirm fit for the soft launch, could you share:
+> Thanks for your interest. We found your [team name] team on FlowFuse Cloud. To confirm fit for the soft launch, could you share your use case: what you want to build, what you plan to do with it, plus any other context you'd like to share?
 >
-> - A short description of your use case (the kind of application you're hoping Expert will help build)
-> - The reason you'd like to be part of the soft launch
->
-> Once we have these we'll enable Expert Agentic Application Building on your team.
+> Once we have that we'll enable Expert Agentic Application Building on your team.
 
 ### D. Decline (not eligible)
 
-> Subject: FlowFuse Expert Agentic Application Building, soft launch eligibility
+> Subject: FlowFuse Expert Agentic Application Building
 >
 > Hi [name],
 >
-> Thanks again for sharing your use case for Expert Agentic Application Building. We're rolling this out as a soft launch to a small group of teams who are a particularly close fit for what the capability does today. Right now [specific reason: e.g. the use case sits outside what Expert can build at this stage / the team's setup doesn't yet match the soft-launch criteria], so we're not enabling it on your team at this stage.
+> Thanks for sharing your use case. Right now [specific reason], so we're not enabling it on your team at this stage.
 >
 > We'll be expanding access over the coming weeks. If your situation changes, reach back out and we'll re-evaluate.
 

--- a/src/handbook/engineering/ops/expert-agentic-application-building-access.md
+++ b/src/handbook/engineering/ops/expert-agentic-application-building-access.md
@@ -14,7 +14,7 @@ Customers request access via the [contact form](/contact-us/?subject=FlowFuse%20
 | --- | --- |
 | **Triage duty** | Whoever is on triage duty owns the end-to-end customer-facing flow: identifying the customer in HubSpot, sending the appropriate reply, judging eligibility, and opening the activation handoff. Default owner of every step unless explicitly labelled `[Engineering]`. |
 | **Engineering** | Owns the technical activation of the feature for the team once triage opens a PCR. Confirms back on the PCR when activation is complete so triage can close the loop with the customer. |
-| **Product** | Owns the soft-launch eligibility criteria, is informed as soon as each new use case becomes clear, and is included in eligibility decisions whenever triage has any doubt. |
+| **Product** | Owns the soft-launch eligibility criteria, is informed as soon as each new use case becomes clear (via a note on the HubSpot record), and is looped in on eligibility whenever triage has any doubt. |
 
 ## Flow
 
@@ -30,9 +30,9 @@ flowchart TD
     AskPaid["<b>[Triage] Reply: request info</b><br />- Use case and reason"]
 
     Receive["<b>[Triage]</b> Receive reply<br />Use case and reason on file<br />Paid tier path confirmed"]
-    InformProduct["<b>[Triage &rarr; Product]</b><br />Inform Product of the new use case<br />(post in #product, ping Product lead)"]
+    InformProduct["<b>Inform Product</b><br />Add note on HubSpot record<br />summarising the use case"]
 
-    Eligibility{"<b>[Triage]</b> Verify eligibility<br />Fit for soft-launch<br /><i>If any doubt: include Product in the call</i>"}
+    Eligibility{"<b>[Triage]</b> Verify eligibility<br />Fit for soft-launch<br /><i>If any doubt: loop Product in via the HubSpot note</i>"}
     Decline(["<b>[Triage] Reply: not eligible</b><br />Polite decline, explain criteria"])
     PCR["<b>[Triage]</b> Open PCR for activation<br />CloudProject issue, pre-filled body"]
     Activate["<b>[Engineering]</b> Activate feature for team<br />Comment back on PCR"]
@@ -51,31 +51,18 @@ flowchart TD
     PCR --> Activate
     Activate --> Notify
 
-    classDef inbound fill:#e2e8f0,stroke:#475569,color:#0f172a
-    classDef triage fill:#fde68a,stroke:#b45309,color:#78350f
-    classDef askUnknown fill:#ddd6fe,stroke:#5b21b6,color:#3b0764
-    classDef askFree fill:#bfdbfe,stroke:#1d4ed8,color:#1e3a8a
-    classDef askPaid fill:#bbf7d0,stroke:#15803d,color:#14532d
-    classDef gather fill:#e0e7ff,stroke:#3730a3,color:#1e1b4b
-    classDef product fill:#f5d0fe,stroke:#86198f,color:#581c87
+    classDef default fill:#e5e7eb,stroke:#6b7280,color:#1f2937
+    classDef product fill:#e9d5ff,stroke:#7e22ce,color:#581c87
     classDef decision fill:#fef08a,stroke:#a16207,color:#713f12
     classDef decline fill:#fecaca,stroke:#b91c1c,color:#7f1d1d
-    classDef handoff fill:#fed7aa,stroke:#c2410c,color:#7c2d12
-    classDef engineering fill:#fdba74,stroke:#9a3412,color:#7c2d12
-    classDef activate fill:#86efac,stroke:#15803d,color:#14532d
+    classDef engineering fill:#fed7aa,stroke:#c2410c,color:#7c2d12
+    classDef success fill:#86efac,stroke:#15803d,color:#14532d
 
-    class Start,Contact inbound
-    class Identify triage
-    class AskUnknown askUnknown
-    class AskFree askFree
-    class AskPaid askPaid
-    class Receive gather
     class InformProduct product
     class Eligibility decision
     class Decline decline
-    class PCR handoff
-    class Activate engineering
-    class Notify activate
+    class PCR,Activate engineering
+    class Notify success
 ```
 {% endraw %}
 
@@ -88,36 +75,18 @@ flowchart TD
 
 2. **[Triage] Reply with an info ask, scoped to what is still missing.** The paid tier requirement always lands in this first reply so it never arrives late in the conversation. Use the relevant template below.
 
-3. **[Triage → Product] Inform Product as soon as the use case is on file.** Post a short summary in `#product` (team name, use case in one or two sentences, plan tier). This keeps Product in the loop on demand patterns without making them a blocker on every case.
+3. **Inform Product as soon as the use case is on file.** Add a note to the HubSpot contact record summarising the request (team name, use case in one or two sentences, plan tier) and mention Product on the note so they are notified. Keep the conversation in HubSpot; do not move it to Slack.
 
 4. **[Triage] Verify eligibility** once use case, reason, and paid tier path are all on file. Eligibility checks fit for the soft-launch (intended use, team readiness, paid plan in place or being arranged). Eligibility runs only after all info is in.
-   - **If you have any doubt about fit, include Product in the eligibility call.** Loop them in via the same `#product` thread or pull them into the HubSpot record. Product owns the criteria; triage should not make borderline decisions alone.
+   - **If you have any doubt about fit, loop Product into the decision** by adding them to the same HubSpot note thread. Product owns the criteria; triage should not make borderline decisions alone.
 
 5. **Outcome:**
-   - **Eligible**: [Triage] open a [Production Change Request](https://github.com/FlowFuse/CloudProject/issues/new?assignees=&labels=change-request&projects=&template=change-request.yml&title=Change%3A+Enable+Expert+Agentic+Application+Building+for+%5Bteam%5D&change-description=Enable+FlowFuse+Expert+Agentic+Application+Building+%28soft+launch%29+for+the+team+below.%0A%0A**Team+name**%3A+%5Bteam+name%5D%0A**FlowFuse+Cloud+team+ID**%3A+%5Bteam-id%5D%0A**Plan+tier**%3A+%5BStarter+%7C+Team+%7C+Enterprise%5D%0A**Use+case**%3A+%5B1-2+sentences+from+customer+reply%5D%0A**Eligibility+confirmed+by**%3A+%5Btriage+name%5D%0A**Product+consulted**%3A+%5Byes+%2F+no%5D%0A**HubSpot+contact**%3A+%5Blink+to+contact+record%5D%0A%0AOnce+activated%2C+please+comment+back+on+this+issue+so+triage+can+notify+the+customer.&validation-steps=-+%5B+%5D+Feature+enabled+for+the+team+in+admin+UI%0A-+%5B+%5D+Spot-check+from+a+team+member+account%3A+Expert+Agentic+Application+Building+entry+point+is+visible%0A-+%5B+%5D+Comment+on+this+issue+confirming+activation) in CloudProject. Most fields prefill from the URL; tick **Production** in the Environment checkbox. Post the link in `#dept-engineering`.
+   - **Eligible**: [Triage] open a [Production Change Request](https://github.com/FlowFuse/CloudProject/issues/new?assignees=&labels=change-request&projects=&template=change-request.yml&title=Change%3A+Enable+Expert+Agentic+Application+Building+for+%5Bteam%5D&change-description=Enable+FlowFuse+Expert+Agentic+Application+Building+%28soft+launch%29+for+the+team+below.%0A%0A**Team+name**%3A+%5Bteam+name%5D%0A**FlowFuse+Cloud+team+ID**%3A+%5Bteam-id%5D%0A**Plan+tier**%3A+%5BStarter+%7C+Team+%7C+Enterprise%5D%0A**Use+case**%3A+%5B1-2+sentences+from+customer+reply%5D%0A**Eligibility+confirmed+by**%3A+%5Btriage+name%5D%0A**Product+consulted**%3A+%5Byes+%2F+no%5D%0A**HubSpot+contact**%3A+%5Blink+to+contact+record%5D%0A%0AOnce+activated%2C+please+comment+back+on+this+issue+so+triage+can+notify+the+customer.&validation-steps=-+%5B+%5D+Feature+enabled+for+the+team+in+admin+UI%0A-+%5B+%5D+Spot-check+from+a+team+member+account%3A+Expert+Agentic+Application+Building+entry+point+is+visible%0A-+%5B+%5D+Comment+on+this+issue+confirming+activation) in CloudProject. Tick **Production** in the Environment checkbox.
    - **Not eligible**: [Triage] reply with a polite decline using the template below.
 
 6. **[Engineering] Activate the feature for the team** referenced in the PCR and comment back on the PCR when complete.
 
 7. **[Triage] Notify the contact** that access is live.
-
-### If the PCR URL pre-fill doesn't populate
-
-Paste this into Change Description manually:
-
-```
-Enable FlowFuse Expert Agentic Application Building (soft launch) for the team below.
-
-**Team name**: [team name]
-**FlowFuse Cloud team ID**: [team-id]
-**Plan tier**: [Starter | Team | Enterprise]
-**Use case**: [1-2 sentences from customer reply]
-**Eligibility confirmed by**: [triage name]
-**Product consulted**: [yes / no]
-**HubSpot contact**: [link to contact record]
-
-Once activated, please comment back on this issue so triage can notify the customer.
-```
 
 ## Reply templates
 
@@ -179,6 +148,6 @@ Adapt to tone and context. The shape of the ask is what matters.
 
 - **Contact never replies to the info ask**: [Triage] treat as stalled. Follow up on the standard cadence; close the loop after the cadence is exhausted.
 - **Found-tier classification is ambiguous** (e.g. trial about to expire, plan change in flight): [Triage] treat as Free tier and include the paid tier note.
-- **Eligibility genuinely borderline or use case is unusual**: [Triage] pull Product into the call before deciding. Better to slow one case down by a day than ship a no/yes Product would have flipped.
+- **Eligibility genuinely borderline or use case is unusual**: [Triage] loop Product into the HubSpot note before deciding. Better to slow one case down by a day than ship a no/yes Product would have flipped.
 - **Decline appeals**: [Triage] handle out of band. The decline reply explains the criteria so the customer can return with new context if their situation changes.
 - **Engineering activation fails or is delayed**: Engineering comments back on the PCR; triage keeps the customer informed.

--- a/src/handbook/engineering/ops/expert-agentic-application-building-access.md
+++ b/src/handbook/engineering/ops/expert-agentic-application-building-access.md
@@ -12,9 +12,9 @@ Customers request access via the [contact form](/contact-us/?subject=FlowFuse%20
 
 | Role | Responsibility |
 | --- | --- |
-| **Triage duty** | Whoever is on triage duty owns the end-to-end customer-facing flow: identifying the customer in HubSpot, sending the appropriate reply, judging eligibility, and opening the activation handoff. Default owner of every step in the flow below unless explicitly labelled `[Engineering]`. |
+| **Triage duty** | Whoever is on triage duty owns the end-to-end customer-facing flow: identifying the customer in HubSpot, sending the appropriate reply, judging eligibility, and opening the activation handoff. Default owner of every step unless explicitly labelled `[Engineering]`. |
 | **Engineering** | Owns the technical activation of the feature for the team once triage opens a PCR. Confirms back on the PCR when activation is complete so triage can close the loop with the customer. |
-| **Product** | Owns the soft-launch eligibility criteria. Triage escalates here only when fit is genuinely borderline. |
+| **Product** | Owns the soft-launch eligibility criteria, is informed as soon as each new use case becomes clear, and is included in eligibility decisions whenever triage has any doubt. |
 
 ## Flow
 
@@ -30,10 +30,11 @@ flowchart TD
     AskPaid["<b>[Triage] Reply: request info</b><br />- Use case and reason"]
 
     Receive["<b>[Triage]</b> Receive reply<br />Use case and reason on file<br />Paid tier path confirmed"]
+    InformProduct["<b>[Triage &rarr; Product]</b><br />Inform Product of the new use case<br />(post in #product, ping Product lead)"]
 
-    Eligibility{"<b>[Triage]</b> Verify eligibility<br />Fit for soft-launch<br />(escalate to Product if borderline)"}
+    Eligibility{"<b>[Triage]</b> Verify eligibility<br />Fit for soft-launch<br /><i>If any doubt: include Product in the call</i>"}
     Decline(["<b>[Triage] Reply: not eligible</b><br />Polite decline, explain criteria"])
-    PCR["<b>[Triage]</b> Open PCR for activation<br />CloudProject issue, team identifier in body"]
+    PCR["<b>[Triage]</b> Open PCR for activation<br />CloudProject issue, pre-filled body"]
     Activate["<b>[Engineering]</b> Activate feature for team<br />Comment back on PCR"]
     Notify(["<b>[Triage]</b> Notify contact<br />Access is live"])
 
@@ -44,11 +45,37 @@ flowchart TD
     AskUnknown --> Receive
     AskFree --> Receive
     AskPaid --> Receive
-    Receive --> Eligibility
+    Receive --> InformProduct --> Eligibility
     Eligibility -- "Not eligible" --> Decline
     Eligibility -- "Eligible" --> PCR
     PCR --> Activate
     Activate --> Notify
+
+    classDef inbound fill:#e2e8f0,stroke:#475569,color:#0f172a
+    classDef triage fill:#fde68a,stroke:#b45309,color:#78350f
+    classDef askUnknown fill:#ddd6fe,stroke:#5b21b6,color:#3b0764
+    classDef askFree fill:#bfdbfe,stroke:#1d4ed8,color:#1e3a8a
+    classDef askPaid fill:#bbf7d0,stroke:#15803d,color:#14532d
+    classDef gather fill:#e0e7ff,stroke:#3730a3,color:#1e1b4b
+    classDef product fill:#f5d0fe,stroke:#86198f,color:#581c87
+    classDef decision fill:#fef08a,stroke:#a16207,color:#713f12
+    classDef decline fill:#fecaca,stroke:#b91c1c,color:#7f1d1d
+    classDef handoff fill:#fed7aa,stroke:#c2410c,color:#7c2d12
+    classDef engineering fill:#fdba74,stroke:#9a3412,color:#7c2d12
+    classDef activate fill:#86efac,stroke:#15803d,color:#14532d
+
+    class Start,Contact inbound
+    class Identify triage
+    class AskUnknown askUnknown
+    class AskFree askFree
+    class AskPaid askPaid
+    class Receive gather
+    class InformProduct product
+    class Eligibility decision
+    class Decline decline
+    class PCR handoff
+    class Activate engineering
+    class Notify activate
 ```
 {% endraw %}
 
@@ -61,16 +88,36 @@ flowchart TD
 
 2. **[Triage] Reply with an info ask, scoped to what is still missing.** The paid tier requirement always lands in this first reply so it never arrives late in the conversation. Use the relevant template below.
 
-3. **[Triage] Verify eligibility** once the reply is received and use case, reason, and paid tier path are all on file. Eligibility checks fit for the soft-launch (intended use, team readiness, paid plan in place or being arranged). Eligibility runs only after all info is in.
-   - **Escalate to Product** only when fit is genuinely borderline. Product owns the criteria, not the case-by-case decision.
+3. **[Triage → Product] Inform Product as soon as the use case is on file.** Post a short summary in `#product` (team name, use case in one or two sentences, plan tier). This keeps Product in the loop on demand patterns without making them a blocker on every case.
 
-4. **Outcome:**
-   - **Eligible**: [Triage] open a [Production Change Request](https://github.com/FlowFuse/CloudProject/issues/new?assignees=&labels=change-request&projects=&template=change-request.yml&title=Change%3A+Enable+Expert+Agentic+Application+Building+for+%5Bteam%5D) in CloudProject with the FlowFuse Cloud team identifier in the body. Post the link in `#dept-engineering`.
+4. **[Triage] Verify eligibility** once use case, reason, and paid tier path are all on file. Eligibility checks fit for the soft-launch (intended use, team readiness, paid plan in place or being arranged). Eligibility runs only after all info is in.
+   - **If you have any doubt about fit, include Product in the eligibility call.** Loop them in via the same `#product` thread or pull them into the HubSpot record. Product owns the criteria; triage should not make borderline decisions alone.
+
+5. **Outcome:**
+   - **Eligible**: [Triage] open a [Production Change Request](https://github.com/FlowFuse/CloudProject/issues/new?assignees=&labels=change-request&projects=&template=change-request.yml&title=Change%3A+Enable+Expert+Agentic+Application+Building+for+%5Bteam%5D&change-description=Enable+FlowFuse+Expert+Agentic+Application+Building+%28soft+launch%29+for+the+team+below.%0A%0A**Team+name**%3A+%5Bteam+name%5D%0A**FlowFuse+Cloud+team+ID**%3A+%5Bteam-id%5D%0A**Plan+tier**%3A+%5BStarter+%7C+Team+%7C+Enterprise%5D%0A**Use+case**%3A+%5B1-2+sentences+from+customer+reply%5D%0A**Eligibility+confirmed+by**%3A+%5Btriage+name%5D%0A**Product+consulted**%3A+%5Byes+%2F+no%5D%0A**HubSpot+contact**%3A+%5Blink+to+contact+record%5D%0A%0AOnce+activated%2C+please+comment+back+on+this+issue+so+triage+can+notify+the+customer.&validation-steps=-+%5B+%5D+Feature+enabled+for+the+team+in+admin+UI%0A-+%5B+%5D+Spot-check+from+a+team+member+account%3A+Expert+Agentic+Application+Building+entry+point+is+visible%0A-+%5B+%5D+Comment+on+this+issue+confirming+activation) in CloudProject. Most fields prefill from the URL; tick **Production** in the Environment checkbox. Post the link in `#dept-engineering`.
    - **Not eligible**: [Triage] reply with a polite decline using the template below.
 
-5. **[Engineering] Activate the feature for the team** referenced in the PCR and comment back on the PCR when complete.
+6. **[Engineering] Activate the feature for the team** referenced in the PCR and comment back on the PCR when complete.
 
-6. **[Triage] Notify the contact** that access is live.
+7. **[Triage] Notify the contact** that access is live.
+
+### If the PCR URL pre-fill doesn't populate
+
+Paste this into Change Description manually:
+
+```
+Enable FlowFuse Expert Agentic Application Building (soft launch) for the team below.
+
+**Team name**: [team name]
+**FlowFuse Cloud team ID**: [team-id]
+**Plan tier**: [Starter | Team | Enterprise]
+**Use case**: [1-2 sentences from customer reply]
+**Eligibility confirmed by**: [triage name]
+**Product consulted**: [yes / no]
+**HubSpot contact**: [link to contact record]
+
+Once activated, please comment back on this issue so triage can notify the customer.
+```
 
 ## Reply templates
 
@@ -132,6 +179,6 @@ Adapt to tone and context. The shape of the ask is what matters.
 
 - **Contact never replies to the info ask**: [Triage] treat as stalled. Follow up on the standard cadence; close the loop after the cadence is exhausted.
 - **Found-tier classification is ambiguous** (e.g. trial about to expire, plan change in flight): [Triage] treat as Free tier and include the paid tier note.
-- **Eligibility genuinely borderline**: [Triage] escalate to Product. Do not block the queue on every case.
+- **Eligibility genuinely borderline or use case is unusual**: [Triage] pull Product into the call before deciding. Better to slow one case down by a day than ship a no/yes Product would have flipped.
 - **Decline appeals**: [Triage] handle out of band. The decline reply explains the criteria so the customer can return with new context if their situation changes.
 - **Engineering activation fails or is delayed**: Engineering comments back on the PCR; triage keeps the customer informed.

--- a/src/handbook/engineering/ops/expert-agentic-application-building-access.md
+++ b/src/handbook/engineering/ops/expert-agentic-application-building-access.md
@@ -1,10 +1,10 @@
 ---
-navTitle: Expert Application Building Access
+navTitle: Expert Agentic Application Building Access
 ---
 
-# Expert Application Building Soft-Launch Access
+# Expert Agentic Application Building Soft-Launch Access
 
-FlowFuse Expert Application Building (agentic Node-RED development, FlowFuse 2.30) is in soft launch on FlowFuse Cloud. Access is granted on request to teams on a paid plan (Starter, Team, Enterprise). This page describes how to triage incoming requests.
+FlowFuse Expert Agentic Application Building (agentic Node-RED development, FlowFuse 2.30) is in soft launch on FlowFuse Cloud. Access is granted on request to teams on a paid plan (Starter, Team, Enterprise). This page describes how to triage incoming requests.
 
 Customers request access via the [contact form](/contact-us/?subject=FlowFuse%20Expert%20Application%20Building) linked from the [2.30 release blog post](/blog/2026/05/flowfuse-release-2-30/) and the changelog. They are asked to include the email associated with their FlowFuse Cloud team.
 
@@ -65,7 +65,7 @@ flowchart TD
    - **Escalate to Product** only when fit is genuinely borderline. Product owns the criteria, not the case-by-case decision.
 
 4. **Outcome:**
-   - **Eligible**: [Triage] open a [Production Change Request](https://github.com/FlowFuse/CloudProject/issues/new?assignees=&labels=change-request&projects=&template=change-request.yml&title=Change%3A+Enable+Expert+Application+Building+for+%5Bteam%5D) in CloudProject with the FlowFuse Cloud team identifier in the body. Post the link in `#dept-engineering`.
+   - **Eligible**: [Triage] open a [Production Change Request](https://github.com/FlowFuse/CloudProject/issues/new?assignees=&labels=change-request&projects=&template=change-request.yml&title=Change%3A+Enable+Expert+Agentic+Application+Building+for+%5Bteam%5D) in CloudProject with the FlowFuse Cloud team identifier in the body. Post the link in `#dept-engineering`.
    - **Not eligible**: [Triage] reply with a polite decline using the template below.
 
 5. **[Engineering] Activate the feature for the team** referenced in the PCR and comment back on the PCR when complete.
@@ -78,53 +78,53 @@ Adapt to tone and context. The shape of the ask is what matters.
 
 ### A. Not found (no FlowFuse Cloud team matched)
 
-> Subject: FlowFuse Expert Application Building, information needed
+> Subject: FlowFuse Expert Agentic Application Building, information needed
 >
 > Hi [name],
 >
-> Thanks for your interest in FlowFuse Expert Application Building. We couldn't match the email you used to a FlowFuse Cloud team. To take this further we'll need:
+> Thanks for your interest in FlowFuse Expert Agentic Application Building. We couldn't match the email you used to a FlowFuse Cloud team. To take this further we'll need:
 >
 > - The email associated with the FlowFuse Cloud team that should receive access
 > - A short description of your use case (the kind of application you're hoping Expert will help build)
 > - The reason you'd like to be part of the soft launch
 >
-> One thing to flag upfront: Expert Application Building is currently available on FlowFuse Cloud paid plans (Starter, Team, Enterprise). The team that gets enabled will need to be on one of these plans.
+> One thing to flag upfront: Expert Agentic Application Building is currently available on FlowFuse Cloud paid plans (Starter, Team, Enterprise). The team that gets enabled will need to be on one of these plans.
 >
 > Looking forward to hearing back.
 
 ### B. Found, team is on the Free plan
 
-> Subject: FlowFuse Expert Application Building, a couple of things
+> Subject: FlowFuse Expert Agentic Application Building, a couple of things
 >
 > Hi [name],
 >
-> Thanks for your interest in FlowFuse Expert Application Building. We found your [team name] team on FlowFuse Cloud. Two things before we move forward:
+> Thanks for your interest in FlowFuse Expert Agentic Application Building. We found your [team name] team on FlowFuse Cloud. Two things before we move forward:
 >
-> - Expert Application Building is currently available on FlowFuse Cloud paid plans (Starter, Team, Enterprise). Your team is on the Free plan today, so it'll need to be upgraded before we can enable the feature. Happy to walk through plan options if useful.
+> - Expert Agentic Application Building is currently available on FlowFuse Cloud paid plans (Starter, Team, Enterprise). Your team is on the Free plan today, so it'll need to be upgraded before we can enable the feature. Happy to walk through plan options if useful.
 > - We'd also like to learn more so we can confirm your team is a good fit for the soft launch:
 >   - A short description of your use case
 >   - The reason you'd like to be part of the soft launch
 
 ### C. Found, team is already on a paid plan
 
-> Subject: FlowFuse Expert Application Building, a couple of questions
+> Subject: FlowFuse Expert Agentic Application Building, a couple of questions
 >
 > Hi [name],
 >
-> Thanks for your interest in FlowFuse Expert Application Building. We found your [team name] team on FlowFuse Cloud. To confirm fit for the soft launch, could you share:
+> Thanks for your interest in FlowFuse Expert Agentic Application Building. We found your [team name] team on FlowFuse Cloud. To confirm fit for the soft launch, could you share:
 >
 > - A short description of your use case (the kind of application you're hoping Expert will help build)
 > - The reason you'd like to be part of the soft launch
 >
-> Once we have these we'll enable Expert Application Building on your team.
+> Once we have these we'll enable Expert Agentic Application Building on your team.
 
 ### D. Decline (not eligible)
 
-> Subject: FlowFuse Expert Application Building, soft launch eligibility
+> Subject: FlowFuse Expert Agentic Application Building, soft launch eligibility
 >
 > Hi [name],
 >
-> Thanks again for sharing your use case for Expert Application Building. We're rolling this out as a soft launch to a small group of teams who are a particularly close fit for what the capability does today. Right now [specific reason: e.g. the use case sits outside what Expert can build at this stage / the team's setup doesn't yet match the soft-launch criteria], so we're not enabling it on your team at this stage.
+> Thanks again for sharing your use case for Expert Agentic Application Building. We're rolling this out as a soft launch to a small group of teams who are a particularly close fit for what the capability does today. Right now [specific reason: e.g. the use case sits outside what Expert can build at this stage / the team's setup doesn't yet match the soft-launch criteria], so we're not enabling it on your team at this stage.
 >
 > We'll be expanding access over the coming weeks. If your situation changes, reach back out and we'll re-evaluate.
 

--- a/src/handbook/engineering/ops/expert-application-building-access.md
+++ b/src/handbook/engineering/ops/expert-application-building-access.md
@@ -8,6 +8,14 @@ FlowFuse Expert Application Building (agentic Node-RED development, FlowFuse 2.3
 
 Customers request access via the [contact form](/contact-us/?subject=FlowFuse%20Expert%20Application%20Building) linked from the [2.30 release blog post](/blog/2026/05/flowfuse-release-2-30/) and the changelog. They are asked to include the email associated with their FlowFuse Cloud team.
 
+## Ownership
+
+| Role | Responsibility |
+| --- | --- |
+| **Triage duty** | Whoever is on triage duty owns the end-to-end customer-facing flow: identifying the customer in HubSpot, sending the appropriate reply, judging eligibility, and opening the activation handoff. Default owner of every step in the flow below unless explicitly labelled `[Engineering]`. |
+| **Engineering** | Owns the technical activation of the feature for the team once triage opens a PCR. Confirms back on the PCR when activation is complete so triage can close the loop with the customer. |
+| **Product** | Owns the soft-launch eligibility criteria. Triage escalates here only when fit is genuinely borderline. |
+
 ## Flow
 
 {% raw %}
@@ -15,17 +23,19 @@ Customers request access via the [contact form](/contact-us/?subject=FlowFuse%20
 flowchart TD
     Start(["Reads soft-launch announcement<br />Includes FlowFuse team email"])
     Contact["Contact submitted<br />HubSpot notification fires"]
-    Identify["Identify customer and team"]
+    Identify["<b>[Triage]</b> Identify customer and team"]
 
-    AskUnknown["<b>Reply: request all info</b><br />- Email tied to FlowFuse Cloud team<br />- Use case and reason<br />- Note: paid tier team required"]
-    AskFree["<b>Reply: request info, note tier</b><br />- Use case and reason<br />- Note: paid tier team required"]
-    AskPaid["<b>Reply: request info</b><br />- Use case and reason"]
+    AskUnknown["<b>[Triage] Reply: request all info</b><br />- Email tied to FlowFuse Cloud team<br />- Use case and reason<br />- Note: paid tier team required"]
+    AskFree["<b>[Triage] Reply: request info, note tier</b><br />- Use case and reason<br />- Note: paid tier team required"]
+    AskPaid["<b>[Triage] Reply: request info</b><br />- Use case and reason"]
 
-    Receive["Receive reply<br />Use case and reason on file<br />Paid tier path confirmed"]
+    Receive["<b>[Triage]</b> Receive reply<br />Use case and reason on file<br />Paid tier path confirmed"]
 
-    Eligibility{"Verify eligibility<br />Fit for soft-launch"}
-    Decline(["Reply: not eligible<br />Polite decline, explain criteria"])
-    Activate(["<b>Activate access</b><br />Notify contact, all prerequisites confirmed"])
+    Eligibility{"<b>[Triage]</b> Verify eligibility<br />Fit for soft-launch<br />(escalate to Product if borderline)"}
+    Decline(["<b>[Triage] Reply: not eligible</b><br />Polite decline, explain criteria"])
+    PCR["<b>[Triage]</b> Open PCR for activation<br />CloudProject issue, team identifier in body"]
+    Activate["<b>[Engineering]</b> Activate feature for team<br />Comment back on PCR"]
+    Notify(["<b>[Triage]</b> Notify contact<br />Access is live"])
 
     Start --> Contact --> Identify
     Identify -- "Not found" --> AskUnknown
@@ -36,33 +46,92 @@ flowchart TD
     AskPaid --> Receive
     Receive --> Eligibility
     Eligibility -- "Not eligible" --> Decline
-    Eligibility -- "Eligible" --> Activate
+    Eligibility -- "Eligible" --> PCR
+    PCR --> Activate
+    Activate --> Notify
 ```
 {% endraw %}
 
 ## Step by step
 
-1. **Identify customer and team in HubSpot** using the email provided in the contact submission. Three outcomes:
+1. **[Triage] Identify customer and team in HubSpot** using the email from the contact submission. Three outcomes:
    - **Not found**: no matching contact or FlowFuse Cloud team.
    - **Found, free tier**: the team exists but is on the Free plan.
    - **Found, paid tier**: the team is on Starter, Team, or Enterprise.
 
-2. **Reply with an info ask, scoped to what is still missing.** The paid tier note always lands in this first reply so it never arrives late in the conversation.
+2. **[Triage] Reply with an info ask, scoped to what is still missing.** The paid tier requirement always lands in this first reply so it never arrives late in the conversation. Use the relevant template below.
 
-   | Identify result | Ask for | Include paid tier note |
-   | --- | --- | --- |
-   | Not found | Email tied to FlowFuse Cloud team, use case, reason | Yes |
-   | Found, free tier | Use case, reason | Yes |
-   | Found, paid tier | Use case, reason | No |
+3. **[Triage] Verify eligibility** once the reply is received and use case, reason, and paid tier path are all on file. Eligibility checks fit for the soft-launch (intended use, team readiness, paid plan in place or being arranged). Eligibility runs only after all info is in.
+   - **Escalate to Product** only when fit is genuinely borderline. Product owns the criteria, not the case-by-case decision.
 
-3. **Verify eligibility** once the reply is received and use case, reason, and paid tier path are all on file. Eligibility checks fit for the soft-launch (intended use, team readiness, paid plan in place or being arranged). Eligibility runs only after all info is in.
+4. **Outcome:**
+   - **Eligible**: [Triage] open a [Production Change Request](https://github.com/FlowFuse/CloudProject/issues/new?assignees=&labels=change-request&projects=&template=change-request.yml&title=Change%3A+Enable+Expert+Application+Building+for+%5Bteam%5D) in CloudProject with the FlowFuse Cloud team identifier in the body. Post the link in `#dept-engineering`.
+   - **Not eligible**: [Triage] reply with a polite decline using the template below.
 
-4. **Outcome**:
-   - **Eligible**: activate access for the team and notify the contact. Activation is a single step (it both technically enables the feature and confirms with the customer).
-   - **Not eligible**: reply with a polite decline and explain the criteria that were not met.
+5. **[Engineering] Activate the feature for the team** referenced in the PCR and comment back on the PCR when complete.
+
+6. **[Triage] Notify the contact** that access is live.
+
+## Reply templates
+
+Adapt to tone and context. The shape of the ask is what matters.
+
+### A. Not found (no FlowFuse Cloud team matched)
+
+> Subject: FlowFuse Expert Application Building, information needed
+>
+> Hi [name],
+>
+> Thanks for your interest in FlowFuse Expert Application Building. We couldn't match the email you used to a FlowFuse Cloud team. To take this further we'll need:
+>
+> - The email associated with the FlowFuse Cloud team that should receive access
+> - A short description of your use case (the kind of application you're hoping Expert will help build)
+> - The reason you'd like to be part of the soft launch
+>
+> One thing to flag upfront: Expert Application Building is currently available on FlowFuse Cloud paid plans (Starter, Team, Enterprise). The team that gets enabled will need to be on one of these plans.
+>
+> Looking forward to hearing back.
+
+### B. Found, team is on the Free plan
+
+> Subject: FlowFuse Expert Application Building, a couple of things
+>
+> Hi [name],
+>
+> Thanks for your interest in FlowFuse Expert Application Building. We found your [team name] team on FlowFuse Cloud. Two things before we move forward:
+>
+> - Expert Application Building is currently available on FlowFuse Cloud paid plans (Starter, Team, Enterprise). Your team is on the Free plan today, so it'll need to be upgraded before we can enable the feature. Happy to walk through plan options if useful.
+> - We'd also like to learn more so we can confirm your team is a good fit for the soft launch:
+>   - A short description of your use case
+>   - The reason you'd like to be part of the soft launch
+
+### C. Found, team is already on a paid plan
+
+> Subject: FlowFuse Expert Application Building, a couple of questions
+>
+> Hi [name],
+>
+> Thanks for your interest in FlowFuse Expert Application Building. We found your [team name] team on FlowFuse Cloud. To confirm fit for the soft launch, could you share:
+>
+> - A short description of your use case (the kind of application you're hoping Expert will help build)
+> - The reason you'd like to be part of the soft launch
+>
+> Once we have these we'll enable Expert Application Building on your team.
+
+### D. Decline (not eligible)
+
+> Subject: FlowFuse Expert Application Building, soft launch eligibility
+>
+> Hi [name],
+>
+> Thanks again for sharing your use case for Expert Application Building. We're rolling this out as a soft launch to a small group of teams who are a particularly close fit for what the capability does today. Right now [specific reason: e.g. the use case sits outside what Expert can build at this stage / the team's setup doesn't yet match the soft-launch criteria], so we're not enabling it on your team at this stage.
+>
+> We'll be expanding access over the coming weeks. If your situation changes, reach back out and we'll re-evaluate.
 
 ## Edge cases
 
-- **Contact never replies to the info ask**: treat as stalled. Follow up on the standard cadence; close the loop after the cadence is exhausted.
-- **Found-tier classification is ambiguous** (e.g. trial about to expire, plan change in flight): treat as free tier and include the paid tier note.
-- **Decline appeals**: handle out of band. The decline reply explains the criteria so the customer can return with new context if their situation changes.
+- **Contact never replies to the info ask**: [Triage] treat as stalled. Follow up on the standard cadence; close the loop after the cadence is exhausted.
+- **Found-tier classification is ambiguous** (e.g. trial about to expire, plan change in flight): [Triage] treat as Free tier and include the paid tier note.
+- **Eligibility genuinely borderline**: [Triage] escalate to Product. Do not block the queue on every case.
+- **Decline appeals**: [Triage] handle out of band. The decline reply explains the criteria so the customer can return with new context if their situation changes.
+- **Engineering activation fails or is delayed**: Engineering comments back on the PCR; triage keeps the customer informed.

--- a/src/handbook/engineering/ops/expert-application-building-access.md
+++ b/src/handbook/engineering/ops/expert-application-building-access.md
@@ -10,11 +10,12 @@ Customers request access via the [contact form](/contact-us/?subject=FlowFuse%20
 
 ## Flow
 
+{% raw %}
 ```mermaid
 flowchart TD
     Start(["Reads soft-launch announcement<br />Includes FlowFuse team email"])
     Contact["Contact submitted<br />HubSpot notification fires"]
-    Identify{{"Identify customer and team"}}
+    Identify["Identify customer and team"]
 
     AskUnknown["<b>Reply: request all info</b><br />- Email tied to FlowFuse Cloud team<br />- Use case and reason<br />- Note: paid tier team required"]
     AskFree["<b>Reply: request info, note tier</b><br />- Use case and reason<br />- Note: paid tier team required"]
@@ -37,6 +38,7 @@ flowchart TD
     Eligibility -- "Not eligible" --> Decline
     Eligibility -- "Eligible" --> Activate
 ```
+{% endraw %}
 
 ## Step by step
 

--- a/src/handbook/engineering/ops/expert-application-building-access.md
+++ b/src/handbook/engineering/ops/expert-application-building-access.md
@@ -1,0 +1,66 @@
+---
+navTitle: Expert Application Building Access
+---
+
+# Expert Application Building Soft-Launch Access
+
+FlowFuse Expert Application Building (agentic Node-RED development, FlowFuse 2.30) is in soft launch on FlowFuse Cloud. Access is granted on request to teams on a paid plan (Starter, Team, Enterprise). This page describes how to triage incoming requests.
+
+Customers request access via the [contact form](/contact-us/?subject=FlowFuse%20Expert%20Application%20Building) linked from the [2.30 release blog post](/blog/2026/05/flowfuse-release-2-30/) and the changelog. They are asked to include the email associated with their FlowFuse Cloud team.
+
+## Flow
+
+```mermaid
+flowchart TD
+    Start([Reads soft-launch announcement<br/><i>Includes FlowFuse team email</i>])
+    Contact[Contact submitted<br/><i>HubSpot notification fires</i>]
+    Identify{{Identify customer and team}}
+
+    AskUnknown[<b>Reply: request all info</b><br/>· Email tied to FlowFuse Cloud team<br/>· Use case and reason<br/>· Note: paid tier team required]
+    AskFree[<b>Reply: request info, note tier</b><br/>· Use case and reason<br/>· Note: paid tier team required]
+    AskPaid[<b>Reply: request info</b><br/>· Use case and reason]
+
+    Receive[Receive reply<br/><i>Use case and reason on file,<br/>paid tier path confirmed</i>]
+
+    Eligibility{Verify eligibility<br/><i>Fit for soft-launch</i>}
+    Decline([Reply: not eligible<br/><i>Polite decline, explain criteria</i>])
+    Activate([Activate access<br/><i>Notify contact, all prerequisites confirmed</i>])
+
+    Start --> Contact --> Identify
+    Identify -- Not found --> AskUnknown
+    Identify -- Found, free tier --> AskFree
+    Identify -- Found, paid tier --> AskPaid
+    AskUnknown --> Receive
+    AskFree --> Receive
+    AskPaid --> Receive
+    Receive --> Eligibility
+    Eligibility -- Not eligible --> Decline
+    Eligibility -- Eligible --> Activate
+```
+
+## Step by step
+
+1. **Identify customer and team in HubSpot** using the email provided in the contact submission. Three outcomes:
+   - **Not found**: no matching contact or FlowFuse Cloud team.
+   - **Found, free tier**: the team exists but is on the Free plan.
+   - **Found, paid tier**: the team is on Starter, Team, or Enterprise.
+
+2. **Reply with an info ask, scoped to what is still missing.** The paid tier note always lands in this first reply so it never arrives late in the conversation.
+
+   | Identify result | Ask for | Include paid tier note |
+   | --- | --- | --- |
+   | Not found | Email tied to FlowFuse Cloud team, use case, reason | Yes |
+   | Found, free tier | Use case, reason | Yes |
+   | Found, paid tier | Use case, reason | No |
+
+3. **Verify eligibility** once the reply is received and use case, reason, and paid tier path are all on file. Eligibility checks fit for the soft-launch (intended use, team readiness, paid plan in place or being arranged). Eligibility runs only after all info is in.
+
+4. **Outcome**:
+   - **Eligible**: activate access for the team and notify the contact. Activation is a single step (it both technically enables the feature and confirms with the customer).
+   - **Not eligible**: reply with a polite decline and explain the criteria that were not met.
+
+## Edge cases
+
+- **Contact never replies to the info ask**: treat as stalled. Follow up on the standard cadence; close the loop after the cadence is exhausted.
+- **Found-tier classification is ambiguous** (e.g. trial about to expire, plan change in flight): treat as free tier and include the paid tier note.
+- **Decline appeals**: handle out of band. The decline reply explains the criteria so the customer can return with new context if their situation changes.

--- a/src/handbook/engineering/ops/expert-application-building-access.md
+++ b/src/handbook/engineering/ops/expert-application-building-access.md
@@ -12,30 +12,30 @@ Customers request access via the [contact form](/contact-us/?subject=FlowFuse%20
 
 ```mermaid
 flowchart TD
-    Start([Reads soft-launch announcement<br/><i>Includes FlowFuse team email</i>])
-    Contact[Contact submitted<br/><i>HubSpot notification fires</i>]
-    Identify{{Identify customer and team}}
+    Start(["Reads soft-launch announcement<br />Includes FlowFuse team email"])
+    Contact["Contact submitted<br />HubSpot notification fires"]
+    Identify{{"Identify customer and team"}}
 
-    AskUnknown[<b>Reply: request all info</b><br/>· Email tied to FlowFuse Cloud team<br/>· Use case and reason<br/>· Note: paid tier team required]
-    AskFree[<b>Reply: request info, note tier</b><br/>· Use case and reason<br/>· Note: paid tier team required]
-    AskPaid[<b>Reply: request info</b><br/>· Use case and reason]
+    AskUnknown["<b>Reply: request all info</b><br />- Email tied to FlowFuse Cloud team<br />- Use case and reason<br />- Note: paid tier team required"]
+    AskFree["<b>Reply: request info, note tier</b><br />- Use case and reason<br />- Note: paid tier team required"]
+    AskPaid["<b>Reply: request info</b><br />- Use case and reason"]
 
-    Receive[Receive reply<br/><i>Use case and reason on file,<br/>paid tier path confirmed</i>]
+    Receive["Receive reply<br />Use case and reason on file<br />Paid tier path confirmed"]
 
-    Eligibility{Verify eligibility<br/><i>Fit for soft-launch</i>}
-    Decline([Reply: not eligible<br/><i>Polite decline, explain criteria</i>])
-    Activate([Activate access<br/><i>Notify contact, all prerequisites confirmed</i>])
+    Eligibility{"Verify eligibility<br />Fit for soft-launch"}
+    Decline(["Reply: not eligible<br />Polite decline, explain criteria"])
+    Activate(["<b>Activate access</b><br />Notify contact, all prerequisites confirmed"])
 
     Start --> Contact --> Identify
-    Identify -- Not found --> AskUnknown
-    Identify -- Found, free tier --> AskFree
-    Identify -- Found, paid tier --> AskPaid
+    Identify -- "Not found" --> AskUnknown
+    Identify -- "Found, free tier" --> AskFree
+    Identify -- "Found, paid tier" --> AskPaid
     AskUnknown --> Receive
     AskFree --> Receive
     AskPaid --> Receive
     Receive --> Eligibility
-    Eligibility -- Not eligible --> Decline
-    Eligibility -- Eligible --> Activate
+    Eligibility -- "Not eligible" --> Decline
+    Eligibility -- "Eligible" --> Activate
 ```
 
 ## Step by step

--- a/src/handbook/engineering/ops/index.md
+++ b/src/handbook/engineering/ops/index.md
@@ -12,6 +12,7 @@ navTitle: Platform Ops
  - [FlowFuse Dedicated](./dedicated.md)
  - [Updating Stacks](./production-stack-update.md)
  - [Self Hosted Assistant](./self-hosted-assistant.md)
+ - [Expert Application Building Access](./expert-application-building-access.md)
  
 
 ## CI/CD

--- a/src/handbook/engineering/ops/index.md
+++ b/src/handbook/engineering/ops/index.md
@@ -12,7 +12,7 @@ navTitle: Platform Ops
  - [FlowFuse Dedicated](./dedicated.md)
  - [Updating Stacks](./production-stack-update.md)
  - [Self Hosted Assistant](./self-hosted-assistant.md)
- - [Expert Application Building Access](./expert-application-building-access.md)
+ - [Expert Agentic Application Building Access](./expert-agentic-application-building-access.md)
  
 
 ## CI/CD


### PR DESCRIPTION
## Summary

Adds a handbook page documenting how to triage inbound contact submissions for the FlowFuse Expert Application Building soft launch (FF 2.30, agentic Node-RED development).

Forks the info ask by Identify outcome (not found, found-free-tier, found-paid-tier) so the paid tier note always lands in the first reply, and gates eligibility on use case + reason being on file.

Links the new page from \`engineering/ops/index.md\`.