### PR TITLE
Add Swan AI to cookie banner and fix autoClear gaps

### DIFF
--- a/src/js/cookieconsent-config.js
+++ b/src/js/cookieconsent-config.js
@@ -204,12 +204,24 @@ CookieConsent.run({
                     },
                     {
                         name: /^warmly_/
+                    },
+                    {
+                        name: /^_lc2_/
                     }
                 ],
                 reloadPage: false
             }
         },
-        ads: {}
+        ads: {
+            autoClear: {
+                cookies: [
+                    {
+                        name: /^(_li_dcdm_c|_li_ss|li_sugr|lidc|bcookie|bscookie|UserMatchHistory)$/
+                    }
+                ],
+                reloadPage: false
+            }
+        }
     },
     
     language: {
@@ -248,7 +260,7 @@ CookieConsent.run({
                         },
                         {
                             title: "Analytics Cookies",
-                            description: "We use tools including Google Analytics, HubSpot tracking, PostHog, and warmly.ai to understand how visitors interact with our website. This category enables HubSpot tracking, meeting embeds, and the chat widget.",
+                            description: "We use tools including Google Analytics, HubSpot tracking, PostHog, warmly.ai, and Swan AI to understand how visitors interact with our website. This category enables HubSpot tracking, meeting embeds, and the chat widget.",
                             linkedCategory: "analytics"
                         },
                         {


### PR DESCRIPTION
## Summary

- Swan AI tag is already live in GTM (configured under `analytics_storage` consent, with `FF Consent Update` trigger)
- Updates the cookie preferences modal to list Swan AI alongside GA, HubSpot, PostHog, and Warmly in the Analytics Cookies description
- Adds `_lc2_` to analytics `autoClear` — Swan AI sets `_lc2_fpi` / `_lc2_fpi_js` cookies (confirmed via Tag Assistant)
- Adds `autoClear` to the `ads` category for LinkedIn Insight Tag cookies (`_li_dcdm_c`, `_li_ss`, etc.) — previously missing, so LinkedIn cookies were not cleaned up on consent withdrawal

## Test plan (in production, after the PR is merged)

- [ ] Accept analytics cookies only → confirm GA4, Warmly, and Swan AI tags fire in Tag Assistant; LinkedIn and Google Ads remain blocked
- [ ] Reject all cookies → confirm `_lc2_fpi`, `_li_dcdm_c`, `_li_ss` are cleared from browser storage
- [ ] Check preferences modal → "Analytics Cookies" section lists Swan AI

Closes #5043

🤖 Generated with [Claude Code](https://claude.com/claude-code)