### PR TITLE
Add sales deck handbook page

### DIFF
--- a/src/handbook/sales/index.md
+++ b/src/handbook/sales/index.md
@@ -38,7 +38,7 @@ Questions can be asked in the [#dept-sales](https://flowfuse.slack.com/archives/
  - [Sales Team Operating Principles](./operating-principles.md)
  - [Forecast Review](./forecast-review.md)
  - [Demo](./meetings/demo.md)
- - [Sales Deck](https://docs.google.com/presentation/d/1xygs4VS6A7sHY8tmx0EoE7eNrlIWHHkHZbMXQ5PhtL0/)
+ - [Sales Deck](./sales-deck.md)
  - [Engagements & Pricing](./engagements.md)
  - [Deal Board](https://app-eu1.hubspot.com/contacts/26586079/objects/0-3/views/all/board)
  - [Sales playbook (internal)](https://docs.google.com/document/d/1Jrt5sNg46wngQ5UAii8sbN94PTlIAscOWrFcOhSVNPE/edit){rel="nofollow"}

--- a/src/handbook/sales/sales-deck.md
+++ b/src/handbook/sales/sales-deck.md
@@ -1,0 +1,27 @@
+---
+navTitle: Sales Deck
+---
+
+# Sales Deck
+
+The [FlowFuse Sales Deck](https://docs.google.com/presentation/d/1xygs4VS6A7sHY8tmx0EoE7eNrlIWHHkHZbMXQ5PhtL0/) is the primary presentation used to introduce FlowFuse to prospects. It establishes the problem we solve, who we solve it for, and why FlowFuse — before moving into a product demo.
+
+## When to Use It
+
+Use it in **intro and discovery calls** — the first or second meeting with a new prospect. It's also appropriate for executive briefings or re-engagement conversations where a high-level overview is more useful than a deep technical walkthrough.
+
+## How to Use It
+
+- **Make a copy before customizing.** Never edit the master deck.
+- Tailor the opening to the prospect's industry or known pain points.
+- Use the slides as a visual anchor, not a script — the goal is dialogue.
+- Close every meeting with a defined next step.
+
+## Stakeholders
+
+| Role | Responsibility |
+|------|----------------|
+| VP of Sales (Michael Davis) | Owns the deck; approves changes to messaging or structure. |
+| Account Executives | Primary users. Responsible for customizing per engagement. |
+| Marketing | Contributes positioning and competitive messaging. Loop them in before making narrative changes. |
+| CEO | Consulted on major positioning shifts or executive/investor-level use. |


### PR DESCRIPTION
## Summary
- Adds a dedicated `sales-deck.md` page with context on when to use the deck, how to use it, and who the stakeholders are
- Updates the sales index to link to the new page instead of directly to Google Slides

🤖 Generated with [Claude Code](https://claude.com/claude-code)