### PR TITLE
Fix spelling errors across handbook

### DIFF
--- a/src/handbook/company/guides/git.md
+++ b/src/handbook/company/guides/git.md
@@ -25,7 +25,7 @@ If you've been asked to do a new piece of work, this is the quick bullet list of
 6. You can do multiple commits and pushes to iterate on your work. It will all be saved to your branch
 7. When ready for review, open a Pull Request
 8. Assign someone else as a reviewer, they may offer feedback
-9. The reviewer, when happy, will aprove and merge the Pull request
+9. The reviewer, when happy, will approve and merge the Pull request
 10. Once your PR is merged, be sure to switch back to the `main` branch again
 
 ### Modifying an Existing Contribution
@@ -39,8 +39,8 @@ If another person has opened a Pull Request or branch already, and asked you to 
 5. You can do multiple commits and pushes to iterate on your work. It will all be saved to your branch & PR.
 6. Check with the original PR owner as to whether you're reviewing the PR, or if someone else has been assigned
 7. Reviewer submits their feedback, if any.
-8. The reviewer, when happy, will aprove and merge the Pull request
-10. Once you have finished your contirubtions, you can switch back to the `main` branch
+8. The reviewer, when happy, will approve and merge the Pull request
+10. Once you have finished your contributions, you can switch back to the `main` branch
 
 ### Completing a Pull Request Review
 
@@ -48,7 +48,7 @@ You may be asked to conduct a Pull Request Review. This means that someone else 
 
 1. Switch to their branch on your machine (if request to append to the Pull Request, that will have a branch associated to.)
 2. Run the code (e.g. website server or FlowFuse platform) and ensure their changes work as expected.
-3. "Add your Review" on GitHub, offer comments and recommendatins where required.
+3. "Add your Review" on GitHub, offer comments and recommendations where required.
 4. Once you're happy, "Approve" the Pull Request
 5. Merge the PR
 6. Ensure you have switched back to the `main` branch locally before continuing any other work.

--- a/src/handbook/company/guides/markdown.md
+++ b/src/handbook/company/guides/markdown.md
@@ -58,7 +58,7 @@ from the previous paragraph.
 2. this is another item in the list
 ```
 
-To prevent reordering and keeping count, Markdown allows you to use non-sequencial numbers:
+To prevent reordering and keeping count, Markdown allows you to use non-sequential numbers:
 
 ```
 1. Item one
@@ -117,7 +117,7 @@ For `inline` quoting, use single backticks:
 For `inline` quoting, use single backticks.
 ```
 
-For block quotes, use tripple backticks:
+For block quotes, use triple backticks:
 
 ```
 this will write the content as if it is code

--- a/src/handbook/company/security/access-control.md
+++ b/src/handbook/company/security/access-control.md
@@ -86,7 +86,7 @@ Enforce industry best practices for passwords and configure systems to support t
 - Do not reuse passwords across different systems.
 - Store passwords only in the company-provided password vault, 1Password.
 
-## Programmaticaly Accessible Resources
+## Programmatically Accessible Resources
 
 When programmatic access to resources is required, the following guidelines must
 be followed:

--- a/src/handbook/company/security/data-management.md
+++ b/src/handbook/company/security/data-management.md
@@ -74,7 +74,7 @@ Disclosure requires the signing of NDA and management approval.
  - Non-production security data
  - Incident reports - prior to publication
 
-**Internal** data contains information used for day-to-day interal operations of
+**Internal** data contains information used for day-to-day internal operations of
 the company.
 
 Unauthorized disclosure may cause undesirable outcomes to business operations.
@@ -108,7 +108,7 @@ outside of FlowFuse.
  - Backups encrypted and secured
  - Retained for as long as operationally, contractually or legally required
  - Only accessible to privileged users
- - Never transfered to entites outside of the company
+ - Never transferred to entities outside of the company
 
 ### Confidential
 

--- a/src/handbook/company/security/operations-security.md
+++ b/src/handbook/company/security/operations-security.md
@@ -74,7 +74,7 @@ periodically tested, not less than annually.
 Backups must be stored separately from the production data location.
 
 FlowFuse does not regularly backup user devices like laptops. Users are expected to
-store critical files and information in the commpany-provided Google Drive with
+store critical files and information in the company-provided Google Drive with
 appropriate access controls applied.
 
 ## Logging & Monitoring

--- a/src/handbook/design/art-requests.md
+++ b/src/handbook/design/art-requests.md
@@ -32,7 +32,7 @@ When creating an issue, you'll be presented with an option to create an "Art Req
 Please be sure to include as much detail as possible, but most importantly:
 
 - **Type**: What type of asset is this? Blog Tile? YouTube Thumbnail?
-- **Format**: Image (e.g. `.png`, `.jpg`), Video (e.g. `mp4`), Animation (e.g. `.gif` or Lottie Animtion)
+- **Format**: Image (e.g. `.png`, `.jpg`), Video (e.g. `mp4`), Animation (e.g. `.gif` or Lottie Animation)
 - **Deadline**: This is defined on the right-side of the issue under the "Art Requests" project, once the issue has been created.
 - **Milestone**: If this is a Product request, please add the Development Project and assign the relevant release milestone, otherwise, this is not required.
 

--- a/src/handbook/engineering/contributing/certified-nodes.md
+++ b/src/handbook/engineering/contributing/certified-nodes.md
@@ -30,11 +30,11 @@ Full details on the technical process are provided in the [certified-nr-nodes](h
 
 ## Generating Tokens for Access to Certified Nodes Registry
 
-Licensed Self Hosting customers can request acces to the Certified Nodes registry via support. These are the steps to generate a token for them
+Licensed Self Hosting customers can request access to the Certified Nodes registry via support. These are the steps to generate a token for them
 
 1. On FlowFuse Cloud in the FlowFuse Team, locate the `ff-certified-nodes` instance in the `Internal Tools` Application
 2. Open the editor and locate the function node in the `Authentication` tab
-3. The comments at the top of the tab explain how to generate a token using the customer name and a randomly generated password (recomend using the `pwgen` command to create random password)
+3. The comments at the top of the tab explain how to generate a token using the customer name and a randomly generated password (recommend using the `pwgen` command to create random password)
 4. Add the username, password and token (as comment) to the `tokens` object in the function node
 5. Provide the token to the customer to add in the `Admin Settings` -> `Flowfuse Nodes` section in their Forge instance
 

--- a/src/handbook/engineering/contributing/index.md
+++ b/src/handbook/engineering/contributing/index.md
@@ -14,7 +14,7 @@ All code repositories adopt our standard linting rules found in the [flowforge/.
 
 We use [StandardJS](https://standardjs.com/), with one exception - 4 spaces not 2.
 
-If you're using VSCode, then we recommend using the [ESLint extenstion](https://github.com/Microsoft/vscode-eslint) and setting `all` for the `Eslint › Code Actions On Save: Mode` setting:
+If you're using VSCode, then we recommend using the [ESLint extension](https://github.com/Microsoft/vscode-eslint) and setting `all` for the `Eslint › Code Actions On Save: Mode` setting:
 
 <img width="429" alt="ESLint - Action on Save" src="../../images/eslint_actiononsave.png">
 

--- a/src/handbook/engineering/ops/incident-response.md
+++ b/src/handbook/engineering/ops/incident-response.md
@@ -4,7 +4,7 @@ navTitle: Incident Response
 
 # Incident Response
 
-When an issue is identified that impacts the availablity of any part of the production platform,
+When an issue is identified that impacts the availability of any part of the production platform,
 it is vital we are able to respond effectively, resolve the issue and ensure lessons are learnt
 to prevent it happening again.
 
@@ -43,7 +43,7 @@ The issue should remain open until all actions are complete.
 
 Depending on the nature of the incident, we may choose to publish a blog post with details
 for our customers. This should be our default response, however we may decide some incidents
-are sufficiently localised to not warrent a full write-up.
+are sufficiently localised to not warrant a full write-up.
 
 The blog post should explain the incident in an accessible way - we want to be open with
 our customers. This should include links to any relevant follow-up actions to demonstrate

--- a/src/handbook/marketing/webinars.md
+++ b/src/handbook/marketing/webinars.md
@@ -7,7 +7,7 @@ navGroup: Sales & Marketing
 
 FlowFuse organizes monthly webinars on topics about Node-RED, FlowFuse and the general IoT industry. The topics are typically educational and technical in content. The goal is to become the source of great content for learning about these topics.
 
-The FlowFuse webinar is typically scheduled during the last week of the month, but be mindfull of trade-shows and company in-person events, as webinars should not be scheduled during those weeks.
+The FlowFuse webinar is typically scheduled during the last week of the month, but be mindful of trade-shows and company in-person events, as webinars should not be scheduled during those weeks.
 
 The webinar typically starts at 17:00CET or 11amET, to allow for European and Pacific coast of North America attendees.  All webinars are recorded and the recording is made available on the FlowFuse Youtube channel.
 

--- a/src/handbook/sales/engagements.md
+++ b/src/handbook/sales/engagements.md
@@ -60,7 +60,7 @@ Follow these steps to create a quote.
    [the instructions](/handbook/sales/engagements/#what-to-quote)
    - Select the appropriate Plan that is being quoted
    - For each line item, except Professional Services, check the Billing
-     frequence to `Annual` and if the terms *_ensure automatic renewal_
+     frequency to `Annual` and if the terms *_ensure automatic renewal_
    - Adjust fields for Term and discount/fee/tax as needed.
    - Add Add-on line items for purchases that exceed features that are included
      with the Plan.

--- a/src/handbook/sales/partnerships.md
+++ b/src/handbook/sales/partnerships.md
@@ -14,7 +14,7 @@ For reseller partnerships, please refer to our [Reseller Agreement](https://docs
 
 FlowFuse also continues to build it's partner channel by working with strategic System Integrators.
 
-When there's interest in becoming a partner FlowFuse requires a project to colaborate on jointly.
+When there's interest in becoming a partner FlowFuse requires a project to collaborate on jointly.
 Implementation projects structure the partnership and learning on both sides.
 
 Please [contact us](https://flowfuse.com/partners/) to discuss and complete an agreement.


### PR DESCRIPTION
## Summary

Fixes 19 confirmed spelling errors across 11 handbook files:

- `aprove` → `approve` (×2), `contirubtions` → `contributions`, `recommendatins` → `recommendations` (`company/guides/git.md`)
- `sequencial` → `sequential`, `tripple` → `triple` (`company/guides/markdown.md`)
- `Programmaticaly` → `Programmatically` (`company/security/access-control.md`)
- `interal` → `internal`, `transfered` → `transferred`, `entites` → `entities` (`company/security/data-management.md`)
- `commpany` → `company` (`company/security/operations-security.md`)
- `acces` → `access`, `recomend` → `recommend` (`engineering/contributing/certified-nodes.md`)
- `extenstion` → `extension` (`engineering/contributing/index.md`)
- `availablity` → `availability`, `warrent` → `warrant` (`engineering/ops/incident-response.md`)
- `colaborate` → `collaborate` (`sales/partnerships.md`)
- `mindfull` → `mindful` (`marketing/webinars.md`)
- `Animtion` → `Animation` (`design/art-requests.md`)
- `frequence` → `frequency` (`sales/engagements.md`)

## Test plan
- [ ] Spot-check a few of the corrected files to confirm fixes look right in context

🤖 Generated with [Claude Code](https://claude.com/claude-code)