### PR TITLE
Truncate blog card excerpts and strip markdown formatting

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -17,6 +17,7 @@ const spacetime = require("spacetime");
 const { minify } = require("terser");
 const codeowners = require('codeowners');
 const pluginTOC = require('eleventy-plugin-toc');
+const { decodeHTML } = require('entities');
 const imageHandler = require('./lib/image-handler.js')
 const site = require("./src/_data/site");
 const coreNodeDoc = require("./lib/core-node-docs.js");
@@ -516,6 +517,10 @@ module.exports = function(eleventyConfig) {
         return text.split(" ").splice(0, maxWordCount).join(" ") + "..."
     });
 
+
+    eleventyConfig.addFilter("striptags", function(text) {
+        return decodeHTML(String(text).replace(/<[^>]+>/g, ""));
+    });
 
     eleventyConfig.addFilter("restoreParagraphs", function(str) {
         const content = new String(str);

--- a/src/_includes/blog/blog-posts.njk
+++ b/src/_includes/blog/blog-posts.njk
@@ -50,7 +50,8 @@
             <h2 class="mt-1 mb-0 text-xl font-medium group-hover:underline">{{ item.data.title }}</h2>
         </div>
         <div class="text-sm prose prose-blue md:prose-md py-1">
-            {% include "summary.njk" %}
+            {% set summary = item.data.excerpt or item.data.description or item.data.meta.description %}
+            {% if summary %}{{ summary | md | striptags | truncate(20) }}{% endif %}
         </div>
         <div class="italic text-xs mb-3">
             <div class="author">


### PR DESCRIPTION
## Summary

- Truncates small blog card excerpts to 20 words so cards stay uniform in height
- Strips markdown formatting (bold, italics) and decodes HTML entities for plain-text display
- Featured/hero post is unaffected — still renders the full excerpt with formatting
- Adds a `striptags` Eleventy filter backed by the `entities` library to cover all HTML entities (not just the common handful)

## Test plan

- [ ] Visit `/blog` and confirm small cards show short, plain-text excerpts
- [ ] Confirm the featured post at the top still renders its full excerpt
- [ ] Check a post whose description contains bold/italics — should appear as plain text in the card
- [ ] Check a post whose description contains quotes (`"`) — should display as `"` not `&quot;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)