### PR TITLE
Fix link checker: check combined Nuxt+11ty output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,3 +51,7 @@ jobs:
       - name: Build the forge
         run: npm run build:nuxt:skip-images
         working-directory: 'website'
+      - name: Check links
+        uses: untitaker/hyperlink@fb5bb9c5011a3d143a54b4b30aedc30ec5bc0f89 # 0.2.0
+        with:
+          args: website/nuxt/.output/public/ --check-anchors --sources website/src


### PR DESCRIPTION
## Summary

- Adds `untitaker/hyperlink` to the website CI (`test.yml`) pointing to `nuxt/.output/public/`, which contains the full combined output of both 11ty and Nuxt pages
- Previously, `untitaker/hyperlink` was removed in #4984 and replaced with `nuxt-link-checker`, but investigation showed `nuxt-link-checker` as configured only checks 2 pages (`/terms` and `/privacy-policy`) and skips links to 11ty pages entirely
- This restores full link coverage across the entire site

## Context

As part of the Nuxt migration, `privacy-policy` was moved to Nuxt, so it no longer exists in the 11ty `_site/` output. This caused a false positive in the `flowfuse` repo CI ([PR #7328](https://github.com/FlowFuse/flowfuse/pull/7328)) and led to the removal of `untitaker/hyperlink` from the website CI — leaving no effective link checking in place.

`--sources` only accepts a single value, so it's set to `src/` (11ty sources). For broken links originating in Nuxt pages, the error will point to the generated HTML file in `nuxt/.output/public/` rather than the source `.vue` file — but all broken links across the full site are still detected regardless.

Once the Nuxt migration is complete and all pages are served by Nuxt, we'll evaluate whether `untitaker/hyperlink` is still needed or can be replaced entirely by `nuxt-link-checker`.

## Test plan

- [x] CI passes with 0 link errors on this PR
- [x] Intentionally breaking a link in a source file causes the check to fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)