### PR TITLE
fix: resolve pre-existing Trivy CVEs in npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1190,27 +1190,33 @@
             }
         },
         "node_modules/@clack/core": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.2.0.tgz",
-            "integrity": "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.3.1.tgz",
+            "integrity": "sha512-fT1qHVGAag4IEkrupZ6lRRbNCs1vS9P01KB/sG8zKgvUztbYtFBtQpjSITNwooDZ83tpsPzP0mRNs1/KVszCRA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "fast-wrap-ansi": "^0.1.3",
+                "fast-wrap-ansi": "^0.2.0",
                 "sisteransi": "^1.0.5"
+            },
+            "engines": {
+                "node": ">= 20.12.0"
             }
         },
         "node_modules/@clack/prompts": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.2.0.tgz",
-            "integrity": "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.4.0.tgz",
+            "integrity": "sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@clack/core": "1.2.0",
-                "fast-string-width": "^1.1.0",
-                "fast-wrap-ansi": "^0.1.3",
+                "@clack/core": "1.3.1",
+                "fast-string-width": "^3.0.2",
+                "fast-wrap-ansi": "^0.2.0",
                 "sisteransi": "^1.0.5"
+            },
+            "engines": {
+                "node": ">= 20.12.0"
             }
         },
         "node_modules/@cloudflare/kv-asset-handler": {
@@ -2263,14 +2269,14 @@
             }
         },
         "node_modules/@nuxt/cli": {
-            "version": "3.35.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/cli/-/cli-3.35.1.tgz",
-            "integrity": "sha512-nX9XO+e3l9pnhHL2zsbnBmQb/nsOQYhGz2XiqE8X962QN9ufc1ZSuDZoTmQVv/ymkbYNR6hpNWW8RZQhuhzadw==",
+            "version": "3.35.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/cli/-/cli-3.35.2.tgz",
+            "integrity": "sha512-sCxNnFuYamqippdj+Cj4Nue55yaUvasaneyf2mnowK5/F1TKln/WVqTH18McxQ4baLlIlVapIFovKjJx1L8XMQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@bomb.sh/tab": "^0.0.14",
-                "@clack/prompts": "^1.2.0",
+                "@bomb.sh/tab": "^0.0.15",
+                "@clack/prompts": "^1.3.0",
                 "c12": "^3.3.4",
                 "citty": "^0.2.2",
                 "confbox": "^0.2.4",
@@ -2281,21 +2287,21 @@
                 "fuse.js": "^7.3.0",
                 "fzf": "^0.5.2",
                 "giget": "^3.2.0",
-                "jiti": "^2.6.1",
-                "listhen": "^1.9.1",
+                "jiti": "^2.7.0",
+                "listhen": "^1.10.0",
                 "nypm": "^0.6.6",
                 "ofetch": "^1.5.1",
                 "ohash": "^2.0.11",
                 "pathe": "^2.0.3",
                 "perfect-debounce": "^2.1.0",
-                "pkg-types": "^2.3.0",
+                "pkg-types": "^2.3.1",
                 "scule": "^1.3.0",
-                "semver": "^7.7.4",
+                "semver": "^7.8.0",
                 "srvx": "^0.11.15",
                 "std-env": "^4.1.0",
                 "tinyclip": "^0.1.12",
-                "tinyexec": "^1.1.1",
-                "ufo": "^1.6.3",
+                "tinyexec": "^1.1.2",
+                "ufo": "^1.6.4",
                 "youch": "^4.1.1"
             },
             "bin": {
@@ -2308,7 +2314,7 @@
                 "node": "^16.14.0 || >=18.0.0"
             },
             "peerDependencies": {
-                "@nuxt/schema": "^4.4.2"
+                "@nuxt/schema": "^4.4.5"
             },
             "peerDependenciesMeta": {
                 "@nuxt/schema": {
@@ -2317,9 +2323,9 @@
             }
         },
         "node_modules/@nuxt/cli/node_modules/@bomb.sh/tab": {
-            "version": "0.0.14",
-            "resolved": "https://registry.npmjs.org/@bomb.sh/tab/-/tab-0.0.14.tgz",
-            "integrity": "sha512-cHMk2LI430MVoX1unTt9oK1iZzQS4CYDz97MSxKLNErW69T43Z2QLFTpdS/3jVOIKrIADWfuxQ+nQNJkNV7E4w==",
+            "version": "0.0.15",
+            "resolved": "https://registry.npmjs.org/@bomb.sh/tab/-/tab-0.0.15.tgz",
+            "integrity": "sha512-Y90ub44TAvbdO9P8mcD/XPyQjFhiR5xmd4Fk7JErmWmEWEUimNnjWiBrVZ16Tj3GA1rLZ+uvCN2V/pzLawv31g==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -2480,9 +2486,9 @@
             }
         },
         "node_modules/@nuxt/kit": {
-            "version": "4.4.4",
-            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.4.4.tgz",
-            "integrity": "sha512-oy4fAeMkyz7gelnalDQLPm8QZRN+c5c/Eh/M6oFgPx86jnA8m6xeOlONpJN2dk0GhcJwJYuN/kmzBffZ93WXPQ==",
+            "version": "4.4.6",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.4.6.tgz",
+            "integrity": "sha512-AzsqBJeG7b3whIciyzkz4nBossEotM314KzKAptc8kH07ORBIR8Qh3QYKepo2YZwtxiDP2Y9aqzAztwpSEDHtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2493,7 +2499,7 @@
                 "errx": "^0.1.0",
                 "exsolve": "^1.0.8",
                 "ignore": "^7.0.5",
-                "jiti": "^2.6.1",
+                "jiti": "^2.7.0",
                 "klona": "^2.0.6",
                 "mlly": "^1.8.2",
                 "ohash": "^2.0.11",
@@ -2501,7 +2507,7 @@
                 "pkg-types": "^2.3.1",
                 "rc9": "^3.0.1",
                 "scule": "^1.3.0",
-                "semver": "^7.7.4",
+                "semver": "^7.8.0",
                 "tinyglobby": "^0.2.16",
                 "ufo": "^1.6.4",
                 "unctx": "^2.5.0",
@@ -2540,9 +2546,9 @@
             }
         },
         "node_modules/@nuxt/kit/node_modules/jiti": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-            "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+            "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -2580,21 +2586,20 @@
             }
         },
         "node_modules/@nuxt/nitro-server": {
-            "version": "4.4.4",
-            "resolved": "https://registry.npmjs.org/@nuxt/nitro-server/-/nitro-server-4.4.4.tgz",
-            "integrity": "sha512-jMZPf+vJ2/IF5TZc+c/1c6O6p94pklVLvrexCu9FYZFK3H9oqYUlzBfYRd2kL5tdRTkIOpxTjfcgB1oc62UOhw==",
+            "version": "4.4.6",
+            "resolved": "https://registry.npmjs.org/@nuxt/nitro-server/-/nitro-server-4.4.6.tgz",
+            "integrity": "sha512-3OgAWW8cK+0BgEWiGYv9wP/vfQcIWTs+YNmZZAf1f89py8KnHgHp2aFQjZ/zTXWKTHlkGPl9NntQQkMoF3j1fA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/plugin-syntax-typescript": "^7.28.6",
                 "@nuxt/devalue": "^2.0.2",
-                "@nuxt/kit": "4.4.4",
-                "@unhead/vue": "^2.1.13",
-                "@vue/shared": "^3.5.33",
+                "@nuxt/kit": "4.4.6",
+                "@unhead/vue": "^2.1.15",
+                "@vue/shared": "^3.5.34",
                 "consola": "^3.4.2",
                 "defu": "^6.1.7",
                 "destr": "^2.0.5",
-                "devalue": "^5.7.1",
+                "devalue": "^5.8.1",
                 "errx": "^0.1.0",
                 "escape-string-regexp": "^5.0.0",
                 "exsolve": "^1.0.8",
@@ -2611,20 +2616,24 @@
                 "ufo": "^1.6.4",
                 "unctx": "^2.5.0",
                 "unstorage": "^1.17.5",
-                "vue": "^3.5.33",
+                "vue": "^3.5.34",
                 "vue-bundle-renderer": "^2.2.0",
                 "vue-devtools-stub": "^0.1.0"
             },
             "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+                "node": "^22.12.0 || ^24.11.0 || >=26.0.0"
             },
             "peerDependencies": {
                 "@babel/plugin-proposal-decorators": "^7.25.0",
+                "@babel/plugin-syntax-typescript": "^7.25.0",
                 "@rollup/plugin-babel": "^6.0.0 || ^7.0.0",
-                "nuxt": "^4.4.4"
+                "nuxt": "^4.4.6"
             },
             "peerDependenciesMeta": {
                 "@babel/plugin-proposal-decorators": {
+                    "optional": true
+                },
+                "@babel/plugin-syntax-typescript": {
                     "optional": true
                 },
                 "@rollup/plugin-babel": {
@@ -2785,9 +2794,9 @@
             }
         },
         "node_modules/@nuxt/nitro-server/node_modules/postcss": {
-            "version": "8.5.14",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+            "version": "8.5.15",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
             "dev": true,
             "funding": [
                 {
@@ -2805,7 +2814,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.12",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -2836,13 +2845,13 @@
             }
         },
         "node_modules/@nuxt/schema": {
-            "version": "4.4.4",
-            "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-4.4.4.tgz",
-            "integrity": "sha512-X70+lDZ4Wtp38l18/zFlKOZO5fd0uWQ60nrr1gxTNua8sqOxqVeZpLWTBmor7lFfJsXPPclsaFjcstyXYqXgpg==",
+            "version": "4.4.6",
+            "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-4.4.6.tgz",
+            "integrity": "sha512-7FDMuD+skbFMgfF2ORYKEAKEuEFbu2oS60dln5uVtn94c8DHWCseJSrT3FUHzVUlVwyhztPU6stzB44dEoWAzw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vue/shared": "^3.5.33",
+                "@vue/shared": "^3.5.34",
                 "defu": "^6.1.7",
                 "pathe": "^2.0.3",
                 "pkg-types": "^2.3.1",
@@ -2890,24 +2899,24 @@
             "license": "MIT"
         },
         "node_modules/@nuxt/vite-builder": {
-            "version": "4.4.4",
-            "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-4.4.4.tgz",
-            "integrity": "sha512-SNyxEYVeTo3d26tt5rxS550VOFLyXx1UBqhZJexWhk42HgHa3d115LWZx+4e+FJf75SYZ1B/KTrkVeeOhfNBMw==",
+            "version": "4.4.6",
+            "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-4.4.6.tgz",
+            "integrity": "sha512-q/JDHLy/tBJodyqu75GBrFWcOkkj9alGH8Qh/Wpir/xD6/MAMvnQNOHewC3KH40jMHxdETSglEmFaAkEIHzmLQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@nuxt/kit": "4.4.4",
+                "@nuxt/kit": "4.4.6",
                 "@rollup/plugin-replace": "^6.0.3",
-                "@vitejs/plugin-vue": "^6.0.6",
+                "@vitejs/plugin-vue": "^6.0.7",
                 "@vitejs/plugin-vue-jsx": "^5.1.5",
                 "autoprefixer": "^10.5.0",
                 "consola": "^3.4.2",
-                "cssnano": "^7.1.7",
+                "cssnano": "^8.0.1",
                 "defu": "^6.1.7",
                 "escape-string-regexp": "^5.0.0",
                 "exsolve": "^1.0.8",
                 "get-port-please": "^3.2.0",
-                "jiti": "^2.6.1",
+                "jiti": "^2.7.0",
                 "knitwork": "^1.3.0",
                 "magic-string": "^0.30.21",
                 "mlly": "^1.8.2",
@@ -2915,23 +2924,23 @@
                 "nypm": "^0.6.6",
                 "pathe": "^2.0.3",
                 "pkg-types": "^2.3.1",
-                "postcss": "^8.5.12",
-                "seroval": "^1.5.2",
+                "postcss": "^8.5.14",
+                "seroval": "^1.5.4",
                 "std-env": "^4.1.0",
                 "ufo": "^1.6.4",
                 "unenv": "^2.0.0-rc.24",
-                "vite": "^7.3.2",
+                "vite": "^7.3.3",
                 "vite-node": "^5.3.0",
                 "vite-plugin-checker": "^0.13.0",
                 "vue-bundle-renderer": "^2.2.0"
             },
             "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+                "node": "^22.12.0 || ^24.11.0 || >=26.0.0"
             },
             "peerDependencies": {
                 "@babel/plugin-proposal-decorators": "^7.25.0",
                 "@babel/plugin-syntax-jsx": "^7.25.0",
-                "nuxt": "4.4.4",
+                "nuxt": "4.4.6",
                 "rolldown": "^1.0.0-beta.38",
                 "rollup-plugin-visualizer": "^6.0.0 || ^7.0.1",
                 "vue": "^3.3.4"
@@ -3039,82 +3048,81 @@
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/cssnano": {
-            "version": "7.1.9",
-            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.1.9.tgz",
-            "integrity": "sha512-uPR75+5Dk/WJ/YSPR1/YDHdwMM9c5FsaARljfKWgeCKLKOtJ0we21xy/RcCjn53fZnD/f6yYEIZ8pu18+GnbNQ==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-8.0.1.tgz",
+            "integrity": "sha512-oSiOnPQNNYjusTUlYJiE6xvFQG4don3N0QavaoV1BxIsC1zjvxOwikXlR7lG1EVmZNDDaJkHbQx1VRB8kaoMHA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "cssnano-preset-default": "^7.0.17",
+                "cssnano-preset-default": "^8.0.1",
                 "lilconfig": "^3.1.3"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/cssnano"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/cssnano-preset-default": {
-            "version": "7.0.17",
-            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.17.tgz",
-            "integrity": "sha512-11qO63A+czwguQFJCaTdICvbaxn0pJzz/XghLlv+OT7WyToDxAMR0Xb3/26/l0y0hQJywwNbj/SLSQlGBHE1OA==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-8.0.1.tgz",
+            "integrity": "sha512-OTdKeYMlvQ8KBgyej5ysktnWJoeyo7rGrVnm+bdpIHGvxhbTGPsOkB+7T1EdTuX00dGlQQb2UEbSPB1OpMXULw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "browserslist": "^4.28.2",
-                "css-declaration-sorter": "^7.2.0",
-                "cssnano-utils": "^5.0.3",
+                "cssnano-utils": "^6.0.0",
                 "postcss-calc": "^10.1.1",
-                "postcss-colormin": "^7.0.10",
-                "postcss-convert-values": "^7.0.12",
-                "postcss-discard-comments": "^7.0.8",
-                "postcss-discard-duplicates": "^7.0.4",
-                "postcss-discard-empty": "^7.0.3",
-                "postcss-discard-overridden": "^7.0.3",
-                "postcss-merge-longhand": "^7.0.7",
-                "postcss-merge-rules": "^7.0.11",
-                "postcss-minify-font-values": "^7.0.3",
-                "postcss-minify-gradients": "^7.0.5",
-                "postcss-minify-params": "^7.0.9",
-                "postcss-minify-selectors": "^7.1.2",
-                "postcss-normalize-charset": "^7.0.3",
-                "postcss-normalize-display-values": "^7.0.3",
-                "postcss-normalize-positions": "^7.0.4",
-                "postcss-normalize-repeat-style": "^7.0.4",
-                "postcss-normalize-string": "^7.0.3",
-                "postcss-normalize-timing-functions": "^7.0.3",
-                "postcss-normalize-unicode": "^7.0.9",
-                "postcss-normalize-url": "^7.0.3",
-                "postcss-normalize-whitespace": "^7.0.3",
-                "postcss-ordered-values": "^7.0.4",
-                "postcss-reduce-initial": "^7.0.9",
-                "postcss-reduce-transforms": "^7.0.3",
-                "postcss-svgo": "^7.1.3",
-                "postcss-unique-selectors": "^7.0.7"
+                "postcss-colormin": "^8.0.0",
+                "postcss-convert-values": "^8.0.0",
+                "postcss-discard-comments": "^8.0.0",
+                "postcss-discard-duplicates": "^8.0.0",
+                "postcss-discard-empty": "^8.0.0",
+                "postcss-discard-overridden": "^8.0.0",
+                "postcss-merge-longhand": "^8.0.0",
+                "postcss-merge-rules": "^8.0.0",
+                "postcss-minify-font-values": "^8.0.0",
+                "postcss-minify-gradients": "^8.0.0",
+                "postcss-minify-params": "^8.0.0",
+                "postcss-minify-selectors": "^8.0.1",
+                "postcss-normalize-charset": "^8.0.0",
+                "postcss-normalize-display-values": "^8.0.0",
+                "postcss-normalize-positions": "^8.0.0",
+                "postcss-normalize-repeat-style": "^8.0.0",
+                "postcss-normalize-string": "^8.0.0",
+                "postcss-normalize-timing-functions": "^8.0.0",
+                "postcss-normalize-unicode": "^8.0.0",
+                "postcss-normalize-url": "^8.0.0",
+                "postcss-normalize-whitespace": "^8.0.0",
+                "postcss-ordered-values": "^8.0.0",
+                "postcss-reduce-initial": "^8.0.0",
+                "postcss-reduce-transforms": "^8.0.0",
+                "postcss-svgo": "^8.0.0",
+                "postcss-unique-selectors": "^8.0.0"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/cssnano-utils": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-5.0.3.tgz",
-            "integrity": "sha512-ynIREMICLxkxm7e9bCR9sh75s4Q5drICi0ua1yxo5jH2XPBqSKkl4dOh4EbFqtUmnTMhRffHgYL0EKKkMjtJTg==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-6.0.0.tgz",
+            "integrity": "sha512-ztS9W/+uaDn+bkYmDhs+GdMveHJ3CL8IPNHpRqDUQXv5GJOTQAJjV1XUOInr9esLXSabQV1pLRZlJpyUwEqDyQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/fraction.js": {
@@ -3198,9 +3206,9 @@
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss": {
-            "version": "8.5.14",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+            "version": "8.5.15",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
             "dev": true,
             "funding": [
                 {
@@ -3218,7 +3226,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.12",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -3227,9 +3235,9 @@
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-colormin": {
-            "version": "7.0.10",
-            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.10.tgz",
-            "integrity": "sha512-yFr6JezOolHLta/buLE71VKPh2mXursp4saVe98/ol8ZnEWhL+racShqPKlvd/DKWLre/39B6HhcMXf7RZ3hxg==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-8.0.0.tgz",
+            "integrity": "sha512-KKwMmsSgsmdYXqrjQeqL3tnuIFtctiR1GEMHdjNpDpz/TCRkkkok2mMcreK2zVV3l7POWOmAkR2xYHUpRUK1DA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3239,16 +3247,16 @@
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-convert-values": {
-            "version": "7.0.12",
-            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.12.tgz",
-            "integrity": "sha512-xurKu5qqk4viR3Cp3p4xBR4KfnZm4w4ys6+UBwBmeuBSNkH7+DtLnYOYnOffgtE4yx8sH9S1VZ6RAAvROXzP2Q==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-8.0.0.tgz",
+            "integrity": "sha512-Ohtj3rNZWawTRePv5NCHTy8VJSdJ/G/uKuxcxJreOMichuqcT6uEl2TAnopVeJCJ/c13jaSqg7m63yFLM5zBsA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3256,159 +3264,159 @@
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-discard-comments": {
-            "version": "7.0.8",
-            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.8.tgz",
-            "integrity": "sha512-CvvS5S9WrXblFXCEJ9nVo+4z+eA7zSC7Z88V1HEJuwlQhlFnYTIjg1xJY+BCUiG2bvICap2tXii4mP22BD108Q==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-8.0.0.tgz",
+            "integrity": "sha512-zGpvVLj2sbagEp+BTVETvAfkZdGVA6rALNujDK/WTIjdf1/rQOxOG8BBzkI8UQgnw8SkL6xffAfbtGMHFypadw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "postcss-selector-parser": "^7.1.1"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-discard-duplicates": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-7.0.4.tgz",
-            "integrity": "sha512-VBNn1+EuMZkeGVVtz0gRfbNGtx9IFgAsAV+E2pHtXPrp4qfGBkhTIiAuE/wrb+Y6Pakg9NewAlfTpYIFAWODtw==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-8.0.0.tgz",
+            "integrity": "sha512-zjRyYmNGI3PTipKBBtCgExlmZXQn49KvKoaiNnR2g+iXxeNk7GY5Js2ULtZXPrCYeqjPagrzKIBNcBocvXCR7g==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-discard-empty": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-7.0.3.tgz",
-            "integrity": "sha512-M2pyjQCU+/7cMHVtL6bKTHjv0lZnPLMpicgr67Dlth7AbuV9gjVTtUqaRwn6Pp6BwSDspUzhz8SaUrRykJU5Dw==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-8.0.0.tgz",
+            "integrity": "sha512-kxPJg6EqahbBvm+l7hpYYCtpsv8dlz7Tv6wJXUXZaeuY0WGS61DxfGdZR4uVB/Cx+yi3iOHQVSqpSHKMFaBg6Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-discard-overridden": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-7.0.3.tgz",
-            "integrity": "sha512-aNovXo9UsZuRNLzHJtp13lHIvinDPfiXBPePpXkSjCbgp++iU2FqE+YxvjIsg6EdyPZsASFbfu+JcBFVsErXIQ==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-8.0.0.tgz",
+            "integrity": "sha512-sW2OWH3l9p0FmBSVr228uztFseqroZxwgD7SGF0Ks0dRPDttSo3P8FK5ZBLtWBH2A5+chpB0J2fB/T8heKHLBw==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-merge-longhand": {
-            "version": "7.0.7",
-            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.7.tgz",
-            "integrity": "sha512-b3mfYUxR388u5Pt0HPcVIUtUDn/k15UfTY9M+ORW+meCR6JLNxoZffiYvXyOYQoRYQNZyX/UFkMCM/mNHxe1qA==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-8.0.0.tgz",
+            "integrity": "sha512-YDmAmQ8H+ljfomVpSXvr9NA0GP01fraQJqjWBYoMVGg6rOT+PJLwPyeVo2ekn4WB4ZVSH5ddtK3DTRxbz6CFzg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0",
-                "stylehacks": "^7.0.11"
+                "stylehacks": "^8.0.0"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-merge-rules": {
-            "version": "7.0.11",
-            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.11.tgz",
-            "integrity": "sha512-SJUPM18g2BmPhf8BVlbwqWz4aK3pLu6u6xjfwEzra7xL6IBR10sUaiB++EzqcVfadPHrKBSMlNdP+XieykhI+Q==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-8.0.0.tgz",
+            "integrity": "sha512-bgstL5mpi41dDpnYGDUcI3M814NWkCMcIWpwDqEHXkHg3BT7b4XRAfNEuwJncZOVn/67kVKvWzhfv/7xyrp2uQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "browserslist": "^4.28.2",
                 "caniuse-api": "^3.0.0",
-                "cssnano-utils": "^5.0.3",
+                "cssnano-utils": "^6.0.0",
                 "postcss-selector-parser": "^7.1.1"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-minify-font-values": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-7.0.3.tgz",
-            "integrity": "sha512-yilG/VOaNI74IylQvAQQxm3/wZVBkXyYUqNUAdxqwtbWUXPsbK1q8Ms0mL83v+f8YicgcyfYCRZtWACUdYajpA==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-8.0.0.tgz",
+            "integrity": "sha512-EnOHQEnSt6oH5NrL1DMFAQuwB2IOimFXTCzc9bKfUeH1jREbqIF5MAK4gQJQOC4mPUwJt4sWifAmNZ1qLu6j3Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-minify-gradients": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-7.0.5.tgz",
-            "integrity": "sha512-YraROyQRg3BI1+Hg8E05B/JPdnTm8EDSVu4P2BxdM+CRiOyfmou809+chGIqo6fQqwjPGQ947nbGncSjmTU1WQ==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-8.0.0.tgz",
+            "integrity": "sha512-43iAnYIGk0ZjNx5X/rkIcHi6dhmu/vEjY0kqfUfxPuJRO+V7jx8uKIdcnL0dpfNoC5J9TSh3EtzLWbq0gpqnWA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@colordx/core": "^5.4.3",
-                "cssnano-utils": "^5.0.3",
+                "cssnano-utils": "^6.0.0",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-minify-params": {
-            "version": "7.0.9",
-            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.9.tgz",
-            "integrity": "sha512-R8itbB8BhlpoYyBm1ou0dD+vJnQ3F6adQipR4UnkCHUwlo+S9WXJaDRg1RHjC8YVAtIdrQzSWvJl40HnGDTKjA==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-8.0.0.tgz",
+            "integrity": "sha512-z7w4QO7G55l4vMUK1Lmx03GW7iyRLgf2V5Dz/7ioSPLnXRjeD+b7m0XfAXUGrbBYYrJ6bXPk+3LoX5u4JfAcSg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "browserslist": "^4.28.2",
-                "cssnano-utils": "^5.0.3",
+                "cssnano-utils": "^6.0.0",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-minify-selectors": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.1.2.tgz",
-            "integrity": "sha512-aQtrEWKwqafNlExcKHQvPGsXR2+vlUqqJtf5XsCQcgsSb5PL4wlujWBYDJuWsP4UnQX1YHDHU8qRlD+1PzTQ+Q==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-8.0.1.tgz",
+            "integrity": "sha512-c31D46811kTkQDxV1KTTow79axX6gj/01AY5G7cGZg3s31KvAwP13jEFXGAzQbJ7NvOFV1pRqEia6nrAdHU7qg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3418,109 +3426,109 @@
                 "postcss-selector-parser": "^7.1.1"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-normalize-charset": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-7.0.3.tgz",
-            "integrity": "sha512-NoBfZu8PR4c2NlmjvrqQTzCzLY79hwcSRgNQ3ZiNK0ABzf9kYKloE/jNj+/8GQY1wsm8pRRgANk6ydLH8cwo0Q==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-8.0.0.tgz",
+            "integrity": "sha512-s88FUNDSUD8m0wBYvTQQcubVts6zhXwBU8zCD4vkRKiecd0v8cOjHVIF9r/i+5xzS/WG3f98qq4XsOM0JqvfLA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-normalize-display-values": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-7.0.3.tgz",
-            "integrity": "sha512-ldsCX0QIt05pKIOobZtVQ48wXJecr+czw4+e1/YjVhLMqslShgpVxgPtI2CefURR8oyVoYaU/l829MMwExDMLw==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-8.0.0.tgz",
+            "integrity": "sha512-gG2nBxD27fiw6Luinb1QYKdM/Co5GornRJgSD+JTwNH4PGKxImP0qyruDDav49aHUPLY3qrL3qN3LvybO7IzxQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-normalize-positions": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-7.0.4.tgz",
-            "integrity": "sha512-VEvlpeGd3Ju1Hqa/oN4jaP3+ms4laYwkEL9N9u+B6k54PZjXbW1n6wI+aVprf1BQXlCYpS5+1pl/7/vHiKgARg==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-8.0.0.tgz",
+            "integrity": "sha512-t/wGqpehS20Ke7kc4QAsWpH+AJjUdMK/V5qV2RhrXkj8hO/fT1t1MJ8NL7sedWYk7ZqC7eISEJQonW5j0tU1MQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-normalize-repeat-style": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-7.0.4.tgz",
-            "integrity": "sha512-6mPKlY/8cSaDHxX502wERADarJsccwlky6yIrOapHH2ZgfoKAV94SbiTKfKEs4EEpdazuc3J72WsqeYk7hp9+Q==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-8.0.0.tgz",
+            "integrity": "sha512-3ebOmGdCYKrBYyGKc1xhj0unEnW7beZpVU7JohVeGl7mTxR+7T6egpaawTWAVsB0pEIhcsbJVOjPKCJSoRO6Zg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-normalize-string": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-7.0.3.tgz",
-            "integrity": "sha512-HnEQPUchi1eznmDKEYrKUTqrprEq97SrpUYClgUkv7V2zRODD9DFoUsYU+m9ZOetmD5ku7fEMZB/lwy8IT6xVQ==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-8.0.0.tgz",
+            "integrity": "sha512-TvWCGZ/e04Tv31uJvOUtbexkfgUnqmQ3M2P5DkAaVzvOj+BvTkG2QjpA5Y71SL1SPxJcj4M23fNh+RDVCmG8kA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-normalize-timing-functions": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-7.0.3.tgz",
-            "integrity": "sha512-zmEzHdvpZBZu0OKlbJSfgASQvaayyAoVuWtvyr34IJ/LyS+DaOKvvR3EvFJ9RWWtNIx+CMvO125OVophaxNYew==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-8.0.0.tgz",
+            "integrity": "sha512-uEfaXst5Xgqxv7geYUuz6vs9mn88K2NPY2RoIzM3BMmSjsdTSeppV9x2qIgrxsisdbSqF6IVhzI2occcte3hTA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-normalize-unicode": {
-            "version": "7.0.9",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.9.tgz",
-            "integrity": "sha512-DRAdWfeh/TjmhLJsw91vdiWCnUod9iwvM7xyS02/nF/sLsCR3A8l3pztrSUrWG8DSBqfX7yEk9FM0USaVJ2mSg==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-8.0.0.tgz",
+            "integrity": "sha512-+WYngZaChEeTHZmWhmKtnJ4gTzWdINEaFcgWBnu6WdVu8Ftim8OBTcw768DuCC/3Aax9bZ9WkwrLGHym2Lzf+A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3528,65 +3536,65 @@
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-normalize-url": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-7.0.3.tgz",
-            "integrity": "sha512-CL93wmloq5qsffmFv+bw24MIRbmhHrp53qoh1LDAb/5TtjWEXI/np4xcP/Gw9oWCb2XyWnqHYLDUwiKRoJBA1Q==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-8.0.0.tgz",
+            "integrity": "sha512-4Mz9hZHn/QIB+YtFqTXrDmE2193GYxGb3F8uMfLvMicaEXCCUlDIJ658gFFJbqEGl9FYzwPtRiuNgbwlO9kkBg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-normalize-whitespace": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-7.0.3.tgz",
-            "integrity": "sha512-FdHjjn+Ht5Z2ZRjNOmeCbNq6lq09sUYKpmlF/Aq0XjVNSLTL6fmHlA/3swN2wP2caY9GV/tjSDcIIyS7aN7W0A==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-8.0.0.tgz",
+            "integrity": "sha512-V1f8tYnwIP5tscOXQFTKK8Y5EJ+R2GMpFJ6FjzwoKoQnhbqQy3IeSrDjJJb8JjVos8ut6Osi80Zybpayv/XjIQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-ordered-values": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-7.0.4.tgz",
-            "integrity": "sha512-nubSi49hDHQk4E8KIj+IbLY8Bg+8OcSUEhgyolgM+atnOvXjV7EjaR6bac4YGZoFyPa9mWoAF3EaYbWdFkKqVg==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-8.0.0.tgz",
+            "integrity": "sha512-Dg9+itb6lmD0bxqhQyHCtXAwYRh0wUrx6Mp4/BNXgkLoJmdYMmWi+V+Pypw79Q6iQhxA8KFMHqLBITQJV2gKMA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "cssnano-utils": "^5.0.3",
+                "cssnano-utils": "^6.0.0",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-reduce-initial": {
-            "version": "7.0.9",
-            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.9.tgz",
-            "integrity": "sha512-ztTNPdIxXTxtBcG03E9u8v44M4ElXbMIRT7pf2onlquGula0Y83nKKxqM22FA/hMgkfCjN7ohevkVlaNwI8iOQ==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-8.0.0.tgz",
+            "integrity": "sha512-DChcE9d528AKrlpCTHjhsAiOsWCk4H9ApHPS1QqRT3praObWTiWyn6W1UddGpc46K9LQnHwUu4YwaPUukGtXVA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3594,26 +3602,26 @@
                 "caniuse-api": "^3.0.0"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-reduce-transforms": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-7.0.3.tgz",
-            "integrity": "sha512-FXsnN9ZwcZTT8Yf8cAHA8qIGUXcX6WfLd9JoYhrdDfmvsVhhfqkkv7m4AC3rwFOfz+GzkUa87OCKF9dUcicd+g==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-8.0.0.tgz",
+            "integrity": "sha512-cLZT0som7vvumQT9XQCnSKOSnRinNQZd1Hm+J723Ney13E8CIydDhw6JwzsjPtgnYThTqn9Q45906gz6wxaAsw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-selector-parser": {
@@ -3631,9 +3639,9 @@
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-svgo": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-7.1.3.tgz",
-            "integrity": "sha512-2QfoFOYMcj8lwcVEf9WeTlkVIAm7u2QvOEhMzkQU3KUhhGX/l8hVV9EtjMv4iq3E9iI3OeeMN0YoMLbGusuigw==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-8.0.0.tgz",
+            "integrity": "sha512-Q2fMSYEiNE1ioDc/3sxvI24NdgA/MJno2XLNpOxgv8aCcJbym8mZY10/lDY5+AWCIc3Aiqzy2Wcp9/zaIXBZgQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3641,26 +3649,26 @@
                 "svgo": "^4.0.1"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >= 18"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/postcss-unique-selectors": {
-            "version": "7.0.7",
-            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.7.tgz",
-            "integrity": "sha512-d+sCkaRnSefghOUdH8CMJZV9yUQhj2ojpe8Nw/lA+LV1UOfeleGkLTl6XdCFFSai9UJ+DJPb69FFuqthXYsY8w==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-8.0.0.tgz",
+            "integrity": "sha512-iObuolUX+ITJfMU2QQFQdh31JgSjNLPNjVs6YGAqBHvOvAWXMMNget6donQl83aQaeS32i5XeKZURUW/WBxIUw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "postcss-selector-parser": "^7.1.1"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/readdirp": {
@@ -3678,9 +3686,9 @@
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/stylehacks": {
-            "version": "7.0.11",
-            "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.11.tgz",
-            "integrity": "sha512-iODNfhXVLqc5LADs+Y6Oh5wJuK5ZcHbVng8aiK3y9pjMQdc5hLrBW0eFU6FtnpNrE6PoEg/MmFTU4waotj5WNg==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-8.0.0.tgz",
+            "integrity": "sha512-sWyjaJvBqHoVKYPbQ8JRvrGSPaYWtWrJsU+fGVtwKB1GE1rRPu3rC7T6UCuXLoL00Dwb+tsHe2T904r8Vnsx8w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3688,10 +3696,10 @@
                 "postcss-selector-parser": "^7.1.1"
             },
             "engines": {
-                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+                "node": "^22.11.0 || ^24.11.0 || >=26.0"
             },
             "peerDependencies": {
-                "postcss": "^8.5.13"
+                "postcss": "^8.5.14"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/update-browserslist-db": {
@@ -4027,9 +4035,9 @@
             }
         },
         "node_modules/@oxc-minify/binding-android-arm-eabi": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm-eabi/-/binding-android-arm-eabi-0.128.0.tgz",
-            "integrity": "sha512-EwdDhZLRmXxSnfy0v9gdOru7TutM8ItRg1Xv8e2B4boWMnHlFCIH38JfwgQnenbkF8SVTwVJtDCkmwEzN4q3xA==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm-eabi/-/binding-android-arm-eabi-0.131.0.tgz",
+            "integrity": "sha512-yLa7y9jjJgUeUUMm6AtjmBIQzK1YU5sYcNJnVVtr6WtoWu5SpuNDZ8u6cl/dhn0g/oQgVlf+E+8WJfsExt8R+Q==",
             "cpu": [
                 "arm"
             ],
@@ -4044,9 +4052,9 @@
             }
         },
         "node_modules/@oxc-minify/binding-android-arm64": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm64/-/binding-android-arm64-0.128.0.tgz",
-            "integrity": "sha512-kwJ8YxWTzty8hD36jXxKiB+Po/ecmHZvT1xAYklkATbr0A4NUqV32sV+3Wfm8TecdA6jX34/mc+4CKK2+Hha2Q==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm64/-/binding-android-arm64-0.131.0.tgz",
+            "integrity": "sha512-ShZDYFEVd46qCc9L0D3ZTPLXe/DezTedEj7g6x1Bdlm1WwgQ1pQJgWkqpMGlQhUet5wq4WUpQB/P6afK470Ydg==",
             "cpu": [
                 "arm64"
             ],
@@ -4061,9 +4069,9 @@
             }
         },
         "node_modules/@oxc-minify/binding-darwin-arm64": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-arm64/-/binding-darwin-arm64-0.128.0.tgz",
-            "integrity": "sha512-WBV8j5EZ7/3rvFbiJ8LxowmobR/XH+l2iRzkE7zRYLD5VC+TvZayYGrVGGDXQvXm6cGED0B1NweByTmeT4lpGQ==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-arm64/-/binding-darwin-arm64-0.131.0.tgz",
+            "integrity": "sha512-h+5iCSKxpK7SJdAHmY4I+0BBxR+pJQVNJvAIB3KcOVyz8/ybaO2r41URCwV1N3FnPYkIIiMokZ24YYMB6/GrRw==",
             "cpu": [
                 "arm64"
             ],
@@ -4078,9 +4086,9 @@
             }
         },
         "node_modules/@oxc-minify/binding-darwin-x64": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-x64/-/binding-darwin-x64-0.128.0.tgz",
-            "integrity": "sha512-U4k1CSBsY1uf6yHE+vCNJp0mHzjsUUXgOZXMyhRN3sE2ovBDT9Gl8oACmLWPjg0R68jwP+1vhnNPsSqpTEOycg==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-x64/-/binding-darwin-x64-0.131.0.tgz",
+            "integrity": "sha512-EIP8KmjqfZeDdhrbG+0GDsiw1/Bi3415uCFokhOm6b8tGG0UdiemVHAz9IQE/sIJgwguXYtg5ydz9oFYVOlOfA==",
             "cpu": [
                 "x64"
             ],
@@ -4095,9 +4103,9 @@
             }
         },
         "node_modules/@oxc-minify/binding-freebsd-x64": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-freebsd-x64/-/binding-freebsd-x64-0.128.0.tgz",
-            "integrity": "sha512-NT1GtcWpX4sOuU5dMdSNpdXJRpk9BGAHHnKc42IUId8E+jEhZUrg9vqIRIlspZG5O9Y7FjO2r6GBK93bpyIIUg==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-freebsd-x64/-/binding-freebsd-x64-0.131.0.tgz",
+            "integrity": "sha512-2/xcCZfVm24sLFHbI5Rg/t6Ec93pth0NvTgy/J8vXjIOy8Yf5kkO/K1KVtdZBHW+cyLPe7YLLybxMF/BeqM8Kg==",
             "cpu": [
                 "x64"
             ],
@@ -4112,9 +4120,9 @@
             }
         },
         "node_modules/@oxc-minify/binding-linux-arm-gnueabihf": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.128.0.tgz",
-            "integrity": "sha512-OskPMYMH2KtkqvRMULF2/+55hFo/qmRz2p/g7Cp7XNiqdjZ/DvQDiVbME63rVoX3dYjgS15DolGbo54mHTyA9w==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.131.0.tgz",
+            "integrity": "sha512-LDQ1Y+QfL5lN54ib1Je2paoh4EsQmmDRvB5Bd9AQIGCP16LI+8jZnB8cjTT3GD1acITDg1aiaBKk9JpBjBA4iw==",
             "cpu": [
                 "arm"
             ],
@@ -4129,9 +4137,9 @@
             }
         },
         "node_modules/@oxc-minify/binding-linux-arm-musleabihf": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.128.0.tgz",
-            "integrity": "sha512-fKUY7Y1vb8CYlGnS5FzqTeeM5zQz1Fleyaqz/T9iNHYAYNJ0Os9iT0rACLfAVCQKP9yOqPSwZ80xgZdVVGD61w==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.131.0.tgz",
+            "integrity": "sha512-mz99O2sZoyHnMoksxlZ5Mc+USS/w/uIp1LWQAn42RHAvVdIyQsqPRmTD/pJtW/KnjgpgaB0yDCpI6Xa3ivJppQ==",
             "cpu": [
                 "arm"
             ],
@@ -4146,13 +4154,16 @@
             }
         },
         "node_modules/@oxc-minify/binding-linux-arm64-gnu": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.128.0.tgz",
-            "integrity": "sha512-T+CQQZ3BoWY/TxQk9LZsXZYj3madR/5tCErV6wzphTYZJfVjvKmQxnxMaT+TKE40Jha6+iGgwzxwcYWJfltULQ==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.131.0.tgz",
+            "integrity": "sha512-QjS1N4FwCV67ZylGyfTWoqURzar48dN5WTq/JVrGsiShFKlT9SpuyRsoUGMGJhiKNiI39MsLIHBlBWvoRQG+ng==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4163,13 +4174,16 @@
             }
         },
         "node_modules/@oxc-minify/binding-linux-arm64-musl": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.128.0.tgz",
-            "integrity": "sha512-F6RkJ90S1Xt25Mk7/wPUmddsE4RZ7Nei+HlEa2FAjfhpoaTciOwV6E/Gtp7wPIYbwft7UfhMYwuEuZiZQytVWw==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.131.0.tgz",
+            "integrity": "sha512-HGzqTov5sAzXyaNfRkQEpl0fRs+PrMYjT8b5jZAw8foQ/qnW+VMWgAr80Q+2j79T5nhXfboSF5SUgB8mcisgHw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4180,13 +4194,16 @@
             }
         },
         "node_modules/@oxc-minify/binding-linux-ppc64-gnu": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.128.0.tgz",
-            "integrity": "sha512-0HP2FBGMlquLjShIIJvS4cebc6sdRRYL04GtxVpg96MtpejrkHYI2gQWcezsTUaGgg+eNRsuv2tdZPENu5+iWA==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.131.0.tgz",
+            "integrity": "sha512-zpUZ4pmbDBqaZmRYacxeLHUBxA3fs5K7hi1WSXRVMXC4OjWuVcLsNxeavenKF9i0YtP7Q5n2z12Rz7eEnNWoDA==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4197,13 +4214,16 @@
             }
         },
         "node_modules/@oxc-minify/binding-linux-riscv64-gnu": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.128.0.tgz",
-            "integrity": "sha512-2j6Bd340IZqZbu4KUI28z87Ao9aHhq56HH1Qz5/+EdE732ajFYIoDF3z+QcxHXY0CFOG/Ur1ZOKTBEIWQ6BYIw==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.131.0.tgz",
+            "integrity": "sha512-CYrC4tpW1wolbw/Fox+T0hxW92s1aG/WLi+htkk02JMiCHOWqGQKxUnm37lLiODKR/OwTYht3LB4xNrsS0RtCg==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4214,13 +4234,16 @@
             }
         },
         "node_modules/@oxc-minify/binding-linux-riscv64-musl": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.128.0.tgz",
-            "integrity": "sha512-z5HSppdxNwB6//3Eo7mDWbTrLeyuTKvL/iLXaKEgocrJg1MhZLbRR7P5ore9gKvS4lF4EtEpA24xzilFxQK0iw==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.131.0.tgz",
+            "integrity": "sha512-ZQNur0zujUjNYgjFF4mcNaeEKWuerY9XkaALYtBsHqNetkj55w0ZwCKYfYKLH2JAdyNF2LuS0s7VGgjXP9EvWA==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4231,13 +4254,16 @@
             }
         },
         "node_modules/@oxc-minify/binding-linux-s390x-gnu": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.128.0.tgz",
-            "integrity": "sha512-9rxYqH7P8NiYqRlLxlnNjJSF8BYADOmihM5ZHVkmlE4tqjHkoLNevdAyAP2ZBkL8QJflm1WGOXFWmFnWA54EvA==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.131.0.tgz",
+            "integrity": "sha512-tR8oiFSNpcS1mfGY1N3/Hy6TxP2wr5X9FFdn/y8GarN8ST/JMLY5SUiwPiU35NKiC69CDaAsLHXoIKUxK/r8Pw==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4248,13 +4274,16 @@
             }
         },
         "node_modules/@oxc-minify/binding-linux-x64-gnu": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.128.0.tgz",
-            "integrity": "sha512-sy5+4Oamw6Ly5gUNUIDQ7346Lryt7AhqjKhOtWl5dzYZnTIwwoI0V2DeIl3bR/vU8D629ZMYQOqhquRtSyBUOA==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.131.0.tgz",
+            "integrity": "sha512-KodzbW12zmT/C/w4bGv2aWN7Q5+KVJKbNoAv5hooYeSujj8xSPGWl8pnyj7dJ9nd8j0CVjubEvHQ86rtzV99OA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4265,13 +4294,16 @@
             }
         },
         "node_modules/@oxc-minify/binding-linux-x64-musl": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-musl/-/binding-linux-x64-musl-0.128.0.tgz",
-            "integrity": "sha512-59Cxvjppy09TsaB15gr6rA9Bf87rm9t0bD1EW9dCZsdxWElnAC+TvWZ7v9dFUIeYeZUkhAAMPtpdqa3Y9CI2zA==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-musl/-/binding-linux-x64-musl-0.131.0.tgz",
+            "integrity": "sha512-CNG3/hPE6MxdLikfLq5l0aZMvJ3W5AP1aoVjzQ1Itokv5sbfBcW0fp6Srn8mB86CyAqO9e7dbffZVOWBDVkhgw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4282,9 +4314,9 @@
             }
         },
         "node_modules/@oxc-minify/binding-openharmony-arm64": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-openharmony-arm64/-/binding-openharmony-arm64-0.128.0.tgz",
-            "integrity": "sha512-XGa03zmiYpD7Kf1aXy6vjgkjfaCR90qH0TzGplnUXo6FF6gNe6sH9Zgneo9kxOyYt8CKKzXYD4VudT/nDTXq8Q==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-openharmony-arm64/-/binding-openharmony-arm64-0.131.0.tgz",
+            "integrity": "sha512-UyfimTwMLitJ0+5i5fL9M9U4E+DcIQJpGZWbVxxD3Mp9f7CTyQBIHnS68VEGZe+KQL/Y3IIb3AJ7cZB+ICgTVQ==",
             "cpu": [
                 "arm64"
             ],
@@ -4299,9 +4331,9 @@
             }
         },
         "node_modules/@oxc-minify/binding-wasm32-wasi": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-wasm32-wasi/-/binding-wasm32-wasi-0.128.0.tgz",
-            "integrity": "sha512-W+fK3cWhu/cUgx3NIAmDYcAyJs01aULlr3E3n/ZN79Q1/CX+FS+yWfwt/IysIi4FhpVL7z58azbJHDzhEx4X4g==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-wasm32-wasi/-/binding-wasm32-wasi-0.131.0.tgz",
+            "integrity": "sha512-fH7sy51iYnmGv2pEPsS9KEVExHDKI1/nfy/OqYnStW2E5di41CQ1qBjVIvxHOMHcPD8RmKEBCf0zng6d9/vGDg==",
             "cpu": [
                 "wasm32"
             ],
@@ -4318,9 +4350,9 @@
             }
         },
         "node_modules/@oxc-minify/binding-win32-arm64-msvc": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.128.0.tgz",
-            "integrity": "sha512-pwMZd27FF+j4tHLYKtu4QBl6KI0gkt6xTNGLffs8VlH5vfDPHUvLo/AS6y66tdEjQ3chhs8OGg1mAFhPoQldDw==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.131.0.tgz",
+            "integrity": "sha512-C05v+5eIdvF4YXQ4t+U0JQDl8IWoIabxsmh4inBSGOL0VziELmis3lb5X6JMj208RbQdKhZGJbUkmNWq2B5Kxw==",
             "cpu": [
                 "arm64"
             ],
@@ -4335,9 +4367,9 @@
             }
         },
         "node_modules/@oxc-minify/binding-win32-ia32-msvc": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.128.0.tgz",
-            "integrity": "sha512-GskPdx/Fsn3ttkJbzxh51LYhla4N4p1sMufJKgf6PHupt5RukBaHI/GKM/2ni6ObxUI0b9UK37fROdV+5ekpMQ==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.131.0.tgz",
+            "integrity": "sha512-bZio0euDmT6Er00I6jng66ftGw5doP/UmCAr2XtBooZMdr7ofTJ4+Bpp+ufguVIeVk5i1vgMPsq7g6FTcxHevg==",
             "cpu": [
                 "ia32"
             ],
@@ -4352,9 +4384,9 @@
             }
         },
         "node_modules/@oxc-minify/binding-win32-x64-msvc": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.128.0.tgz",
-            "integrity": "sha512-m8oakspZCbCod3WuY0U9DvwQlhMYaU31bK+Way1Rb+JGs455WLtkebEie/luSuN5DeF+aZyRH/zt1AY4weKQQg==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.131.0.tgz",
+            "integrity": "sha512-Lih6D0rjXStl0eUjzlcCiqr60AI/LuE+Zy29beEeXrXqTjOf8t0mcDX/MN3TZBBncxwUNi6osAEsKj4FRnItmQ==",
             "cpu": [
                 "x64"
             ],
@@ -4369,9 +4401,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-android-arm-eabi": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.128.0.tgz",
-            "integrity": "sha512-aca6ZvzmCBUGOANQRiRQRZuRKYI3ENhcit6GisnknOOmcezfQc7xJ4dxlPU7MV7mOvrC7RNR1u3LAD7xyaiCxA==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.131.0.tgz",
+            "integrity": "sha512-t2xicr9pfzkSRYx5aPqZqlLaayIwJTqgQ81Jor31Xep2nGyL2Aq3d0K5wOfeR7VevaSdxaS9dzSQP9xDwn8fDg==",
             "cpu": [
                 "arm"
             ],
@@ -4386,9 +4418,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-android-arm64": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.128.0.tgz",
-            "integrity": "sha512-BbeDmuohoJ7Rz/it5wnkj69i/OsCPS3Z51nLEzwO/Y6YshtC4JU+15oNwhY8v4LRKRYclRc7ggOikwrsJ/eOEQ==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.131.0.tgz",
+            "integrity": "sha512-nlGIod6gw75x1aEDgLS+srj+JRGY0HHm9MI9YgzE/B64l6d6+H3MSP9NOgp0+HTg8tp4vV9rVfgQGgd+TfVZcA==",
             "cpu": [
                 "arm64"
             ],
@@ -4403,9 +4435,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-darwin-arm64": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.128.0.tgz",
-            "integrity": "sha512-tRUHPt80417QmvNpoSslJT1VY8NUbWdrWR+L14Zn+RbOTcaqB8E6PYE/ZGN8jjWBzqporiA/H4MfO50ew/NCNA==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.131.0.tgz",
+            "integrity": "sha512-jukuV6xe5RbQKFo7QD34NDCLDZp4PSOm8rmckhNdH/60ymG5zXbDzGBEyc+nTkuLQNama2aSGCt+CPfpjNTqyw==",
             "cpu": [
                 "arm64"
             ],
@@ -4420,9 +4452,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-darwin-x64": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.128.0.tgz",
-            "integrity": "sha512-rWI2Hb1Nt3U/vKsjyNvZzDC8i/l144U20DKjhzaTmwIhIiSRGeroPWWiImwypmKLqrw8GuIixbWJkpGWLbkzrQ==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.131.0.tgz",
+            "integrity": "sha512-g3JOo4khe9rslHm5WYaVDWb0HS/M1MLR3I9S8560MkKIcC96VQY00QjOlsuRyfSj/JDXj8i9T7ryPO2RidiXVg==",
             "cpu": [
                 "x64"
             ],
@@ -4437,9 +4469,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-freebsd-x64": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.128.0.tgz",
-            "integrity": "sha512-hhpdVMaNCLgQxjgNPeeFzSeJMmZPc5lKfv0NGSI3egZq9EdnEGqeC8JsYsQjK7PoQgbvZ17xlj0SO5ziH5Obkg==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.131.0.tgz",
+            "integrity": "sha512-1hziITDTxjMePnX+dR9ocVT+EuZkQ8wm4FPAbmbEiKG+Phbo73J1ZnPAA6Y/aGsWF3McOFnQuZIktAFwalkfJQ==",
             "cpu": [
                 "x64"
             ],
@@ -4454,9 +4486,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.128.0.tgz",
-            "integrity": "sha512-093zNw0zZ/e/obML+rhlSdmnzR0mVZluPcAkxunEc5E3F0yBVsFn24Y1ILfsEte11Ud041qn/gp2OJ1jxNqUng==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.131.0.tgz",
+            "integrity": "sha512-9uRxfXwyKG9+MwmGQBo2ncPNwZH5HTmCETFM2WiuDBNDCW4NC5ttSQkwCAMrTAWgwMzVBH1CP8pM0v7nebCWXQ==",
             "cpu": [
                 "arm"
             ],
@@ -4471,9 +4503,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.128.0.tgz",
-            "integrity": "sha512-fq7DmKmfC+dvD97IXrgbph6Jzwe0EDu+PYMofmzZ6fv5X1k9vtaqLpDGMuICO9MmUnyKAQmVl+wIv2RNy4Dz8g==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.131.0.tgz",
+            "integrity": "sha512-mgbLvzRShXOLBdWGInf08Af4q+pfj1xD8hSgLClDZ9of/BXkB6+LIhTH7fihiDUipqB3yoSkKBWaZ3Ejlf5Yag==",
             "cpu": [
                 "arm"
             ],
@@ -4488,13 +4520,16 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.128.0.tgz",
-            "integrity": "sha512-Xvm48jJah8TlIrURIjNOP/gNiGe6aKvCB+r06VliflFo8Kq7VOLE8PxtgShJzZIqubrgdMdYfvuPPozn7F6MbQ==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.131.0.tgz",
+            "integrity": "sha512-OPT8++4aN6j2GJ8+3IZHS/byXoZP4aSBn+FoG6rgBJ2fKwPKXWF3MqrFMNW7NKHM28FLY579xYLxJSfgobEqPA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4505,13 +4540,16 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-arm64-musl": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.128.0.tgz",
-            "integrity": "sha512-M7iwBGmYJTx+pKOYFjI0buop4gJvlmcVzFGaXPt21DKpQkbQZG1f63Yg7LloIYT/t9yLxCw0Lhfx/RFlAlMSjA==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.131.0.tgz",
+            "integrity": "sha512-vtPiwmfVTAXzaxDKsOXG+LwgRAA7WEnaeHzhS5z0GE89gAK18KSXnly7Z6saXXq6L3dVMyK44uoTI03zKxrpmw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4522,13 +4560,16 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.128.0.tgz",
-            "integrity": "sha512-21LGNIZb1Pcfk5/EGsqabrxv4yqQOWis1407JJrClS7XpFCrbvr74YAB1V+m54cYbwvO6UWwQqS4WecxiyfCRg==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.131.0.tgz",
+            "integrity": "sha512-8AW8L7w5cGHSdZPcyZX2yR0+GUODsT15rbRjfdD54rv6DMbtuEB19ysLOpKJlRGfH6UNYNpCHaU1uJWgTWf1/w==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4539,13 +4580,16 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.128.0.tgz",
-            "integrity": "sha512-gyHjOTFpg9bTTYjxPmQirvufb89+VdZwVfcMtAUyPr6F5H8ZswvCQshK4qOW+Q+2Xyb33hduRgY/eFHJQjU/vQ==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.131.0.tgz",
+            "integrity": "sha512-vvpjkjEOUsPcsYf8evE4MO3aGx9+3wodXEBOicGNnOwTuAik8eBONNkgSdhkGsAblQmfVHJyanRnpxglddTXIA==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4556,13 +4600,16 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.128.0.tgz",
-            "integrity": "sha512-X6Q2oKUrP5GyDd2xniuEBLk6aFQCZ97W2+aVXGgJXdjx5t4/oFuA9ri0wLOUrBIX+qdSuK581snMBio4z910eA==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.131.0.tgz",
+            "integrity": "sha512-AqmcNC3fClXX+fxQ6VGEN1667xVFiRBkY0CZmDMSiaeFUsv1+UkBPYYi48IUKcA9/ivvoKNRzQl2I4//kT9F/w==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4573,13 +4620,16 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.128.0.tgz",
-            "integrity": "sha512-BdzTmqxfxoYkpgokoLaSnOX6T+R3/goL42klre2tnG+kHbG2TXS0VN+P5BPofH1axdKOHy5ei4ENZrjmCOt2lA==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.131.0.tgz",
+            "integrity": "sha512-7d3jOMKy7RSQCcDLIci+ySll2FgsOMl/GiRux4q2JNv0zg4EdhFISa9idvrdN/HEUIQQJNg6dmveUeJl2YErGA==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4590,13 +4640,16 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-x64-gnu": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.128.0.tgz",
-            "integrity": "sha512-OO1nW2Q7sSYYvJZpDHdvyFSdRaVcQqRijZSSmWVMqFxPYy8cEF45zJ9fcdIYuzIT3jYq6YRhEFm/VMWNWhE22Q==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.131.0.tgz",
+            "integrity": "sha512-JHK/h95qVqVQ+ITER837kcTdwBDFpFaNnOTYGCP0zdUSX/mLKC7tXOoyrTb6vG7iRPwGlcgBil3v2IjYw1FqJA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4607,13 +4660,16 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-x64-musl": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.128.0.tgz",
-            "integrity": "sha512-4NehAe404MRdoZVS9DW8C5XbJwbXIc/KfVlYdpi5vE4081zc9Y0YzKVqyOYj/Puye7/Do+ohaONBFWlEHYl9hw==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.131.0.tgz",
+            "integrity": "sha512-b2BO82O8azXAyf7EUgOPKu145nWypbNyk07HbU09fkzhm9lEA5oPvaN/M8Nlo7tOErVTa2WOgS4QbOnxAPXdDQ==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4624,9 +4680,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-openharmony-arm64": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.128.0.tgz",
-            "integrity": "sha512-kVbqgW9xLL8bh8oc7aYOJilRKXE5G33+tE0jan+duo/9OriaFRpijcCwT2waWs2oqYROYq0GlE7/p3ywoshVeg==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.131.0.tgz",
+            "integrity": "sha512-GHO9glZaX7LkX/OGfluEPf1yjg+ehiFbUdowbX6uNWOQhmwKWU4m4+nZ9FJkrHNKuxyI1KKertMdGjVKCApKWA==",
             "cpu": [
                 "arm64"
             ],
@@ -4641,9 +4697,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-wasm32-wasi": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.128.0.tgz",
-            "integrity": "sha512-L38ojghJYHmgiz6fJd7jwLB/ESDBpB02NdFxh+smqVM6P2anCEvHn0jhaSrt5eVNR1Ak8+moOeftUlofeyvniA==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.131.0.tgz",
+            "integrity": "sha512-3SkikPaEFoih1N83qLVEDLRLeY4nYsf6JT9SnWiMCQ5lGQdKup6bEuKCqkRiG9dD1IIaFeYz9RjlciPmYoFIWA==",
             "cpu": [
                 "wasm32"
             ],
@@ -4660,9 +4716,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.128.0.tgz",
-            "integrity": "sha512-xgvO35GyHBtjlQ5AEpaYr7Rll1rvY7zqIhT6ty8E3ezBW2J1SFLjIDEvI/tcgDg6oaseDAqVcM+jU1HuCekgZw==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.131.0.tgz",
+            "integrity": "sha512-Os5bEhryeA2jkH+ZrnZyAC1EP5gs+X4YB1Fjqml7UPD5kU7ecsK1MPEVMfCrdt/GDNpDbavYXiOXOdyJ5b3OPw==",
             "cpu": [
                 "arm64"
             ],
@@ -4677,9 +4733,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.128.0.tgz",
-            "integrity": "sha512-OY+3eM2SN72prHKRB22mPz8o5A/7dJ+f5DFLBVvggyZhEaNDAH9IB+ElMjmOkOIwf5MDCUAowCK7pAncNxzpBA==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.131.0.tgz",
+            "integrity": "sha512-m+jNz9EuF0NXoiptc6B9h5yompZQVW/a5MJeOu5zojfH5yWk82tvF2ccrHkfhgtrS9h9DD5l1Qv8dWlfY7Nz8g==",
             "cpu": [
                 "ia32"
             ],
@@ -4694,9 +4750,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-win32-x64-msvc": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.128.0.tgz",
-            "integrity": "sha512-NE9ny+cPUCCObXa0IKLfj0tCdPd7pe/dz9ZpkxpUOymB3miNeMPybdlYYTBSGJUalMWeBM85/4JcCErCNTqOXw==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.131.0.tgz",
+            "integrity": "sha512-o14Hk8dAyiEUMFEWEgmAwFZvBt1RzAYLM3xeQ+5315JXgVYhoemivgYcbYVRbsFkS71ShMGlAFE0kPnr460rww==",
             "cpu": [
                 "x64"
             ],
@@ -4711,9 +4767,9 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
-            "integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.131.0.tgz",
+            "integrity": "sha512-PgnWDfV0h+b16XNKbXU7Daib/BFSt/J2mEzfYIBu6JB/wNdlU+kVYXCkGA1A9fWkTbOgbjh4e6NhPeQOYvFhEA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -4721,9 +4777,9 @@
             }
         },
         "node_modules/@oxc-transform/binding-android-arm-eabi": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm-eabi/-/binding-android-arm-eabi-0.128.0.tgz",
-            "integrity": "sha512-qVO4izEs88ZSo7KOK4P+O5nAXXJmkSadInvFjGkhVnm2R2Wr8trU/GLhjAK0S0u8Qv9bkXspNhgpECk+CTQ/ew==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm-eabi/-/binding-android-arm-eabi-0.131.0.tgz",
+            "integrity": "sha512-rcNvLlbNnxTfYVlZVF+Rev2AyCpJDpwVPphG4HOJxauaT1+w5VxL+kRdxCReof4A8ZsszbvIYlvkqvaJKO4Mog==",
             "cpu": [
                 "arm"
             ],
@@ -4738,9 +4794,9 @@
             }
         },
         "node_modules/@oxc-transform/binding-android-arm64": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm64/-/binding-android-arm64-0.128.0.tgz",
-            "integrity": "sha512-F3RXlbCzIgkpRWlz1PEguDZl5NzZRmbeHKTFTQWFnK6mIdw2EkWihPVv9+CIcO80c7+sF/YRGOBaji6hwUDhtQ==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm64/-/binding-android-arm64-0.131.0.tgz",
+            "integrity": "sha512-/y+EH6QYQB2ZDQNvMlzItc36mw16GZwCDlvGYbQ4GCTE+7ZtSmx9E/rJOYzYyzMghz0c5dhJquRKScXdOZHpnQ==",
             "cpu": [
                 "arm64"
             ],
@@ -4755,9 +4811,9 @@
             }
         },
         "node_modules/@oxc-transform/binding-darwin-arm64": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-arm64/-/binding-darwin-arm64-0.128.0.tgz",
-            "integrity": "sha512-xj63gIzQ67LDYHCOWXSHgfx4LbPVz1ck0G3y0eR6mbgYk3CwwylbhWi/CaDC6BWsHwoLQryeYjHB5XBCR0EPMQ==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-arm64/-/binding-darwin-arm64-0.131.0.tgz",
+            "integrity": "sha512-x1Va8zFomdYghAI0Zkt7kUmG50S65XH1u0EbIDr80M9idfXrQgd08ZGl3ejwRGLBrkbA8tkkmeOu1rWVFf7BXg==",
             "cpu": [
                 "arm64"
             ],
@@ -4772,9 +4828,9 @@
             }
         },
         "node_modules/@oxc-transform/binding-darwin-x64": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-x64/-/binding-darwin-x64-0.128.0.tgz",
-            "integrity": "sha512-YQkvFqNqpwEt197RjREAOWeRANalPtCD+ayZlx4IjTQ6IOYZEP83B9/++gTQisHV3r8E7dU8UqJKeSS1cHlTQg==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-x64/-/binding-darwin-x64-0.131.0.tgz",
+            "integrity": "sha512-EwacackWpYYXGZsl0Aj4NKvDdLuxWZg7LQDneFyMwuftpAxPQLRkHFwZib7r6wpIJm4NELhHW261A4vZ8OQqXQ==",
             "cpu": [
                 "x64"
             ],
@@ -4789,9 +4845,9 @@
             }
         },
         "node_modules/@oxc-transform/binding-freebsd-x64": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-freebsd-x64/-/binding-freebsd-x64-0.128.0.tgz",
-            "integrity": "sha512-Jvd3Ximb3x3o0+xRBB5lq63JlzxhJN787IsBjn0PEnmuocYQj+tJ5BB4n9xPIG27GXwg3ycckQPO/RsWeEcBPg==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-freebsd-x64/-/binding-freebsd-x64-0.131.0.tgz",
+            "integrity": "sha512-EhXqWOtL1PWcJ3ktdplV4Wrez2PRuTBSDdB7KF6CN4zuZhohUjxC1bxqDNRbNSX46yaZ27IzJLafah1J6mSA8Q==",
             "cpu": [
                 "x64"
             ],
@@ -4806,9 +4862,9 @@
             }
         },
         "node_modules/@oxc-transform/binding-linux-arm-gnueabihf": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.128.0.tgz",
-            "integrity": "sha512-TaRKWeGnAJNIdCa5+m0I8/SksBgkLX94iH40qy3chvLuaIOGAmOViUStYx8geXBzO9P99V7En8nHXLoqCONBRQ==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.131.0.tgz",
+            "integrity": "sha512-NfNACr3aqBKeeUh6HCoGGPSjdMkLvyXUZQywCg/DwRkEpqZo55KX65saW1sQdgBcu0SKXrAReTjIm/HDO/OI0Q==",
             "cpu": [
                 "arm"
             ],
@@ -4823,9 +4879,9 @@
             }
         },
         "node_modules/@oxc-transform/binding-linux-arm-musleabihf": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.128.0.tgz",
-            "integrity": "sha512-7TMrtA5/3SCvS+yMPrGnri5T4ZhIoCbjwKWV6Kn8d3v+vx7MpEmNkfe+CdF3rb5LlnuxeDMPwr1E2ntya0b8HQ==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.131.0.tgz",
+            "integrity": "sha512-ABp6KGhbYFGDaAdB4gGZW12DYa55OF/Cu+6Rw6/Di0skuwpiDwnBOLHWz9VBq0QTcREy/qIUOnKW+vZHQLOT8A==",
             "cpu": [
                 "arm"
             ],
@@ -4840,13 +4896,16 @@
             }
         },
         "node_modules/@oxc-transform/binding-linux-arm64-gnu": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.128.0.tgz",
-            "integrity": "sha512-lMQEa1jLBNm1N+5uvyj9zX9urVY4xKkLnhO8/4CtSGdXX+mExqsVawyQPAZqbtq1fLQ0yt1QYJ9YuM0+fiSJTQ==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.131.0.tgz",
+            "integrity": "sha512-4nKYkHHjRela+jpt+VO4++jxgHoJQFxAeAGtfQ4x11dQMJllzqo3Yu8gfcfLEMsAfflwN/gY+KBbMD/y0exitg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4857,13 +4916,16 @@
             }
         },
         "node_modules/@oxc-transform/binding-linux-arm64-musl": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.128.0.tgz",
-            "integrity": "sha512-dPSjyd0gQ9dE3mpdJi0BHNJaqQz4V7mVW6Fbs6jRSiGnrxwGfXdMJFInXoJ49B3k5Zhfa9Is9Ixp6St7c6ouCA==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.131.0.tgz",
+            "integrity": "sha512-cW0Ab1s0sxfiyP1+gdd94f0vUjwGzJF4F3DepF3VnR9nFTGMmFLugwtrBS3DYjTnbugiUH3Fp+16yys1FhNzIA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4874,13 +4936,16 @@
             }
         },
         "node_modules/@oxc-transform/binding-linux-ppc64-gnu": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.128.0.tgz",
-            "integrity": "sha512-YNa9XAotPKvAXFJrHC7kBsHMVg0HOB4vRiKuYUjzFsfLkxTbuztKHTKG/gW5kjp7dBw+TNFofTaVCVZgOnHXPQ==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.131.0.tgz",
+            "integrity": "sha512-wunAU/lzE1nPGKL47uI0g+4Nsv/12xveOXNu4M70xe85kNBm7mQdMpZIeoVYCxtXew0iHxFKJDT6qK5mYFSA3w==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4891,13 +4956,16 @@
             }
         },
         "node_modules/@oxc-transform/binding-linux-riscv64-gnu": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.128.0.tgz",
-            "integrity": "sha512-jjSiG9H8ya/U3igW5DdIBFIDwhffF7Vbc7th2tcHV73eg0DQz75n36a9RmQ1/0aS9vknUuNtY6SODr8/gmuzsQ==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.131.0.tgz",
+            "integrity": "sha512-r4sMt4OB4TryDcVWW9KnsXOf/ea7tIGX2QASNrpetzPocsBZqhHIFDbZ8EkBDjmlmWGHg6BgjVx6lLcMXX4Dcw==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4908,13 +4976,16 @@
             }
         },
         "node_modules/@oxc-transform/binding-linux-riscv64-musl": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.128.0.tgz",
-            "integrity": "sha512-FVUr/XNT7BfQA4XVMel/HTCJi5mQyEitslgX42ztYPnCFMRFG1sQQKgnlLJdl7qifuyxpvKLR1f7h7HEuwWw1Q==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.131.0.tgz",
+            "integrity": "sha512-/rLVLItsBjKrnZFLiGrwRB3fs0dAjXZLqY7F42omvacFJjZsceQ3481oQX1bBs3RwoDDyDy/9ZkIN7kYIkv5Gw==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4925,13 +4996,16 @@
             }
         },
         "node_modules/@oxc-transform/binding-linux-s390x-gnu": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.128.0.tgz",
-            "integrity": "sha512-caJnVw5PG8v339zAyHgA7p34xXa3A4Kc9VyrDgsT1znr51qacaUv4BRlgRi0qkqxRWXYNVFfsbU2g0t1qS7E9w==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.131.0.tgz",
+            "integrity": "sha512-fUprJgJauI1A7e7cDgY/Z3mwLVtE3aswB4lvS96KpRNDHrwOh8bnCJOWf+0CYveDQzghDVFiZWVDo56pO4Wr9Q==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4942,13 +5016,16 @@
             }
         },
         "node_modules/@oxc-transform/binding-linux-x64-gnu": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.128.0.tgz",
-            "integrity": "sha512-zkQKjsHEUX3ckQBcZTtHE/7pgFMkWQp6y/4t7N8eT3j8wnoL+vapv7l4ISjgx1/EePRJN1HErYXmriz7tPVKRg==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.131.0.tgz",
+            "integrity": "sha512-XdbvDT1GPNxrTLXSRt4RU2uCH112q3nINTT05DZqTYYcAxaCPImnMoZe2TlBv5j2376Gk+2pcVnJs6xut47aSw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4959,13 +5036,16 @@
             }
         },
         "node_modules/@oxc-transform/binding-linux-x64-musl": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-musl/-/binding-linux-x64-musl-0.128.0.tgz",
-            "integrity": "sha512-NjYtwl9ijp34iisHxYBvE7nii1Ac0QPP3doHv8MQHhDA3zjUcDCROuBNybfaEYCxnJ1aF+cAPqsyeopnAGsyuQ==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-musl/-/binding-linux-x64-musl-0.131.0.tgz",
+            "integrity": "sha512-Du2CxlBfC98EV3hOAmLVSUgP0JgqM9F47lRv9v43T4sGPcQVOjs9wffUybGUUraG9unmBZ4dgpMAqlCq0k3dGw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4976,9 +5056,9 @@
             }
         },
         "node_modules/@oxc-transform/binding-openharmony-arm64": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-openharmony-arm64/-/binding-openharmony-arm64-0.128.0.tgz",
-            "integrity": "sha512-itsi0tVkVdrYphSppdFChLq9tD0pvbRRS3EV8NQYKZ/NWHMoxzjlf9TFA/ZZYV113juYo1Dq3glVX48knhBeFQ==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-openharmony-arm64/-/binding-openharmony-arm64-0.131.0.tgz",
+            "integrity": "sha512-wTj2FkOgNhgdisnA0a15QQksyj6AH2snmpgYgAtj098i477x5LpHHdqfuk60jsA/QHSjmUc6dm4P88yI5GY4xA==",
             "cpu": [
                 "arm64"
             ],
@@ -4993,9 +5073,9 @@
             }
         },
         "node_modules/@oxc-transform/binding-wasm32-wasi": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-wasm32-wasi/-/binding-wasm32-wasi-0.128.0.tgz",
-            "integrity": "sha512-elzjX2gy1jcseeFaKtbk/6T2FPTpGNx0IpeD0iyk6cahWN7wD6eHY5u7th1X85cYbRq9rqniS+xYIxN3StthWg==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-wasm32-wasi/-/binding-wasm32-wasi-0.131.0.tgz",
+            "integrity": "sha512-lE9UaZL0KomAlbATiB6FKoJ9no6W49yXs/MujJqY75AkHHMeOCsHSN9HvriyWz2FOIQgV7C5cmNj0jf+IaBtQg==",
             "cpu": [
                 "wasm32"
             ],
@@ -5012,9 +5092,9 @@
             }
         },
         "node_modules/@oxc-transform/binding-win32-arm64-msvc": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.128.0.tgz",
-            "integrity": "sha512-p5LmbI66dk2dziJSUzjQ24gOWeI6pJpXcOC6famloRtKCq54V5/KegsztFgZZCtYFEAEqFgcfspFHrV+CcKWcg==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.131.0.tgz",
+            "integrity": "sha512-8KUfPnuxbEfa9H+OQ5XNPFq9JIEWVCg8kczJaD8PvTprr515mz1lmSLSUoOW8mrLaN0mZaGg6pemuvTawOLoPg==",
             "cpu": [
                 "arm64"
             ],
@@ -5029,9 +5109,9 @@
             }
         },
         "node_modules/@oxc-transform/binding-win32-ia32-msvc": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.128.0.tgz",
-            "integrity": "sha512-CMU3Yn05rXeLw7GyVlDB3bbp2iV14yt3VWyF0pNuMK9NVgOmUkXgFLe5SOcX9rEm64TRJjOMEghtE5+r0GtqIQ==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.131.0.tgz",
+            "integrity": "sha512-pXSu2A7L6H//1Uvsg5RJHb91BDZpCTho0r9oAwxPqKJM2LWV7Zph/ikWEIXt/YLbKF3WpkHrKQ5hbQGP9gWmHg==",
             "cpu": [
                 "ia32"
             ],
@@ -5046,9 +5126,9 @@
             }
         },
         "node_modules/@oxc-transform/binding-win32-x64-msvc": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.128.0.tgz",
-            "integrity": "sha512-Vck5AdNH2JPYMQWVDxvX5PbDFfqVG+tCOgKJzAC/S9bgbD3qcMjN5Dx6FOmEbwY3hZm//fzOsY4tErofoiK/aQ==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.131.0.tgz",
+            "integrity": "sha512-VXgk106WLl3NpBO/6G2gxkWBHguCJm01mGqAq2Q0l2o7hnbglsND0UWSCtM3a9MlsDimfJkLWFQveZu4UtnRvA==",
             "cpu": [
                 "x64"
             ],
@@ -5190,6 +5270,9 @@
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5211,6 +5294,9 @@
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5232,6 +5318,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5253,6 +5342,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5274,6 +5366,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5295,6 +5390,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5557,9 +5655,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
-            "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+            "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
             "dev": true,
             "license": "MIT"
         },
@@ -6253,6 +6351,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/jsesc": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
+            "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/linkify-it": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -6312,14 +6417,14 @@
             "license": "MIT"
         },
         "node_modules/@unhead/vue": {
-            "version": "2.1.13",
-            "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.1.13.tgz",
-            "integrity": "sha512-HYy0shaHRnLNW9r85gppO8IiGz0ONWVV3zGdlT8CQ0tbTwixznJCIiyqV4BSV1aIF1jJIye0pd1p/k6Eab8Z/A==",
+            "version": "2.1.15",
+            "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.1.15.tgz",
+            "integrity": "sha512-SSByXfEjhzPn8gXdEdgpYqpLMPSkLUH2HVE0GxZfOtNsJ0GgOHQs0g9T67ZZ1z0kTELLKdtOtYrzrbv9+ffF7g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "hookable": "^6.0.1",
-                "unhead": "2.1.13"
+                "unhead": "2.1.15"
             },
             "funding": {
                 "url": "https://github.com/sponsors/harlan-zw"
@@ -6376,13 +6481,13 @@
             }
         },
         "node_modules/@vitejs/plugin-vue": {
-            "version": "6.0.6",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.6.tgz",
-            "integrity": "sha512-u9HHgfrq3AjXlysn0eINFnWQOJQLO9WN6VprZ8FXl7A2bYisv3Hui9Ij+7QZ41F/WYWarHjwBbXtD7dKg3uxbg==",
+            "version": "6.0.7",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.7.tgz",
+            "integrity": "sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@rolldown/pluginutils": "1.0.0-rc.13"
+                "@rolldown/pluginutils": "^1.0.1"
             },
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
@@ -6549,13 +6654,13 @@
             }
         },
         "node_modules/@vue/devtools-api": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.1.1.tgz",
-            "integrity": "sha512-bsDMJ07b3GN1puVwJb/fyFnj/U2imyswK5UQVLZwVl7O05jDrt6BHxeG5XffmOOdasOj/bOmIjxJvGPxU7pcqw==",
+            "version": "8.1.2",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.1.2.tgz",
+            "integrity": "sha512-vA0O112YqyDuNA1s7Yb2gCgToQ/OxOWiFDO5ThLCcDy0ldHnSd1dUTaSYhOldbqoNgumE4dxtGAoAaSUKUD1Zg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vue/devtools-kit": "^8.1.1"
+                "@vue/devtools-kit": "^8.1.2"
             }
         },
         "node_modules/@vue/devtools-core": {
@@ -6573,13 +6678,13 @@
             }
         },
         "node_modules/@vue/devtools-kit": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.1.1.tgz",
-            "integrity": "sha512-gVBaBv++i+adg4JpH71k9ppl4soyR7Y2McEqO5YNgv0BI1kMZ7BDX5gnwkZ5COYgiCyhejZG+yGNrBAjj6Coqg==",
+            "version": "8.1.2",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.1.2.tgz",
+            "integrity": "sha512-f75/upc+GCyjXErpgPGz4582ujS0L/adAltGy+tqXMGUJpgAcfGr6CxnnhpZY8BHuMYt6KpbF8uaFrrQG66rGQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vue/devtools-shared": "^8.1.1",
+                "@vue/devtools-shared": "^8.1.2",
                 "birpc": "^2.6.1",
                 "hookable": "^5.5.3",
                 "perfect-debounce": "^2.0.0"
@@ -6596,9 +6701,9 @@
             }
         },
         "node_modules/@vue/devtools-shared": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.1.1.tgz",
-            "integrity": "sha512-+h4ttmJYl/txpxHKaoZcaKpC+pvckgLzIDiSQlaQ7kKthKh8KuwoLW2D8hPJEnqKzXOvu15UHEoGyngAXCz0EQ==",
+            "version": "8.1.2",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.1.2.tgz",
+            "integrity": "sha512-X9RyVFYAdkBe4IUf5v48TxBF/6QPmF8CmWrDAjXzfUHrgQ/HGfTC1A6TqgXqZ03ye66l3AD51BAGD69IvKM9sw==",
             "dev": true,
             "license": "MIT"
         },
@@ -7511,13 +7616,26 @@
             "license": "ISC"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/brace-expansion/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -8188,9 +8306,9 @@
             "license": "MIT"
         },
         "node_modules/cookie-es": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-2.0.1.tgz",
-            "integrity": "sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+            "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
             "dev": true,
             "license": "MIT"
         },
@@ -8313,19 +8431,6 @@
             "license": "MIT",
             "dependencies": {
                 "uncrypto": "^0.1.3"
-            }
-        },
-        "node_modules/css-declaration-sorter": {
-            "version": "7.4.0",
-            "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.4.0.tgz",
-            "integrity": "sha512-LTuzjPoyA2vMGKKcaOqKSp7Ub2eGrNfKiZH4LpezxpNrsICGCSFvsQOI29psISxNZtaXibkC2CXzrQ5enMeGGw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^14 || ^16 || >=18"
-            },
-            "peerDependencies": {
-                "postcss": "^8.0.9"
             }
         },
         "node_modules/css-select": {
@@ -8728,9 +8833,9 @@
             "license": "MIT"
         },
         "node_modules/devalue": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.0.tgz",
-            "integrity": "sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==",
+            "version": "5.8.1",
+            "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+            "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
             "dev": true,
             "license": "MIT"
         },
@@ -9340,30 +9445,30 @@
             }
         },
         "node_modules/fast-string-truncated-width": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-1.2.1.tgz",
-            "integrity": "sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+            "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-string-width": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-1.1.0.tgz",
-            "integrity": "sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+            "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "fast-string-truncated-width": "^1.2.0"
+                "fast-string-truncated-width": "^3.0.2"
             }
         },
         "node_modules/fast-wrap-ansi": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.1.6.tgz",
-            "integrity": "sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+            "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "fast-string-width": "^1.1.0"
+                "fast-string-width": "^3.0.2"
             }
         },
         "node_modules/fastq": {
@@ -9612,9 +9717,9 @@
             }
         },
         "node_modules/get-east-asian-width": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-            "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+            "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9703,29 +9808,6 @@
             },
             "engines": {
                 "node": ">= 6"
-            }
-        },
-        "node_modules/glob/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/glob/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/glob/node_modules/minimatch": {
@@ -11101,58 +11183,16 @@
             }
         },
         "node_modules/magic-regexp": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/magic-regexp/-/magic-regexp-0.10.0.tgz",
-            "integrity": "sha512-Uly1Bu4lO1hwHUW0CQeSWuRtzCMNO00CmXtS8N6fyvB3B979GOEEeAkiTUDsmbYLAbvpUS/Kt5c4ibosAzVyVg==",
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/magic-regexp/-/magic-regexp-0.11.0.tgz",
+            "integrity": "sha512-LG77Z/gVnwz7oaDpD4heX6ryl+lcr4l1B2gnP4MMvt2pGhGC1Dfj7dl1pXpP4ih+VQFLuAadeKVa+lARAzfW+Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "estree-walker": "^3.0.3",
-                "magic-string": "^0.30.12",
-                "mlly": "^1.7.2",
+                "magic-string": "^0.30.21",
                 "regexp-tree": "^0.1.27",
                 "type-level-regexp": "~0.1.17",
-                "ufo": "^1.5.4",
-                "unplugin": "^2.0.0"
-            }
-        },
-        "node_modules/magic-regexp/node_modules/estree-walker": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0"
-            }
-        },
-        "node_modules/magic-regexp/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/magic-regexp/node_modules/unplugin": {
-            "version": "2.3.11",
-            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
-            "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/remapping": "^2.3.5",
-                "acorn": "^8.15.0",
-                "picomatch": "^4.0.3",
-                "webpack-virtual-modules": "^0.6.2"
-            },
-            "engines": {
-                "node": ">=18.12.0"
+                "unplugin": "^3.0.0"
             }
         },
         "node_modules/magic-string": {
@@ -11457,6 +11497,16 @@
                 "node": "*"
             }
         },
+        "node_modules/minimatch/node_modules/brace-expansion": {
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/minimist": {
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -11614,9 +11664,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.12",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
             "dev": true,
             "funding": [
                 {
@@ -12205,6 +12255,13 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
+        "node_modules/nitropack/node_modules/cookie-es": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-2.0.1.tgz",
+            "integrity": "sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/nitropack/node_modules/dot-prop": {
             "version": "10.1.0",
             "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-10.1.0.tgz",
@@ -12655,29 +12712,6 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
-        "node_modules/npm-run-all2/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/npm-run-all2/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
         "node_modules/npm-run-all2/node_modules/isexe": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
@@ -12798,35 +12832,35 @@
             }
         },
         "node_modules/nuxt": {
-            "version": "4.4.4",
-            "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-4.4.4.tgz",
-            "integrity": "sha512-r9E3PYo+uJazltAmjm0TwFW3MQ++Wd//2uRZgCyqkt7VSAVJ5KnRRwUF7JktK/NZbLYAUDiV3tgqE9ZYbHbymA==",
+            "version": "4.4.6",
+            "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-4.4.6.tgz",
+            "integrity": "sha512-QAApJpAx3yGf3pYudALkInuBfv0WkHCiol6ntTvh/lwKwYrcU/MRI1nLNGt0QNyUCgBWdOQukd3z67VJ2xGd0Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@dxup/nuxt": "^0.4.1",
-                "@nuxt/cli": "^3.35.1",
+                "@nuxt/cli": "^3.35.2",
                 "@nuxt/devtools": "^3.2.4",
-                "@nuxt/kit": "4.4.4",
-                "@nuxt/nitro-server": "4.4.4",
-                "@nuxt/schema": "4.4.4",
+                "@nuxt/kit": "4.4.6",
+                "@nuxt/nitro-server": "4.4.6",
+                "@nuxt/schema": "4.4.6",
                 "@nuxt/telemetry": "^2.8.0",
-                "@nuxt/vite-builder": "4.4.4",
-                "@unhead/vue": "^2.1.13",
-                "@vue/shared": "^3.5.33",
+                "@nuxt/vite-builder": "4.4.6",
+                "@unhead/vue": "^2.1.15",
+                "@vue/shared": "^3.5.34",
                 "chokidar": "^5.0.0",
                 "compatx": "^0.2.0",
                 "consola": "^3.4.2",
-                "cookie-es": "^2.0.1",
+                "cookie-es": "^3.1.1",
                 "defu": "^6.1.7",
-                "devalue": "^5.7.1",
+                "devalue": "^5.8.1",
                 "errx": "^0.1.0",
                 "escape-string-regexp": "^5.0.0",
                 "exsolve": "^1.0.8",
                 "hookable": "^6.1.1",
                 "ignore": "^7.0.5",
                 "impound": "^1.1.5",
-                "jiti": "^2.6.1",
+                "jiti": "^2.7.0",
                 "klona": "^2.0.6",
                 "knitwork": "^1.3.0",
                 "magic-string": "^0.30.21",
@@ -12836,36 +12870,36 @@
                 "ofetch": "^1.5.1",
                 "ohash": "^2.0.11",
                 "on-change": "^6.0.2",
-                "oxc-minify": "^0.128.0",
-                "oxc-parser": "^0.128.0",
-                "oxc-transform": "^0.128.0",
-                "oxc-walker": "^0.7.0",
+                "oxc-minify": "^0.131.0",
+                "oxc-parser": "^0.131.0",
+                "oxc-transform": "^0.131.0",
+                "oxc-walker": "^1.0.0",
                 "pathe": "^2.0.3",
                 "perfect-debounce": "^2.1.0",
                 "picomatch": "^4.0.4",
                 "pkg-types": "^2.3.1",
                 "rou3": "^0.8.1",
                 "scule": "^1.3.0",
-                "semver": "^7.7.4",
+                "semver": "^7.8.0",
                 "std-env": "^4.1.0",
                 "tinyglobby": "^0.2.16",
                 "ufo": "^1.6.4",
                 "ultrahtml": "^1.6.0",
                 "uncrypto": "^0.1.3",
                 "unctx": "^2.5.0",
-                "unimport": "^6.2.0",
+                "unimport": "^6.3.0",
                 "unplugin": "^3.0.0",
                 "unrouting": "^0.1.7",
                 "untyped": "^2.0.0",
-                "vue": "^3.5.33",
-                "vue-router": "^5.0.6"
+                "vue": "^3.5.34",
+                "vue-router": "^5.0.7"
             },
             "bin": {
                 "nuxi": "bin/nuxt.mjs",
                 "nuxt": "bin/nuxt.mjs"
             },
             "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+                "node": "^22.12.0 || ^24.11.0 || >=26.0.0"
             },
             "peerDependencies": {
                 "@parcel/watcher": "^2.1.0",
@@ -12878,6 +12912,74 @@
                 "@types/node": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/nuxt/node_modules/@babel/generator": {
+            "version": "8.0.0-rc.5",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0-rc.5.tgz",
+            "integrity": "sha512-nFZPWz3FHIS7y6rMIVoa/WBwjdutfIaRJIBQjzn+t3RnecZoRNlGmGcyR2wb0T/IgSd50Kz/6dG8/LvMCRunjg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^8.0.0-rc.5",
+                "@babel/types": "^8.0.0-rc.5",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
+                "@types/jsesc": "^2.5.0",
+                "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": "^22.18.0 || >=24.11.0"
+            }
+        },
+        "node_modules/nuxt/node_modules/@babel/generator/node_modules/@babel/helper-string-parser": {
+            "version": "8.0.0-rc.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0-rc.5.tgz",
+            "integrity": "sha512-sN7R8rBvDurfaziNfDEIjIntlazmlkCDGO4SNl2RJ3wRCn+QxspLV7hzYAE8WWVd2joVuT8sUxeePdLp2idI1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^22.18.0 || >=24.11.0"
+            }
+        },
+        "node_modules/nuxt/node_modules/@babel/generator/node_modules/@babel/helper-validator-identifier": {
+            "version": "8.0.0-rc.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.5.tgz",
+            "integrity": "sha512-ehJDxHvtbZ85RtX/L2fi0h9AGsBNqB5Euv1EB8RMAvGYvD+2X+QbpzzOpbklnNXO+WSZJNOaetw2BBj27xsWVg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^22.18.0 || >=24.11.0"
+            }
+        },
+        "node_modules/nuxt/node_modules/@babel/generator/node_modules/@babel/parser": {
+            "version": "8.0.0-rc.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0-rc.5.tgz",
+            "integrity": "sha512-/Mfg83rK3+jsRbl4Vbd0jqxc6M1A1/WNFtgrowRM1unEsD3XcNnrBdMM0JWakd0/RN9lseQKwPduW1TiEwKOlQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^8.0.0-rc.5"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": "^22.18.0 || >=24.11.0"
+            }
+        },
+        "node_modules/nuxt/node_modules/@babel/generator/node_modules/@babel/types": {
+            "version": "8.0.0-rc.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0-rc.5.tgz",
+            "integrity": "sha512-JeSVu/m8x/zpp4CLjYHVNXuhEyOkhPXuxM8YOXjh6L4LlvQNKuUNOTo5KdBuKAcTDHw8DquToTaEkhsBqPXOaA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^8.0.0-rc.5",
+                "@babel/helper-validator-identifier": "^8.0.0-rc.5"
+            },
+            "engines": {
+                "node": "^22.18.0 || >=24.11.0"
             }
         },
         "node_modules/nuxt/node_modules/@babel/parser": {
@@ -13084,9 +13186,9 @@
             }
         },
         "node_modules/nuxt/node_modules/jiti": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-            "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+            "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -13184,6 +13286,52 @@
             },
             "peerDependenciesMeta": {
                 "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/nuxt/node_modules/vue-router": {
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.0.7.tgz",
+            "integrity": "sha512-dqfk8kvRbCutmCOCj/XLDqDEYxc1wBdAOGLuVy5M93ifYMsBd5fIjfaPN4tQAbxr5IprdBDIox1gr4wYyOx/SA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/generator": "^8.0.0-rc.4",
+                "@vue-macros/common": "^3.1.1",
+                "@vue/devtools-api": "^8.1.1",
+                "ast-walker-scope": "^0.8.3",
+                "chokidar": "^5.0.0",
+                "json5": "^2.2.3",
+                "local-pkg": "^1.1.2",
+                "magic-string": "^0.30.21",
+                "mlly": "^1.8.0",
+                "muggle-string": "^0.4.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "scule": "^1.3.0",
+                "tinyglobby": "^0.2.15",
+                "unplugin": "^3.0.0",
+                "unplugin-utils": "^0.3.1",
+                "yaml": "^2.8.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/posva"
+            },
+            "peerDependencies": {
+                "@pinia/colada": ">=0.21.2",
+                "@vue/compiler-sfc": "^3.5.34",
+                "pinia": "^3.0.4",
+                "vue": "^3.5.34"
+            },
+            "peerDependenciesMeta": {
+                "@pinia/colada": {
+                    "optional": true
+                },
+                "@vue/compiler-sfc": {
+                    "optional": true
+                },
+                "pinia": {
                     "optional": true
                 }
             }
@@ -13329,9 +13477,9 @@
             }
         },
         "node_modules/oxc-minify": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/oxc-minify/-/oxc-minify-0.128.0.tgz",
-            "integrity": "sha512-VIXQO2W886aB+N17yV55Sack6aCpbUqtuNAYhNcPV6dFiWIZ5+kwOjvvw36igWwoljfjWhasu99CQ5wtvPJDYg==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/oxc-minify/-/oxc-minify-0.131.0.tgz",
+            "integrity": "sha512-Ch0sBbrqZpeNZUMhVDbU2yrTWTVrUT/MkXb9E2DAc+hbhxbbO8D/XklUtfPP86/iqrkvl178+YQvh5u8Of1mUg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -13341,36 +13489,36 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxc-minify/binding-android-arm-eabi": "0.128.0",
-                "@oxc-minify/binding-android-arm64": "0.128.0",
-                "@oxc-minify/binding-darwin-arm64": "0.128.0",
-                "@oxc-minify/binding-darwin-x64": "0.128.0",
-                "@oxc-minify/binding-freebsd-x64": "0.128.0",
-                "@oxc-minify/binding-linux-arm-gnueabihf": "0.128.0",
-                "@oxc-minify/binding-linux-arm-musleabihf": "0.128.0",
-                "@oxc-minify/binding-linux-arm64-gnu": "0.128.0",
-                "@oxc-minify/binding-linux-arm64-musl": "0.128.0",
-                "@oxc-minify/binding-linux-ppc64-gnu": "0.128.0",
-                "@oxc-minify/binding-linux-riscv64-gnu": "0.128.0",
-                "@oxc-minify/binding-linux-riscv64-musl": "0.128.0",
-                "@oxc-minify/binding-linux-s390x-gnu": "0.128.0",
-                "@oxc-minify/binding-linux-x64-gnu": "0.128.0",
-                "@oxc-minify/binding-linux-x64-musl": "0.128.0",
-                "@oxc-minify/binding-openharmony-arm64": "0.128.0",
-                "@oxc-minify/binding-wasm32-wasi": "0.128.0",
-                "@oxc-minify/binding-win32-arm64-msvc": "0.128.0",
-                "@oxc-minify/binding-win32-ia32-msvc": "0.128.0",
-                "@oxc-minify/binding-win32-x64-msvc": "0.128.0"
+                "@oxc-minify/binding-android-arm-eabi": "0.131.0",
+                "@oxc-minify/binding-android-arm64": "0.131.0",
+                "@oxc-minify/binding-darwin-arm64": "0.131.0",
+                "@oxc-minify/binding-darwin-x64": "0.131.0",
+                "@oxc-minify/binding-freebsd-x64": "0.131.0",
+                "@oxc-minify/binding-linux-arm-gnueabihf": "0.131.0",
+                "@oxc-minify/binding-linux-arm-musleabihf": "0.131.0",
+                "@oxc-minify/binding-linux-arm64-gnu": "0.131.0",
+                "@oxc-minify/binding-linux-arm64-musl": "0.131.0",
+                "@oxc-minify/binding-linux-ppc64-gnu": "0.131.0",
+                "@oxc-minify/binding-linux-riscv64-gnu": "0.131.0",
+                "@oxc-minify/binding-linux-riscv64-musl": "0.131.0",
+                "@oxc-minify/binding-linux-s390x-gnu": "0.131.0",
+                "@oxc-minify/binding-linux-x64-gnu": "0.131.0",
+                "@oxc-minify/binding-linux-x64-musl": "0.131.0",
+                "@oxc-minify/binding-openharmony-arm64": "0.131.0",
+                "@oxc-minify/binding-wasm32-wasi": "0.131.0",
+                "@oxc-minify/binding-win32-arm64-msvc": "0.131.0",
+                "@oxc-minify/binding-win32-ia32-msvc": "0.131.0",
+                "@oxc-minify/binding-win32-x64-msvc": "0.131.0"
             }
         },
         "node_modules/oxc-parser": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.128.0.tgz",
-            "integrity": "sha512-XkOw3eiIxAgQ19WRew/Bq9wc5Ga/guaWIzDBzq80z1PyuDNGvWBpPby9k6YGwV8A8uMw+Nlq3xqlzuDYmUFYUw==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.131.0.tgz",
+            "integrity": "sha512-SJ3/7ZPbgie8dr5Z9BI/M51zZbpXba+hRSG0MDzVwMW5CRQg2fjYE0jHGlLX4eeiibGgC/mzoDFKSDHwVZEHRQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "^0.128.0"
+                "@oxc-project/types": "^0.131.0"
             },
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
@@ -13379,32 +13527,32 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxc-parser/binding-android-arm-eabi": "0.128.0",
-                "@oxc-parser/binding-android-arm64": "0.128.0",
-                "@oxc-parser/binding-darwin-arm64": "0.128.0",
-                "@oxc-parser/binding-darwin-x64": "0.128.0",
-                "@oxc-parser/binding-freebsd-x64": "0.128.0",
-                "@oxc-parser/binding-linux-arm-gnueabihf": "0.128.0",
-                "@oxc-parser/binding-linux-arm-musleabihf": "0.128.0",
-                "@oxc-parser/binding-linux-arm64-gnu": "0.128.0",
-                "@oxc-parser/binding-linux-arm64-musl": "0.128.0",
-                "@oxc-parser/binding-linux-ppc64-gnu": "0.128.0",
-                "@oxc-parser/binding-linux-riscv64-gnu": "0.128.0",
-                "@oxc-parser/binding-linux-riscv64-musl": "0.128.0",
-                "@oxc-parser/binding-linux-s390x-gnu": "0.128.0",
-                "@oxc-parser/binding-linux-x64-gnu": "0.128.0",
-                "@oxc-parser/binding-linux-x64-musl": "0.128.0",
-                "@oxc-parser/binding-openharmony-arm64": "0.128.0",
-                "@oxc-parser/binding-wasm32-wasi": "0.128.0",
-                "@oxc-parser/binding-win32-arm64-msvc": "0.128.0",
-                "@oxc-parser/binding-win32-ia32-msvc": "0.128.0",
-                "@oxc-parser/binding-win32-x64-msvc": "0.128.0"
+                "@oxc-parser/binding-android-arm-eabi": "0.131.0",
+                "@oxc-parser/binding-android-arm64": "0.131.0",
+                "@oxc-parser/binding-darwin-arm64": "0.131.0",
+                "@oxc-parser/binding-darwin-x64": "0.131.0",
+                "@oxc-parser/binding-freebsd-x64": "0.131.0",
+                "@oxc-parser/binding-linux-arm-gnueabihf": "0.131.0",
+                "@oxc-parser/binding-linux-arm-musleabihf": "0.131.0",
+                "@oxc-parser/binding-linux-arm64-gnu": "0.131.0",
+                "@oxc-parser/binding-linux-arm64-musl": "0.131.0",
+                "@oxc-parser/binding-linux-ppc64-gnu": "0.131.0",
+                "@oxc-parser/binding-linux-riscv64-gnu": "0.131.0",
+                "@oxc-parser/binding-linux-riscv64-musl": "0.131.0",
+                "@oxc-parser/binding-linux-s390x-gnu": "0.131.0",
+                "@oxc-parser/binding-linux-x64-gnu": "0.131.0",
+                "@oxc-parser/binding-linux-x64-musl": "0.131.0",
+                "@oxc-parser/binding-openharmony-arm64": "0.131.0",
+                "@oxc-parser/binding-wasm32-wasi": "0.131.0",
+                "@oxc-parser/binding-win32-arm64-msvc": "0.131.0",
+                "@oxc-parser/binding-win32-ia32-msvc": "0.131.0",
+                "@oxc-parser/binding-win32-x64-msvc": "0.131.0"
             }
         },
         "node_modules/oxc-transform": {
-            "version": "0.128.0",
-            "resolved": "https://registry.npmjs.org/oxc-transform/-/oxc-transform-0.128.0.tgz",
-            "integrity": "sha512-8DfEHlmUiLOHlCK9DGX+d5tORc1xwPPvoRSHSJCYgLHyGjKp4PvfBrvgi59DkEW0SMOWfO8GL9t+R7vdKtupbg==",
+            "version": "0.131.0",
+            "resolved": "https://registry.npmjs.org/oxc-transform/-/oxc-transform-0.131.0.tgz",
+            "integrity": "sha512-ml0/elXPNnDnuHo3VHmEMN2fnybmKx7YL+0E+gMQ0fuHRZHXYJzF6YJ01KsCWg6FXY6pbZcjm7DC3xwGHnB/BA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -13414,39 +13562,48 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxc-transform/binding-android-arm-eabi": "0.128.0",
-                "@oxc-transform/binding-android-arm64": "0.128.0",
-                "@oxc-transform/binding-darwin-arm64": "0.128.0",
-                "@oxc-transform/binding-darwin-x64": "0.128.0",
-                "@oxc-transform/binding-freebsd-x64": "0.128.0",
-                "@oxc-transform/binding-linux-arm-gnueabihf": "0.128.0",
-                "@oxc-transform/binding-linux-arm-musleabihf": "0.128.0",
-                "@oxc-transform/binding-linux-arm64-gnu": "0.128.0",
-                "@oxc-transform/binding-linux-arm64-musl": "0.128.0",
-                "@oxc-transform/binding-linux-ppc64-gnu": "0.128.0",
-                "@oxc-transform/binding-linux-riscv64-gnu": "0.128.0",
-                "@oxc-transform/binding-linux-riscv64-musl": "0.128.0",
-                "@oxc-transform/binding-linux-s390x-gnu": "0.128.0",
-                "@oxc-transform/binding-linux-x64-gnu": "0.128.0",
-                "@oxc-transform/binding-linux-x64-musl": "0.128.0",
-                "@oxc-transform/binding-openharmony-arm64": "0.128.0",
-                "@oxc-transform/binding-wasm32-wasi": "0.128.0",
-                "@oxc-transform/binding-win32-arm64-msvc": "0.128.0",
-                "@oxc-transform/binding-win32-ia32-msvc": "0.128.0",
-                "@oxc-transform/binding-win32-x64-msvc": "0.128.0"
+                "@oxc-transform/binding-android-arm-eabi": "0.131.0",
+                "@oxc-transform/binding-android-arm64": "0.131.0",
+                "@oxc-transform/binding-darwin-arm64": "0.131.0",
+                "@oxc-transform/binding-darwin-x64": "0.131.0",
+                "@oxc-transform/binding-freebsd-x64": "0.131.0",
+                "@oxc-transform/binding-linux-arm-gnueabihf": "0.131.0",
+                "@oxc-transform/binding-linux-arm-musleabihf": "0.131.0",
+                "@oxc-transform/binding-linux-arm64-gnu": "0.131.0",
+                "@oxc-transform/binding-linux-arm64-musl": "0.131.0",
+                "@oxc-transform/binding-linux-ppc64-gnu": "0.131.0",
+                "@oxc-transform/binding-linux-riscv64-gnu": "0.131.0",
+                "@oxc-transform/binding-linux-riscv64-musl": "0.131.0",
+                "@oxc-transform/binding-linux-s390x-gnu": "0.131.0",
+                "@oxc-transform/binding-linux-x64-gnu": "0.131.0",
+                "@oxc-transform/binding-linux-x64-musl": "0.131.0",
+                "@oxc-transform/binding-openharmony-arm64": "0.131.0",
+                "@oxc-transform/binding-wasm32-wasi": "0.131.0",
+                "@oxc-transform/binding-win32-arm64-msvc": "0.131.0",
+                "@oxc-transform/binding-win32-ia32-msvc": "0.131.0",
+                "@oxc-transform/binding-win32-x64-msvc": "0.131.0"
             }
         },
         "node_modules/oxc-walker": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/oxc-walker/-/oxc-walker-0.7.0.tgz",
-            "integrity": "sha512-54B4KUhrzbzc4sKvKwVYm7E2PgeROpGba0/2nlNZMqfDyca+yOor5IMb4WLGBatGDT0nkzYdYuzylg7n3YfB7A==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/oxc-walker/-/oxc-walker-1.0.0.tgz",
+            "integrity": "sha512-eMsHflAGfOskpWxtp9xP/f5b96XLEU8ifTd2gOOCkdux9HMxKGy5S1ru0Gh1B3aPu+YbfmWUUVkcb7MrZz3XyQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "magic-regexp": "^0.10.0"
+                "magic-regexp": "^0.11.0"
             },
             "peerDependencies": {
-                "oxc-parser": ">=0.98.0"
+                "oxc-parser": ">=0.98.0",
+                "rolldown": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "oxc-parser": {
+                    "optional": true
+                },
+                "rolldown": {
+                    "optional": true
+                }
             }
         },
         "node_modules/p-finally": {
@@ -13727,9 +13884,9 @@
             }
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "11.3.6",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-            "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+            "version": "11.4.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+            "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -15338,9 +15495,9 @@
             "license": "MIT"
         },
         "node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -15653,9 +15810,9 @@
             }
         },
         "node_modules/smob": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.1.tgz",
-            "integrity": "sha512-KAkBqZl3c2GvNgNhcoyJae1aKldDW0LO279wF9bk1PnluRTETKBq0WyzRXxEhoQLk56yHaOY4JCBEKDuJIET5g==",
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.2.tgz",
+            "integrity": "sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -16186,9 +16343,9 @@
             }
         },
         "node_modules/tar": {
-            "version": "7.5.14",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.14.tgz",
-            "integrity": "sha512-/7sHKgQO3JLP9ESlwTYUUftHUadOURUqq23xs1vjcnp8Vss6k0wCfzulyEtk5g91pjvnuriimGlyG7k6msrzRw==",
+            "version": "7.5.15",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+            "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -16340,9 +16497,9 @@
             }
         },
         "node_modules/tinyexec": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-            "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+            "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -16702,9 +16859,9 @@
             }
         },
         "node_modules/unhead": {
-            "version": "2.1.13",
-            "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.1.13.tgz",
-            "integrity": "sha512-jO9M1sI6b2h/1KpIu4Jeu+ptumLmUKboRRLxys5pYHFeT+lqTzfNHbYUX9bxVDhC1FBszAGuWcUVlmvIPsah8Q==",
+            "version": "2.1.15",
+            "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.1.15.tgz",
+            "integrity": "sha512-MCt5T90mCWyr3Z6pUCdM9lVRXoMoVBlL7z7U4CYVIiaDiuzad/UCfLuMqz5MeNmpZUgoBCQnrucJimU7EZR+XA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -16735,9 +16892,9 @@
             }
         },
         "node_modules/unimport": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/unimport/-/unimport-6.2.0.tgz",
-            "integrity": "sha512-4NcqaphAHQff4eBWQ3pjVOCYNLlmVGGMoLDmboobh8+OQe9yP7UyeoMP043M1bG0YNc3CqtukD2VuINxOqm4rQ==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/unimport/-/unimport-6.3.0.tgz",
+            "integrity": "sha512-M+Dxk5W9WRd+8j56W9tp8lGW/dmMc7g5zj7BWQnEjKQhryBstqsi1V0izb0zHwSkEN8cSYV7K75/bykairV2tA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -16760,10 +16917,14 @@
                 "node": ">=18.12.0"
             },
             "peerDependencies": {
-                "oxc-parser": "*"
+                "oxc-parser": "*",
+                "rolldown": "^1.0.0"
             },
             "peerDependenciesMeta": {
                 "oxc-parser": {
+                    "optional": true
+                },
+                "rolldown": {
                     "optional": true
                 }
             }
@@ -17029,9 +17190,9 @@
             }
         },
         "node_modules/unstorage/node_modules/lru-cache": {
-            "version": "11.3.6",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-            "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+            "version": "11.4.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+            "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -17219,9 +17380,9 @@
             "license": "MIT"
         },
         "node_modules/vite": {
-            "version": "7.3.2",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-            "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+            "version": "7.3.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+            "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -17532,95 +17693,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/vue-router": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.0.6.tgz",
-            "integrity": "sha512-9+kmUTGbKMyW9Asoy98IXXYIzrTMT7JDAdpDDeEkorHvybpUvBI2wsrSM5jFOXrFydpzRFJ9vAh+80DN2PGu9w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/generator": "^7.28.6",
-                "@vue-macros/common": "^3.1.1",
-                "@vue/devtools-api": "^8.0.6",
-                "ast-walker-scope": "^0.8.3",
-                "chokidar": "^5.0.0",
-                "json5": "^2.2.3",
-                "local-pkg": "^1.1.2",
-                "magic-string": "^0.30.21",
-                "mlly": "^1.8.0",
-                "muggle-string": "^0.4.1",
-                "pathe": "^2.0.3",
-                "picomatch": "^4.0.3",
-                "scule": "^1.3.0",
-                "tinyglobby": "^0.2.15",
-                "unplugin": "^3.0.0",
-                "unplugin-utils": "^0.3.1",
-                "yaml": "^2.8.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/posva"
-            },
-            "peerDependencies": {
-                "@pinia/colada": ">=0.21.2",
-                "@vue/compiler-sfc": "^3.5.17",
-                "pinia": "^3.0.4",
-                "vue": "^3.5.0"
-            },
-            "peerDependenciesMeta": {
-                "@pinia/colada": {
-                    "optional": true
-                },
-                "@vue/compiler-sfc": {
-                    "optional": true
-                },
-                "pinia": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/vue-router/node_modules/chokidar": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-            "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "readdirp": "^5.0.0"
-            },
-            "engines": {
-                "node": ">= 20.19.0"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/vue-router/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/vue-router/node_modules/readdirp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-            "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 20.19.0"
-            },
-            "funding": {
-                "type": "individual",
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
         "node_modules/webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -17738,9 +17810,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.19.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-            "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+            "version": "8.20.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+            "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -17894,13 +17966,6 @@
                 "@poppinss/exception": "^1.2.2",
                 "error-stack-parser-es": "^1.0.5"
             }
-        },
-        "node_modules/youch/node_modules/cookie-es": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
-            "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/zip-stream": {
             "version": "6.0.1",


### PR DESCRIPTION

Fixes three security vulnerabilities detected by Trivy that pre-existed on `main` before the nuxt privacy policy migration PR.

- **CVE-2026-42570** (HIGH): `devalue` 5.8.0 → 5.8.1 — DoS via sparse array deserialization
- **CVE-2026-45149** (MEDIUM): `brace-expansion` 5.0.5 → 5.0.6 — DoS via large numeric range
- **CVE-2026-45736** (MEDIUM): `ws` 8.19.0 → 8.20.1 — WebSocket vulnerability

## Related Issue(s)

https://github.com/FlowFuse/website/pull/4984

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

