### PR TITLE
Fix grammar, word-choice, and capitalisation errors in handbook

### DIFF
--- a/src/handbook/engineering/contributing/certified-nodes.md
+++ b/src/handbook/engineering/contributing/certified-nodes.md
@@ -36,6 +36,6 @@ Licensed Self Hosting customers can request acces to the Certified Nodes registr
 2. Open the editor and locate the function node in the `Authentication` tab
 3. The comments at the top of the tab explain how to generate a token using the customer name and a randomly generated password (recomend using the `pwgen` command to create random password)
 4. Add the username, password and token (as comment) to the `tokens` object in the function node
-5. Provide the token to the customer to add in the `Admin Settings` -> `Flowfuse Nodes` section in their Forge instance
+5. Provide the token to the customer to add in the `Admin Settings` -> `FlowFuse Nodes` section in their Forge instance
 
 ![screen shot of Admin Settings page where token is entered](../images/ff-cert-nodes-token.png)

--- a/src/handbook/engineering/frontend/testing.md
+++ b/src/handbook/engineering/frontend/testing.md
@@ -8,7 +8,7 @@ meta:
 For our front-end we test on two fronts:
 
 - [Unit Tests](#unit-tests) - Focusses on individual functional testing. Each function should be tested in complete isolation
-- [E2E Integration Tests](#e2e-integration-tests) - Driven by automated testing framework, [Cypress](https://www.cypress.io/), this tests our front-end in it's entirety, including button clicks, navigations and API calls.
+- [E2E Integration Tests](#e2e-integration-tests) - Driven by automated testing framework, [Cypress](https://www.cypress.io/), this tests our front-end in its entirety, including button clicks, navigations and API calls.
 
 ## Unit Tests
 

--- a/src/handbook/engineering/index.md
+++ b/src/handbook/engineering/index.md
@@ -30,7 +30,7 @@ The product function defines what we build and why.
 
 - [Security Policy](./security.md)
 - [Packaging](./packaging.md) - how we manage repos and npm packaging
-- [Contributing](./contributing) - tips & details on how to setup a local development environment.
+- [Contributing](./contributing) - tips & details on how to set up a local development environment.
 - [Dependency Updates](./dependency-updates.md) - how we triage Dependabot PRs each week
 - [Project Management](./project-management.md) - details the processes we use to guide product development.
 - [Tools](./tools.md) - the tools we use

--- a/src/handbook/engineering/ops/dedicated.md
+++ b/src/handbook/engineering/ops/dedicated.md
@@ -18,7 +18,7 @@ In order to create the dedicated instance, some information will be required fro
    - The core platform (`app.`), broker (`mqtt.`) and hosted instances will be made available under this domain.
    - The base domain, `<customer>.flowfuse.io`, will redirect to `app.<customer>.flowfuse.io`
    - All traffic to the domain will be on port 443 - including the Device Agent MQTT connection
-   - If the customer requests to use their own (sub-)domain, they will need to setup their DNS to point
+   - If the customer requests to use their own (sub-)domain, they will need to set up their DNS to point
      at the AWS Route53 end-point once it has been created.
  - **Choice of AWS region**. We default to `eu-west-1` but customers may want to choose one more
    local to them. Not all AWS regions are equal and we may need to review their choice for suitability.
@@ -41,7 +41,7 @@ This checklist covers the follow items:
 
 1. Create a new AWS sub-account for each dedicated env.
 2. Create user accounts for the ops team
-2. Use Terraform to setup initial cluster
+2. Use Terraform to set up initial cluster
 3. Setup grafana monitoring - including all the necessary alerting
 4. Setup initial admin account - store details in 1Password
 5. Setup initial Stacks, Instance Types and Team Types

--- a/src/handbook/engineering/support/troubleshooting.md
+++ b/src/handbook/engineering/support/troubleshooting.md
@@ -66,7 +66,7 @@ You should also, always ask, the reasons for wanting to delete the account. Unde
 
 When debugging FlowFuse Dashboard issues a very useful tool is the `_debug` view which is served up with every FlowFuse Dashboard. You can read more about it in the [FlowFuse Dashboard documentation](https://dashboard.flowfuse.com/contributing/widgets/debugging).
 
-Any bugs found for FlowFuse Dashboard should be logged as as an issue in the [FlowFuse Dashboard repository](https://github.com/FlowFuse/node-red-dashboard/issues).
+Any bugs found for FlowFuse Dashboard should be logged as an issue in the [FlowFuse Dashboard repository](https://github.com/FlowFuse/node-red-dashboard/issues).
 
 ### Pricing
 #### 2025 Pricing & Tier Changes

--- a/src/handbook/index.md
+++ b/src/handbook/index.md
@@ -38,7 +38,7 @@ shared in this handbook.
 
 The handbook is maintained on [GitHub](https://github.com/FlowFuse/website/tree/main/src/handbook)
 and contributions can be made through pull-requests. How to contribute
-is capture [in a guide](https://github.com/FlowFuse/website#flowfuse-website).
+is captured [in a guide](https://github.com/FlowFuse/website#flowfuse-website).
 
 The handbook is here for the whole company to help maintain. **Pull-requests are welcome and strongly encouraged**.
 
@@ -52,7 +52,7 @@ Instead of starting a discussion on Slack or in a meeting, we start it in the ha
 
 * Start with a Proposal, not a Chat: When you have an idea for a new process, a change to an existing one, or a solution to a problem, you don't send a message on Slack. You create a proposal directly in the handbook. This proposal is a merge request that includes your suggested changes, allowing everyone to see and comment on the content directly. This ensures the full context of a discussion is preserved and universally accessible.
 * Integrate Discussion and Documentation: The discussion about your proposal happens right there in the merge request. Team members can provide feedback, ask questions, and suggest edits. This allows us to disagree and commit in a transparent way. Once a consensus is reached or a decision is made, the final version is merged into the handbook, and the entire discussion trail is saved for future reference.
-* Empower Everyone to Contribute: This system allows anyone at Flowfuse—from a new hire to a senior leader—to contribute directly to our company's culture and processes. It generates a shared responsibility to maintain the pace of documentation through a pay-it-forward mentality. The history of every change is visible, showing how learning happens and how iteration shapes proposals.
+* Empower Everyone to Contribute: This system allows anyone at FlowFuse—from a new hire to a senior leader—to contribute directly to our company's culture and processes. It generates a shared responsibility to maintain the pace of documentation through a pay-it-forward mentality. The history of every change is visible, showing how learning happens and how iteration shapes proposals.
 * Eliminate Wasted Effort: By making the handbook the hub of our collaborative work, we ensure that the information we need is always where it should be. This prevents us from having to document something after the fact—a step that is often skipped—and avoids the "torturous pattern of people pinging people for updates". This is how we prioritize results and stay focused on what matters.
 
 

--- a/src/handbook/marketing/email.md
+++ b/src/handbook/marketing/email.md
@@ -15,7 +15,7 @@ The following guidelines are meant to document the roles and responsibilities of
 
 The sales team, customer success, and support team will be required to send email to communicate with specific potential customers and customers. These types of email are typically between the FlowFuse employee and an individual customer to accomplish a task or transaction. For instance, handling a support request or further a sales process.
 
-These types of email should be stored in HubSpot using the HubSpot interface or the HubSpot Chrome plugin. The goal should be that all transactional email is associated with the contact in Hubspot to have an history of the interaction.
+These types of email should be stored in HubSpot using the HubSpot interface or the HubSpot Chrome plugin. The goal should be that all transactional email is associated with the contact in Hubspot to have a history of the interaction.
 
 ### Community email 
 

--- a/src/handbook/marketing/webinars.md
+++ b/src/handbook/marketing/webinars.md
@@ -25,7 +25,7 @@ The following are the steps to produce a montly webinar.
             - If the speaker is unable to commit to this timeline, or does not meet the deadline, the session should be rescheduled for the following month. In that case, an internal webinar should be planned instead.
         * A recording of a [promo video](#promo-video), linking to the referred handbook section for details on format and script.
             - Set the deadline to two weeks before the session.
-        * Slides for the presentation using [our template](/handbook/design/branding/#presentations). Create a copy and and save it in the corresponding folder before sharing it with the speaker.
+        * Slides for the presentation using [our template](/handbook/design/branding/#presentations). Create a copy and save it in the corresponding folder before sharing it with the speaker.
             - Set the deadline to the week before the session so it can be reviewed during the dry run.
         * A list of channels where they could support the event promotion, this would lead to a conversation about joint promotion.
    1. When there's a demo involved, provide the speaker with a non-trial FlowFuse account so they can work on it with an official account

--- a/src/handbook/peopleops/hiring/index.md
+++ b/src/handbook/peopleops/hiring/index.md
@@ -289,6 +289,6 @@ After announcing the departure in Slack, the manager will create a new offboardi
 The template maintained on GitHub, create a new issue though [this link](https://github.com/FlowFuse/admin/issues/new/choose).
 
 Final pay consists of the statutory minimal payment dictated by our payroll provider Deel, and an optional extra severance package.
-Such a package might be dependent on on business requirements, standing of the employee, among other factors.
+Such a package might be dependent on business requirements, standing of the employee, among other factors.
 
 The company will reimburse any outstanding expenses that comply with [our handbook](/handbook/peopleops/expenses/#reimbursement)

--- a/src/handbook/peopleops/organization.md
+++ b/src/handbook/peopleops/organization.md
@@ -8,7 +8,7 @@ All employees at FlowFuse will find PeopleOps policies in this section of the ha
 
 ## Grievance Procedure
 
-We're all about making FlowFuse an great place to work for everyone. However, if you ever run into any concerns while you're here, these guidelines are here to help you out in raising a grievance. 
+We're all about making FlowFuse a great place to work for everyone. However, if you ever run into any concerns while you're here, these guidelines are here to help you out in raising a grievance. 
 
 This procedure applies to all employees and contractors regardless of length of service. It does not apply to ad-hoc freelancers.
 
@@ -88,7 +88,7 @@ contribute effectively to the organization.
 Either the manager or the employee in questions can identify underperformance.
 Identification is always discussed in the first 1:1 meeting between the manager
 and employee.
-The manager is tasked with with addressing the underperformance, and may
+The manager is tasked with addressing the underperformance, and may
 formulate a plan to remedy the situation. All plans cover at most the next
 four weeks.
 

--- a/src/handbook/sales/hubspot.md
+++ b/src/handbook/sales/hubspot.md
@@ -8,7 +8,7 @@ It enables the creation of customer contacts, and then logging of emails/notes a
 ## Contact Management
 
 Given that we have multiple client-facing roles within FlowFuse, it's important to document those that
-we talk to to ensure no crossover in sales and conversations.
+we talk to ensure no crossover in sales and conversations.
 
 ### Lifecycle Stage
 

--- a/src/handbook/sales/partnerships.md
+++ b/src/handbook/sales/partnerships.md
@@ -12,7 +12,7 @@ For reseller partnerships, please refer to our [Reseller Agreement](https://docs
 
 ## Partnership Requirements
 
-FlowFuse also continues to build it's partner channel by working with strategic System Integrators.
+FlowFuse also continues to build its partner channel by working with strategic System Integrators.
 
 When there's interest in becoming a partner FlowFuse requires a project to colaborate on jointly.
 Implementation projects structure the partnership and learning on both sides.


### PR DESCRIPTION
## Summary

Fixes 15 grammar and word-choice errors across 10 handbook files:

**Double words removed:** `to to`, `on on`, `as as`, `and and`, `with with`
**`it's` → `its`** (possessive) in two places
**`an` → `a`** before consonant sounds in two places
**`setup` → `set up`** (verb form) in three places
**Missing past participle:** `is capture` → `is captured`
**`Flowfuse` → `FlowFuse`** capitalisation in two prose instances

## Test plan
- [ ] Spot-check the changed files to confirm fixes read naturally in context

🤖 Generated with [Claude Code](https://claude.com/claude-code)