### PR TITLE
Removed a step from the dependabot PR order

### DIFF
--- a/src/handbook/engineering/dependency-updates.md
+++ b/src/handbook/engineering/dependency-updates.md
@@ -18,11 +18,10 @@ The triage rotation is owned by the engineering team. One engineer takes the slo
 
 Work through Dependabot PRs in this order:
 
-1. **Wait at least 12 hours after a version is published before merging.** Compromised or broken releases are usually flagged within that window. Merging immediately after publish removes that safety margin.
-2. **Check for an active npm advisory or breach report on the package.** Look at the package's npm page and the GitHub advisory database before approving. If anything is open against that version, hold the PR until it clears.
-3. **Read the release notes for each bump.** Confirm there are no breaking changes that affect how we use the package. Patch and minor bumps still occasionally ship behavior changes worth knowing about.
-4. **Merge the safe, small bumps first.** Patch and minor updates with a contained diff and clean release notes go in early. Leave anything with an unusually large diff for closer review.
-5. **CI must pass before merging — no exceptions.** A red build on a dependency PR is the signal that something needs investigation, not a bypass.
+1. **Check for an active npm advisory or breach report on the package.** Look at the package's npm page and the GitHub advisory database before approving. If anything is open against that version, hold the PR until it clears.
+2. **Read the release notes for each bump.** Confirm there are no breaking changes that affect how we use the package. Patch and minor bumps still occasionally ship behavior changes worth knowing about.
+3. **Merge the safe, small bumps first.** Patch and minor updates with a contained diff and clean release notes go in early. Leave anything with an unusually large diff for closer review.
+4. **CI must pass before merging — no exceptions.** A red build on a dependency PR is the signal that something needs investigation, not a bypass.
 
 ## Major version bumps
 


### PR DESCRIPTION
## Description

Removed a step from the dependabot PR order 

## Related Issue(s)

https://github.com/FlowFuse/engineering/issues/43 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

