### PR TITLE
Add warning to README about cleaning Nuxt build output before dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ This starts three watchers concurrently:
 
 **Note**: the first time running this, 11ty may take a little while to process all images in the `/docs` and `/handbook` folders.
 
+**Note**: if you have previously run `npm run build:nuxt`, clean the generated directories before starting dev or you will get a `spawn EBADF` error:
+
+```bash
+npm run clean:nuxt
+```
+
 ### Legacy-only mode
 
 To run just the legacy 11ty stack (equivalent to the old `npm start`):


### PR DESCRIPTION
## Description

Running `npm run build:nuxt` locally populates `nuxt/public/` and  `nuxt/.output/` with the full static build output. Starting `npm run dev`  afterwards causes a `spawn EBADF` error on macOS because Nitro serves those stale files as static assets, opening thousands of file descriptors simultaneously.

This PR documents the fix: run `npm run clean:nuxt` before `npm run dev` after a production build.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

