### PR TITLE
Fix capitalisation: Hubspot → HubSpot throughout handbook

### DIFF
--- a/src/handbook/marketing/customer-stories.md
+++ b/src/handbook/marketing/customer-stories.md
@@ -78,7 +78,7 @@ The date is useful to order the stories in the customer stories index. The newes
 
 Image of the logo to be included in the customer stories index, on top of the image, ideally a png file with transparent background. This is an optional field, if it's covering an important part of the image or if the image already includes a logo, there's no need to add it.
 
-### Hubspot
+### HubSpot
 ##### formId
 
 Download form ID code provided by HubSpot.

--- a/src/handbook/marketing/email.md
+++ b/src/handbook/marketing/email.md
@@ -15,7 +15,7 @@ The following guidelines are meant to document the roles and responsibilities of
 
 The sales team, customer success, and support team will be required to send email to communicate with specific potential customers and customers. These types of email are typically between the FlowFuse employee and an individual customer to accomplish a task or transaction. For instance, handling a support request or further a sales process.
 
-These types of email should be stored in HubSpot using the HubSpot interface or the HubSpot Chrome plugin. The goal should be that all transactional email is associated with the contact in Hubspot to have an history of the interaction.
+These types of email should be stored in HubSpot using the HubSpot interface or the HubSpot Chrome plugin. The goal should be that all transactional email is associated with the contact in HubSpot to have an history of the interaction.
 
 ### Community email 
 

--- a/src/handbook/marketing/lead-activation.md
+++ b/src/handbook/marketing/lead-activation.md
@@ -34,7 +34,7 @@ leads are further categorized into three sub-types based on the strength of the 
 Prospects showing behavioral signals of interest without explicit hand raise.
 
 For example
-- Website visits tracked via intent tools (Hubspot Intent, Warmly)
+- Website visits tracked via intent tools (HubSpot Intent, Warmly)
 - Ad interaction data from platforms like ZenABM
 - Content engagement patterns
 - Product page visits

--- a/src/handbook/marketing/leads.md
+++ b/src/handbook/marketing/leads.md
@@ -10,7 +10,7 @@ For definitions of inbound vs. outbound lead sources and the MQL activation proc
 
 ## Setting up
 
- - Once the content has been finalized, create a PDF version and upload it to Hubspot (Library -> files).
+ - Once the content has been finalized, create a PDF version and upload it to HubSpot (Library -> files).
  - Create a new Form to capture lead information such as name, email, company and title. Add a campaign where relevant. (You can clone an existing form). Set the form submission action to link directly to the PDF or to a thank you page (thank you pages help track conversions in ad campaigns). 
  - Create a Thank you mail which includes the link to the PDf and request to "contact us" for further information/help.
  - Create a workflow to send the email upon form submission and to add the lead to a topic interest group list ([Example](https://app-eu1.hubspot.com/workflows/26586079/platform/flow/1472559590/edit).   

--- a/src/handbook/marketing/programs.md
+++ b/src/handbook/marketing/programs.md
@@ -142,7 +142,7 @@ etc.) Justify why these channels are most appropriate for this campaign
 approximate) Identify what human resources would be needed Specify if external
 tools, services, or vendors are required
 
-**f. Campaigns performance tracking** All campaigns will be trackes using the [Campaigns feature on Hubspot (internal)](https://app-eu1.hubspot.com/marketing/26586079/campaigns/views/all). 
+**f. Campaigns performance tracking** All campaigns will be trackes using the [Campaigns feature on HubSpot (internal)](https://app-eu1.hubspot.com/marketing/26586079/campaigns/views/all). 
 
 **Submission Process**
 

--- a/src/handbook/marketing/webinars.md
+++ b/src/handbook/marketing/webinars.md
@@ -37,8 +37,8 @@ The following are the steps to produce a montly webinar.
         * Under Branding, for the banner add the graphic created for the web site.
         * Under Invitations, invite the speaker as a Panelist.
             - Panelist receive a unique url to join the webinar that grants them access before the webinar starts. It is important the speaker knows to use this url.
-        * Under Email Setting ensure the following: Confirmation email sent to panelist, Reminder sent 1 hour and 1 day before.  Turn off email for follow-up since we do that inside Hubspot.
-        * Under Survey, you can decide if you want to do a survey at the end of the webinar. We ask if someone wants to be contacted by FlowFuse to discuss our services. These become MQLs in Hubspot.
+        * Under Email Setting ensure the following: Confirmation email sent to panelist, Reminder sent 1 hour and 1 day before.  Turn off email for follow-up since we do that inside HubSpot.
+        * Under Survey, you can decide if you want to do a survey at the end of the webinar. We ask if someone wants to be contacted by FlowFuse to discuss our services. These become MQLs in HubSpot.
    1. Setup HubSpot to accept webinar registrations.
         * Create a marketing campaign for the webinar. Name it like this: *‘Webinar [year month keyword]’*, resulting in something like *Webinar 2025 11 Rev Pi* and **add every related asset to it**.
         * Create a new static segment (list) called ‘Webinar Registrations [&lt;month> Edition]
@@ -48,7 +48,7 @@ The following are the steps to produce a montly webinar.
             * Edit ‘Add Contact to Zoom Webinar’ to update the new Webinar ID. Replace the current number with the number from the webinar you just created for this month. You find the Webinar ID on the main page of the Zoom webinar. NOTE: you need to  hyphens to replace the spaces in the ID number.
             * Edit ‘Add to static list’ to change the list to the new list for this month’s webinar.
             * Remember to Save the changes.
-   1. Test the web page for the webinar to see if a new registrant gets added to the Hubspot list.
+   1. Test the web page for the webinar to see if a new registrant gets added to the HubSpot list.
    1. Page is now ready to be published.
    1. Setting up the survey on HubSpot.  
         * Under **Service > Feedback Surveys**, you'll find the latest one called *‘Webinar Survey - [&lt;month> &lt;year>]’*.  
@@ -66,7 +66,7 @@ The following are the steps to produce a montly webinar.
     * LinkedIn, Twitter, Facebook, Node-RED Forum Event category, Redit Node-RED, Node-RED slack. For socials a [promo video](#promo-video) recorded by the speaker is recommended.
     * Encourage FlowFuse employees to promote their network
     * Dedicated email to all in the community outreach list
-* Week 3 (1 week before webinar): Email to Hubspot list (Send to those you didn't open previous week's email and new leads in DB. Exclude registered leads) 
+* Week 3 (1 week before webinar): Email to HubSpot list (Send to those you didn't open previous week's email and new leads in DB. Exclude registered leads) 
     * Typically clone a previous email as the starting point.
 * Week 4: Another social media promotion and email.
     * Typically this is sent 1 day before the webinar as a reminder that its not too late to join.
@@ -111,7 +111,7 @@ And here are a couple of samples of our past promo videos:
     * Trim out the dead air waiting to start the webinar
 * Publish webinar recording
 * Social media post with link to webinar recording
-* In Hubspot send follow-up email to the registration list created in Hubspot that includes a link to the recording on YouTube.
+* In HubSpot send follow-up email to the registration list created in HubSpot that includes a link to the recording on YouTube.
 * Download the attendee list from Zoom and upload it to HubSpot. The filter that captures attendees in HubSpot isn't reliable and might cause non-attendee emails to be sent to actual attendees.
 * For those who wanted to be contacted, change Life Cycle Stage property to MQL 
 

--- a/src/handbook/operations/billing.md
+++ b/src/handbook/operations/billing.md
@@ -4,9 +4,9 @@ navTitle: Billing
 
 # Billing
 
-Subscriptions and their invoices are all stored in Hubspot, and Stripe is used for payment processing for contracted
-revenue. For FlowFuse's montly self-service customers Stripe also tracks the subscription instead of Hubspot.
-Team members will be given a login to the relevant Stripe and Hubspot dashboard as required for
+Subscriptions and their invoices are all stored in HubSpot, and Stripe is used for payment processing for contracted
+revenue. For FlowFuse's montly self-service customers Stripe also tracks the subscription instead of HubSpot.
+Team members will be given a login to the relevant Stripe and HubSpot dashboard as required for
 their role with an appropriate level of access.
 
 ## Providing support
@@ -29,7 +29,7 @@ To generate a subscription, the corresponding deal and quote must first be in pl
 1. Ensure the company details are updated, and include an address and country.
 1. On the Deal page, find the Subscription section on the right-hand side, then click Add and Convert Deal to Subscription.
 1. Change the dates, terms, products, discounts, contact, and company information if required (most will be correct, since it is pulling from the signed quote).
-1. Under Invoice Settings, uncheck the box that automatically emails customers. There will still be an invoice created by Hubspot, but it won't be automatically send to the customer.
+1. Under Invoice Settings, uncheck the box that automatically emails customers. There will still be an invoice created by HubSpot, but it won't be automatically send to the customer.
 2. If additional information is needed on the invoice, you'll void the invoice and follow the steps mentioned under 'creating an invoice'.
 1. Click the Create button on the top right.
 2. If no additional information is needed on the invoice, directly send the automated invoice to the customer.
@@ -45,7 +45,7 @@ To generate a subscription, the corresponding deal and quote must first be in pl
 1. It will prompt to send the invoice automatically to the billing contact you designated, change date of send if needed.
 1. Finalize this manual invoice, then void the automatically created one from the subscription conversion and send an email to accounting.
 1. If you need to void the invoice, send an email with the invoice number and reason to our accounting team through Slack for their administration.
-   - Make sure to void the invoices in all necessary places in Hubspot
+   - Make sure to void the invoices in all necessary places in HubSpot
 
 #### Roles and Responsibilities: CSM vs. Accounting in Accounts Receivable
 
@@ -60,11 +60,11 @@ To generate a subscription, the corresponding deal and quote must first be in pl
 
 ### Creating a PS invoice
 
-For new customers an invoice should be generated in [Hubspot's Invoice section](https://app-eu1.hubspot.com/contacts/26586079/objects/0-53/views/all/list).
+For new customers an invoice should be generated in [HubSpot's Invoice section](https://app-eu1.hubspot.com/contacts/26586079/objects/0-53/views/all/list).
 
 1. Ensure the company details are updated, and include an address and country.
 2. Ensure the customer provided a PO number if they require one.
-3. Create a one-time invoice through Hubspot -- If the customer already is used to paying through Stripe, use best judgement when to switch them over
+3. Create a one-time invoice through HubSpot -- If the customer already is used to paying through Stripe, use best judgement when to switch them over
 
 ## Adding a Coupon
 

--- a/src/handbook/operations/commission-payment.md
+++ b/src/handbook/operations/commission-payment.md
@@ -51,7 +51,7 @@ to your machine.
 
 Make a copy of
 [this Google Sheet template](https://docs.google.com/spreadsheets/d/1fBq4g4W26M3k-uUOg5p4D2mYUyBPP8EbdtPLwuQ5RPI/)
-and import the CSV just downloaded from Hubspot into the "All Deals" sheet.
+and import the CSV just downloaded from HubSpot into the "All Deals" sheet.
 "File" -> "Import" -> "Upload" -> "Replace Current Sheet".
 
 Now "All Deals" have been listed, that adds all the deal closers to the "Team"
@@ -149,7 +149,7 @@ Following the end of each quarter, the Operations team processes CSM commissions
 ### Data Requirements
 The calculation template must include:
 - Company Name & Transaction Amount (ARR Delta).
-- Notice Date: When the customer informed us of the change. Or when we actually closed won the change in Hubspot
+- Notice Date: When the customer informed us of the change. Or when we actually closed won the change in HubSpot
 - Effective Date: When the change actually takes place in the contract.
 
 ### Currency of Payout

--- a/src/handbook/operations/data.md
+++ b/src/handbook/operations/data.md
@@ -9,7 +9,7 @@ At FlowFuse we're trying to leverage data obtained to make better decisions.
 ### Data sources
 
 1. Telemetry from self-managed installations
-2. [Hubspot](https://app-eu1.hubspot.com/reports-dashboard/26586079/view/106501027)
+2. [HubSpot](https://app-eu1.hubspot.com/reports-dashboard/26586079/view/106501027)
 3. Analytics - [Google Analytics](https://analytics.google.com/analytics/web/#/) and [PostHog](https://eu.posthog.com/project/2209)
 
 ### Data visualization

--- a/src/handbook/operations/signatures.md
+++ b/src/handbook/operations/signatures.md
@@ -4,7 +4,7 @@ navTitle: Signatures
 
 # Signatures
 
-FlowFuse uses Hubspot for generating quotes, and requesting the signatures on
+FlowFuse uses HubSpot for generating quotes, and requesting the signatures on
 them. For other legal documents we're using
 [Google eSignatures](https://support.google.com/docs/answer/12315692?hl=en).
 

--- a/src/handbook/sales/commission-plan/index.md
+++ b/src/handbook/sales/commission-plan/index.md
@@ -16,7 +16,7 @@ The purpose of the FlowFuse’s Sales Compensation Plan (“Plan”) is to estab
 
 **“Base Salary”** means the wages paid to a Salesperson each payroll period, regardless of Salesperson’s performance under the Plan.
 
-“**Booked**” means the satisfaction of all of the following conditions:  (1) a written Agreement is executed by a Customer on a Qualifying Sale, (2) the executed Agreement is accepted and approved by the Company, (3) the executed agreement and related quote and PO (if any) are attached to the opportunity in Hubspot.com and (4) the Company has shipped software or delivered services, (5) the “Closing a Deal” process as described in the company handbook has been completed.
+“**Booked**” means the satisfaction of all of the following conditions:  (1) a written Agreement is executed by a Customer on a Qualifying Sale, (2) the executed Agreement is accepted and approved by the Company, (3) the executed agreement and related quote and PO (if any) are attached to the opportunity in HubSpot.com and (4) the Company has shipped software or delivered services, (5) the “Closing a Deal” process as described in the company handbook has been completed.
 
 “**Booking Date**” means the date a sale was Booked.
 

--- a/src/handbook/sales/customer-success.md
+++ b/src/handbook/sales/customer-success.md
@@ -92,7 +92,7 @@ our customers need from us to succeed. the main platforms we use are as follows:
 | ------------------------- | --------------------------------------------------------------------------- |
 | FlowFuse Cloud's Database | Current usage of the platform and uptake of features                        |
 | Stripe                    | Expenditure                                                                 |
-| Hubspot                   | Interaction with support and marketing content on our website and in emails |
+| HubSpot                   | Interaction with support and marketing content on our website and in emails |
 | GitHub                    | Record of upcoming and shipped features                                     |
 
 ### Useful Customer Data
@@ -104,13 +104,13 @@ our customers need from us to succeed. the main platforms we use are as follows:
 
 ### Communication
 
-To deliver automated and manual communication with customers, we use Hubspot
-CRM. Hubspot allows us to collaborate as a team. This is vital when manually
+To deliver automated and manual communication with customers, we use HubSpot
+CRM. HubSpot allows us to collaborate as a team. This is vital when manually
 communicating with customers as well as operating automated email campaigns
 based on a customer's current cohort and interaction with their account.
 
 We have built an integration in Node-RED which can extract data from our
-platforms then append it to a customer's record in Hubspot. The integration as
+platforms then append it to a customer's record in HubSpot. The integration as
 well as any other CS resources built in Node-RED are hosted on FlowFuse Cloud
 and can be
 [accessed in this application](https://main.flowforge.cloud/){rel="nofollow}.
@@ -124,7 +124,7 @@ All team members are asked to identify customer and prospect requests in the fol
 - Customer-specific context (which deal or account the request is tied to) does not go on the public issue. Mention the request on the deal's representative issue inside FlowFuse/product, and if a public issue already exists for the same request, reference that existing one from the deal issue rather than opening a new one. See [Deal Management](./hubspot.md#deal-management). Sales and Product share responsibility for maintaining this link, including for past requests, so any feature request can be traced back to the deals it pertains to.
 
 
-### Hubspot Properties
+### HubSpot Properties
 
 For FlowFuse Cloud customers, we add various useful data to our CRM records to
 help us better understand who each customer is and how they are using FlowFuse.
@@ -132,10 +132,10 @@ They are as follows:
 
 | Field name  | Description | 
 |----------- | ---- |
-| FFC-Tier    | This links each contact on Hubspot to the tier their team is currently associated with. Where a contact is in more than one team with different tiers we will show the tier which is expected to deliver the highest ARR. You can view the current contacts by tier in [this report](https://app-eu1.hubspot.com/reports-list/26586079/182668969/){rel="nofollow"}. |
-| FFC-Actions | This shows actions which have been taken by someone on a team this contact is on. To see a full list of available actions view [this report](https://app-eu1.hubspot.com/reports-list/26586079/182831966/){rel="nofollow"} in Hubspot |                                                                                                                               |
+| FFC-Tier    | This links each contact on HubSpot to the tier their team is currently associated with. Where a contact is in more than one team with different tiers we will show the tier which is expected to deliver the highest ARR. You can view the current contacts by tier in [this report](https://app-eu1.hubspot.com/reports-list/26586079/182668969/){rel="nofollow"}. |
+| FFC-Actions | This shows actions which have been taken by someone on a team this contact is on. To see a full list of available actions view [this report](https://app-eu1.hubspot.com/reports-list/26586079/182831966/){rel="nofollow"} in HubSpot |                                                                                                                               |
 | FFC-Usage | This field shows a contact's answer to how they are planning to use FlowFuse Cloud, you can view the options and current data on [this report](https://app-eu1.hubspot.com/reports-list/26586079/182851924/){rel="nofollow"}.|
-| FFC-Events (deprecated) | This legacy field showed email campaigns which had been triggered to be sent to each contact. For example, after 24 hours if a user had not used out snapshots feature the integration between FlowFuse Cloud and Hubspot would add the relevant tag to this user. Hubspot would in turn send the email to the contact. This way of working is being replaced by FFC-Actions as that field can triggered email campaigns based on action or inaction as well as adding value to our CRM. |
+| FFC-Events (deprecated) | This legacy field showed email campaigns which had been triggered to be sent to each contact. For example, after 24 hours if a user had not used out snapshots feature the integration between FlowFuse Cloud and HubSpot would add the relevant tag to this user. HubSpot would in turn send the email to the contact. This way of working is being replaced by FFC-Actions as that field can triggered email campaigns based on action or inaction as well as adding value to our CRM. |
 
 ## Inbound Support
 
@@ -171,13 +171,13 @@ Whenever a customer raises a new ticket, a message is posted into slack
 
 This will allow the whole team visibility of a new ticket, to reply to a ticket
 we need to use the Help
-[Desk UI in Hubspot](https://app-eu1.hubspot.com/help-desk/26586079/view/233410279/list-view).
+[Desk UI in HubSpot](https://app-eu1.hubspot.com/help-desk/26586079/view/233410279/list-view).
 Once you reply to a ticket (if nobody in our team has already replied) you will
 be assigned as a ticket owner. Once you are a ticket owner you will get alerts
-via the Hubspot Slack app each time a customer replies. You are the only person
+via the HubSpot Slack app each time a customer replies. You are the only person
 who gets these alerts so it's important you deal with them in a timely manner.
 You can assign the ticket to someone you feel is a more appropriate owner using
-the Hubspot interface in the top right corner of the help desk. You may want to
+the HubSpot interface in the top right corner of the help desk. You may want to
 assign a ticket to a team member if you are out of office due to holidays, time
 zones etc so that the customer continues to get the support they need.
 
@@ -301,10 +301,10 @@ when an annually-billed customer chooses not to renew their subscription:
    [CS Customer tracking](https://docs.google.com/spreadsheets/d/1n99ROi49GHdmHjYivbwGlKYH28Qh-x0QZUrxiO9ppHg/edit?gid=0#gid=0)
    and move the churned customer to the "Churned" tab. Add the churn date and the reason for churning. 
 
-2. **Cancel Subscription in Hubspot** Cancel the subscription on their account page in Hubspot, to ensure no further invoices are
+2. **Cancel Subscription in HubSpot** Cancel the subscription on their account page in HubSpot, to ensure no further invoices are
    sent.
    
-3. **Close Opportunities in Hubspot** In Hubspot, locate any open Growth and
+3. **Close Opportunities in HubSpot** In HubSpot, locate any open Growth and
    Renewal opportunities related to the churned customer. Move these
    opportunities to "Closed Lost" to reflect the customer's decision not to
    renew.

--- a/src/handbook/sales/engagements.md
+++ b/src/handbook/sales/engagements.md
@@ -102,7 +102,7 @@ as evidenced by a PO or signed quote, is the sole determinant.
    - Verify the Deal amount is set correctly based on Deal Type:
      - New Business: ACV (Annual Contract Value)
      - Expansions/Renewals: Incremental ARR
-   - On the Hubspot Deal view, check and update:
+   - On the HubSpot Deal view, check and update:
      - Hosting Environment
      - Contract Start Date
      - Company address
@@ -150,7 +150,7 @@ as evidenced by a PO or signed quote, is the sole determinant.
      - Generate a [license key](../sales/meetings/poc.md#generating-a-license)
      - Send the license key with the onboarding email to the customer, following
        this
-       [Hubspot Template](https://app-eu1.hubspot.com/templates/26586079/edit/135404737?q=welco&page=1).
+       [HubSpot Template](https://app-eu1.hubspot.com/templates/26586079/edit/135404737?q=welco&page=1).
 1. If Professional Services are included, inform the PS team of deal.
 1. Add customer to onboarding stage in the CSM tracking document.
 1. Move the deal to `Closed Won` stage.

--- a/src/handbook/sales/hubspot.md
+++ b/src/handbook/sales/hubspot.md
@@ -1,5 +1,5 @@
 ---
-navTitle: Hubspot
+navTitle: HubSpot
 ---
 
 We use [HubSpot](https://www.hubspot.com/) to track and manage all of our customer interactions.
@@ -19,7 +19,7 @@ It is up to the contact owner to ensure their contacts have the appropriate life
 
 | Stage Name | Lifecycle Stage | Owner | Deal Stage | Deal Probability | Requirements for this Stage | Supporting Materials | KPIs |
 | :---- | :---: | :---: | :---: | :---: | :---- | :---- | :---- |
-| Subscriber | Subscriber | Marketing | N/A | 0% | <ul><li>Email known in Hubspot</li><li> Aware of FlowFuse</li></ul> | N/A | <ul><li> Total contacts in Database </li><li>Social Media Company Followers</li></ul> |
+| Subscriber | Subscriber | Marketing | N/A | 0% | <ul><li>Email known in HubSpot</li><li> Aware of FlowFuse</li></ul> | N/A | <ul><li> Total contacts in Database </li><li>Social Media Company Followers</li></ul> |
 | Lead | Lead | Marketing | N/A | 0% | <ul><li>Demonstrated interested in FlowFuse</li><li>Started trial on FlowFuse Cloud OR filled another form on the marketing website</li></ul> | N/A | N/A | # new leads |
 | Marketing Qualified Lead | MQL | Sales | N/A | 0% | <ul><li>Requested a quote or trial license through the website</li><li>Is a business user on FlowFuse Cloud</li><li>Requested to be contacted via a website or other marketing activity</li><li>Confirmation for First Meeting</li><li>Technical Fit and Pain is very probable</li></ul><br>See [Lead Activation](/handbook/marketing/lead-activation/) for inbound vs. outbound definitions. | <ul><li>Lead Scoring</li><li>Sequences & Templates</li></ul> | # new MQLs |
 | Sales Qualified Lead | SQL | Sales | N/A | 0% | <ul><li>SPICED Discovery done</li><li>Customer Pain Identified</li><li>Confirmed Critical Event</li><li>Timeline PoC and Purchase known</li><li>Stakeholders Identified</li></ul> | <ul><li>Intro meeting Deck</li><li>Customer Success Stories</li></ul> | # New SQLs & # First Meetings Occurred |

--- a/src/handbook/sales/meetings/discovery.md
+++ b/src/handbook/sales/meetings/discovery.md
@@ -5,7 +5,7 @@ navTitle: Discovery Meeting
 The goal of the discovery call is to get to know the prospective client and the
 problem that FlowFuse may be able to help them.
 
-FlowFuse will use the "Discovery Call Playbook" in Hubspot, [Learn how to use
+FlowFuse will use the "Discovery Call Playbook" in HubSpot, [Learn how to use
 playbooks](https://knowledge.hubspot.com/playbooks/use-playbooks#use-playbooks-in-contact-company-deal-ticket-or-custom-crm-records).
 
 The next step depends on the outcome of the call, but usually results in a more technical discussion, product demonstration, or sending relevant content to follow-up on at an appropriate time in the future.


### PR DESCRIPTION
## Summary

- Corrects capitalisation of HubSpot (was `Hubspot`) across all handbook pages.

## Test plan
- [ ] Confirm `grep -r "Hubspot" src/handbook/` returns no results

🤖 Generated with [Claude Code](https://claude.com/claude-code)