### PR TITLE
handbook: move signature procedures to Operations section

### DIFF
--- a/src/handbook/operations/signatures.md
+++ b/src/handbook/operations/signatures.md
@@ -1,0 +1,18 @@
+---
+navTitle: Signatures
+---
+
+# Signatures
+
+FlowFuse uses Hubspot for generating quotes, and requesting the signatures on
+them. For other legal documents we're using
+[Google eSignatures](https://support.google.com/docs/answer/12315692?hl=en).
+
+## Signature Circulation Requirements
+
+Before requesting a signature on any document, the following must be in place and
+communicated.
+
+1. Context: What is the document being signed, and why are we signing this agreement? What does it support?
+2. Confirm all required signatures upfront — both internal and counterparty.
+3. The document must be fully filled out before circulation. No placeholder text (e.g., [INSERT DESCRIPTION]) or incomplete fields should remain.

--- a/src/handbook/sales/legal.md
+++ b/src/handbook/sales/legal.md
@@ -7,18 +7,7 @@ navGroup: Customer Department
 
 ## Collecting Signatures
 
-FlowFuse uses Hubspot for generating quotes, and requesting the signatures on
-them. For other legal documents we're using
-[Google eSignatures](https://support.google.com/docs/answer/12315692?hl=en).
-
-### Signature Circulation Requirements
-
-Before requesting a signature on any document, the following must be in place and
-communicated.
-
-1. Context: What is the document being signed, and why are we signing this agreement? What does it support?
-2. Confirm all required signatures upfront — both internal and counterparty.
-3. The document must be fully filled out before circulation. No placeholder text (e.g., [INSERT DESCRIPTION]) or incomplete fields should remain.
+See the [Signatures](/handbook/operations/signatures/) page in Operations for procedures on collecting signatures and circulation requirements.
 
 ## Subscription agreement
 


### PR DESCRIPTION
Extracts the signature collection content from the Sales/Legal page into a dedicated Operations/Signatures page, and replaces it with a cross-link.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

