### PR TITLE
Fix: Exclude generated dirs from Nuxt dev watcher

### DIFF
--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -37,6 +37,13 @@ export default defineNuxtConfig({
         }
     },
 
+    // public/ (11ty static output) and .output/ (nuxt build) are large generated
+    // directory trees. On macOS, chokidar falls back to kqueue which opens file
+    // descriptors for each watched path, causing spawn EBADF when esbuild tries
+    // to start its service process.
+
+    ignore: ['public/**', '.output/**'],
+
     // Dev proxying to 11ty is handled by server/middleware/legacy.ts
     // to allow per-route exclusions as pages are migrated.
 })


### PR DESCRIPTION
## Description

Running `npm run build:nuxt` locally populates `public/` (11ty static output) and `.output/` (Nuxt build output). Chokidar includes both in its watcher by default, but neither is needed for dev.

On macOS, with both dirs present, the process FD count gets high enough to cause `spawn EBADF` when esbuild tries to start its service process.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

