### PR TITLE
Industries + Use Cases sections + Expert dock (skeleton scaffold)

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -221,6 +221,8 @@ module.exports = function(eleventyConfig) {
     eleventyConfig.addLayoutAlias('page', 'layouts/page.njk');
     eleventyConfig.addLayoutAlias('nohero', 'layouts/nohero.njk');
     eleventyConfig.addLayoutAlias('solution', 'layouts/solution.njk');
+    eleventyConfig.addLayoutAlias('industry', 'layouts/industry.njk');
+    eleventyConfig.addLayoutAlias('use-case', 'layouts/use-case.njk');
     eleventyConfig.addLayoutAlias('catalog', 'layouts/catalog.njk');
     eleventyConfig.addLayoutAlias('redirect', 'layouts/redirect.njk');
 

--- a/src/_includes/components/expert-dock.njk
+++ b/src/_includes/components/expert-dock.njk
@@ -1,0 +1,81 @@
+{# ============================================================
+   FLOATING FLOWFUSE EXPERT DOCK (use case pages only)
+   A fixed, floating widget that hovers above the page content with a
+   margin from the left/right/bottom edges, rounded corners and a drop
+   shadow (it does not span edge to edge). It reuses the EXISTING AI
+   Expert experience: the bar contains the same entry point used on
+   /ai/ (the "Describe your workflow" textarea + #tell-me-how-btn), and
+   includes the shared ai-expert-modal component. No chat engine is
+   duplicated here.
+
+   The outer wrapper is transparent and click-through (pointer-events-none)
+   so the gutters either side of the floating card never block the page;
+   the inner card re-enables pointer events.
+   ============================================================ #}
+{% set dockSlug = page.fileSlug %}
+
+<div id="expert-dock"
+     role="region"
+     aria-label="Ask the FlowFuse Expert"
+     class="fixed inset-x-4 bottom-4 sm:bottom-6 z-40 pointer-events-none">
+    <div class="max-w-screen-xl mx-auto pointer-events-auto rounded-2xl border border-indigo-100 bg-white/95 backdrop-blur shadow-[0_12px_40px_-10px_rgba(49,46,129,0.45)] px-4 sm:px-6 py-3 flex items-center gap-3">
+        <div class="hidden sm:flex items-center gap-2 flex-shrink-0">
+            <div class="w-24 h-6">{% include "components/flowfuse-wordmark.njk" %}</div>
+            <span class="text-sm font-semibold text-gray-700">Expert</span>
+        </div>
+        <div class="textarea-wrapper relative flex-1 min-w-0">
+            <textarea
+                aria-label="Describe your workflow"
+                rows="1"
+                placeholder="Ask the FlowFuse Expert about {{ title }}..."
+                class="w-full resize-none bg-gray-50 border border-gray-300 rounded-full py-2.5 px-4 pr-4 text-sm text-gray-700 placeholder-gray-400 focus:outline-none focus:border-indigo-500 h-11 leading-6 overflow-hidden"></textarea>
+        </div>
+        <button id="tell-me-how-btn"
+                class="ff-btn ff-btn--highlight uppercase whitespace-nowrap px-5 py-2.5 flex-shrink-0"
+                onclick="if(typeof capture === 'function') capture('cta-expert-dock', {'usecase': '{{ dockSlug }}'})">
+            Ask
+        </button>
+        <button id="expert-dock-dismiss"
+                type="button"
+                aria-label="Dismiss the FlowFuse Expert"
+                class="flex-shrink-0 w-9 h-9 flex items-center justify-center rounded-full text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors">
+            <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+        </button>
+    </div>
+</div>
+
+{# Shared AI Expert modal (same entry point as /ai/). #}
+{% include "components/ai-expert-modal.njk" %}
+
+<script>
+(function () {
+    var dock = document.getElementById('expert-dock');
+    var dismiss = document.getElementById('expert-dock-dismiss');
+    if (!dock || !dismiss) return;
+
+    function hideDock() {
+        dock.style.display = 'none';
+        // Return focus to the body in a predictable place for keyboard users.
+        var main = document.getElementById('main-content');
+        if (main) {
+            main.setAttribute('tabindex', '-1');
+            main.focus();
+        }
+    }
+
+    dismiss.addEventListener('click', hideDock);
+
+    // ESC dismisses the dock only when the Expert modal is not open
+    // (the modal handles its own ESC/focus-trap behaviour).
+    document.addEventListener('keydown', function (e) {
+        if (e.key !== 'Escape') return;
+        var modal = document.getElementById('ai-expert-modal');
+        var modalOpen = modal && !modal.classList.contains('hidden');
+        if (!modalOpen && dock.style.display !== 'none') {
+            hideDock();
+        }
+    });
+})();
+</script>

--- a/src/_includes/components/related-resources.njk
+++ b/src/_includes/components/related-resources.njk
@@ -1,0 +1,56 @@
+{# ============================================================
+   RELATED RESOURCES (skeleton)
+   Three columns: Case studies / White papers / Blog.
+   Driven by a tag passed in as `relatedTag` (e.g. "industry:food-beverage"
+   or "usecase:track-and-trace"). Resources opt in later by adding that tag;
+   the matching tag collection is then split by section.
+   No existing customer stories are tagged, so every column renders the
+   empty "More coming soon" state.
+   ============================================================ #}
+{% set relatedTag = relatedTag or "" %}
+{% set tagged = collections[relatedTag] or [] %}
+
+{% set caseStudies = [] %}
+{% set whitepapers = [] %}
+{% set blogPosts = [] %}
+{% for item in tagged %}
+    {% if "/customer-stories/" in item.url %}
+        {% set caseStudies = (caseStudies.push(item), caseStudies) %}
+    {% elif "/whitepaper/" in item.url %}
+        {% set whitepapers = (whitepapers.push(item), whitepapers) %}
+    {% elif "/blog/" in item.url %}
+        {% set blogPosts = (blogPosts.push(item), blogPosts) %}
+    {% endif %}
+{% endfor %}
+
+{% set columns = [
+    {heading: "Case studies", items: caseStudies},
+    {heading: "White papers", items: whitepapers},
+    {heading: "Blog", items: blogPosts}
+] %}
+
+<div class="w-full py-16 sm:py-24 px-6 bg-gray-50 border-y border-gray-100">
+    <div class="max-w-screen-lg mx-auto">
+        <h2 class="max-md:text-center">Related resources</h2>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-8 mt-10">
+            {% for column in columns %}
+            <div>
+                <h4 class="text-gray-800 border-b border-gray-200 pb-3 mb-4">{{ column.heading }}</h4>
+                {% if column.items.length %}
+                <ul class="flex flex-col gap-3 list-none p-0 m-0">
+                    {% for item in column.items %}
+                    <li>
+                        <a href="{{ item.url }}" class="text-indigo-600 hover:text-indigo-800">{{ item.data.title }}</a>
+                    </li>
+                    {% endfor %}
+                </ul>
+                {% else %}
+                <div class="rounded-lg border border-dashed border-gray-300 bg-white p-6 text-center">
+                    <p class="m-0 text-gray-400 text-sm">More coming soon</p>
+                </div>
+                {% endif %}
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+</div>

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -270,14 +270,42 @@ eleventyComputed:
                             {% navoption "Why FlowFuse", "/platform/why-flowfuse/", 1, "flowfuse" %}{% endnavoption %}
                         </ul>
                         {% endnavoption %}
+                        {% navoption "Industries", null, 0 %}
+                            <ul class="sm:grid sm:grid-flow-col sm:grid-rows-6 sm:grid-cols-1 sm:pr-9 align-left">
+                                {% navoption "Food & Beverage", "/industries/food-beverage/", 1, "squares-2x2" %}{% endnavoption %}
+                                {% navoption "Pharmaceutical", "/industries/pharmaceutical/", 1, "shield-check" %}{% endnavoption %}
+                                {% navoption "Automotive", "/industries/automotive/", 1, "cog" %}{% endnavoption %}
+                                {% navoption "Aerospace", "/industries/aerospace/", 1, "rocket-launch" %}{% endnavoption %}
+                                {% navoption "Oil & Gas", "/industries/oil-gas/", 1, "power" %}{% endnavoption %}
+                                {% navoption "All industries", "/industries/", 1, "globe-alt" %}{% endnavoption %}
+                            </ul>
+                        {% endnavoption %}
                         {% navoption "Solutions", null, 0 %}
-                            <ul class="sm:grid sm:grid-flow-col sm:grid-rows-3 sm:grid-cols-1 sm:pr-9 align-left">
-                                {% navoption "IT/OT middleware", "/solutions/it-ot-middleware/", 1, "cog" %}{% endnavoption %}
-                                {% navoption "Unified Namespace", "/solutions/uns/", 1, "uns" %}{% endnavoption %}
-                                {% navoption "SCADA", "/solutions/scada/", 1, "adjustments-horizontal" %}{% endnavoption %}
-                                {% navoption "MES", "/solutions/mes/", 1, "chart" %}{% endnavoption %}
-                                {% navoption "Edge Connectivity", "/solutions/edge-connectivity/", 1, "chip" %}{% endnavoption %}
-                                {% navoption "Data integration", "/solutions/data-integration/", 1, "db" %}{% endnavoption %}
+                            <ul class="ff-nav-subgroups sm:grid sm:grid-flow-col sm:auto-cols-max sm:gap-x-8 sm:pr-6 align-left items-stretch">
+                                <li class="!bg-transparent">
+                                    <span class="title block">By architecture</span>
+                                    <ul class="sub-menu">
+                                        {% navoption "IT/OT middleware", "/solutions/it-ot-middleware/", 1, "cog" %}{% endnavoption %}
+                                        {% navoption "Unified Namespace", "/solutions/uns/", 1, "uns" %}{% endnavoption %}
+                                        {% navoption "SCADA", "/solutions/scada/", 1, "adjustments-horizontal" %}{% endnavoption %}
+                                        {% navoption "MES", "/solutions/mes/", 1, "chart" %}{% endnavoption %}
+                                        {% navoption "Edge Connectivity", "/solutions/edge-connectivity/", 1, "chip" %}{% endnavoption %}
+                                        {% navoption "Data integration", "/solutions/data-integration/", 1, "db" %}{% endnavoption %}
+                                    </ul>
+                                </li>
+                                <li class="!bg-transparent ff-nav-subgroup-divider">
+                                    <span class="title block">By use case</span>
+                                    <ul class="sub-menu">
+                                        {% navoption "Production Monitoring & OEE", "/use-cases/production-monitoring-oee/", 1, "chart" %}{% endnavoption %}
+                                        {% navoption "Track and Trace", "/use-cases/track-and-trace/", 1, "point-to-point" %}{% endnavoption %}
+                                        {% navoption "Shop Floor Andon", "/use-cases/shop-floor-andon/", 1, "bell-alert" %}{% endnavoption %}
+                                        {% navoption "Quality Containment & Vision QA", "/use-cases/quality-containment-vision-qa/", 1, "shield-check" %}{% endnavoption %}
+                                        {% navoption "Workforce Allocation", "/use-cases/workforce-allocation/", 1, "user-group" %}{% endnavoption %}
+                                        {% navoption "Continuous Improvement", "/use-cases/continuous-improvement/", 1, "arrow-path" %}{% endnavoption %}
+                                        {% navoption "Controller Monitoring", "/use-cases/controller-monitoring/", 1, "pulse" %}{% endnavoption %}
+                                        {% navoption "All use cases", "/use-cases/", 1, "squares-2x2" %}{% endnavoption %}
+                                    </ul>
+                                </li>
                             </ul>
                         {% endnavoption %}
                         {% navoption "Resources", null, 0 %}

--- a/src/_includes/layouts/industry.njk
+++ b/src/_includes/layouts/industry.njk
@@ -1,0 +1,179 @@
+---
+layout: layouts/base.njk
+sitemapPriority: 0.7
+---
+{# ============================================================
+   INDUSTRY VERTICAL LAYOUT (skeleton)
+   Driven by per-page front-matter so each vertical differs:
+   vertical, tagline, gap[], pillars[], featuredUseCases[], proof[]
+   Placeholder copy only. No customer names anywhere.
+   ============================================================ #}
+{% set verticalName = vertical or title %}
+
+<div class="w-full">
+
+    <!-- ============================================================
+         HERO
+    ============================================================ -->
+    <div class="w-full px-6 bg-[radial-gradient(ellipse_120%_140%_at_50%_-20%,theme(colors.indigo.50)_0%,theme(colors.white)_60%)]">
+        <div class="max-w-screen-lg mx-auto py-16 sm:py-24 text-center">
+            <p class="uppercase tracking-widest text-sm font-semibold text-indigo-500 mb-4">Industries</p>
+            <h1 class="m-auto max-w-3xl font-medium">
+                <span class="text-indigo-600">{{ verticalName }}</span>
+            </h1>
+            <p class="mt-6 max-w-2xl mx-auto text-lg text-gray-600">{{ tagline }}</p>
+            <div class="mt-10 flex flex-wrap gap-4 justify-center">
+                <a class="ff-btn ff-btn--highlight min-h-[40px] uppercase"
+                    href="/contact-us/"
+                    onclick="capture('cta-talk-to-expert', {'position': 'hero', 'industry': '{{ page.fileSlug }}'})">
+                    Talk to an expert
+                </a>
+                <a class="ff-btn ff-btn--primary-outlined min-h-[40px] uppercase flex items-center gap-2"
+                    href="/use-cases/"
+                    onclick="capture('cta-explore-use-cases', {'position': 'hero', 'industry': '{{ page.fileSlug }}'})">
+                    Explore use cases
+                    <span class="w-4 h-4">{% include "components/icons/arrow-right.svg" %}</span>
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <!-- ============================================================
+         THE OPERATIONAL GAP
+    ============================================================ -->
+    <div class="w-full py-16 sm:py-24 px-6 bg-white">
+        <div class="max-w-screen-lg mx-auto">
+            <h2 class="max-md:text-center"><span class="text-red-600">The operational</span> gap</h2>
+            <div class="mt-6 grid grid-cols-1 md:grid-cols-2 gap-8 max-w-4xl">
+                {% for paragraph in gap %}
+                <p class="text-gray-600 m-0">{{ paragraph }}</p>
+                {% endfor %}
+            </div>
+            <p class="mt-8 text-sm text-gray-400 italic">Placeholder copy. Generic operational framing for the {{ verticalName | lower }} vertical.</p>
+        </div>
+    </div>
+
+    <!-- ============================================================
+         HOW FLOWFUSE HELPS (per-vertical pillars from front-matter)
+    ============================================================ -->
+    <div class="w-full bg-[radial-gradient(ellipse_120%_120%_at_50%_120%,theme(colors.indigo.600)_0%,theme(colors.indigo.900)_100%)] py-16 sm:py-24 px-6">
+        <div class="max-w-screen-lg mx-auto">
+            <h2 class="text-white text-center">How FlowFuse helps</h2>
+            <p class="text-indigo-200 text-center max-w-2xl mx-auto mt-4">Turn industrial events into action: Event, Decision, Action.</p>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-12">
+                {% for pillar in pillars %}
+                <div class="rounded-xl border border-indigo-400/40 bg-indigo-950/30 p-6 flex flex-col gap-3">
+                    <div class="w-10 h-10 bg-indigo-50 rounded-full flex items-center justify-center text-indigo-600">
+                        <span class="w-5 h-5">{% include pillar.icon or "components/icons/bolt.svg" %}</span>
+                    </div>
+                    <h4 class="text-white m-0">{{ pillar.title }}</h4>
+                    <p class="text-indigo-100 font-light m-0">{{ pillar.description }}</p>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+
+    <!-- ============================================================
+         FEATURED USE CASES
+    ============================================================ -->
+    <div class="w-full py-16 sm:py-24 px-6 comparison-section-bg">
+        <div class="max-w-screen-lg mx-auto">
+            <div class="flex flex-wrap items-end justify-between gap-4 mb-10">
+                <h2 class="text-indigo-600 m-0">Featured use cases</h2>
+                <a href="/use-cases/" class="text-indigo-600 hover:text-indigo-800 flex items-center gap-2 uppercase text-sm font-semibold">
+                    All use cases
+                    <span class="w-4 h-4">{% include "components/icons/arrow-right.svg" %}</span>
+                </a>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                {% for uc in featuredUseCases %}
+                <a href="{{ uc.url }}" class="group flex flex-col gap-3 rounded-xl border border-white p-5 bg-[linear-gradient(135deg,_theme(colors.white)_0%,_theme(colors.white/10%)_100%)] hover:border-indigo-300 transition-colors">
+                    <h4 class="m-0 text-gray-800 group-hover:text-indigo-600 transition-colors">{{ uc.title }}</h4>
+                    <p class="m-0 text-gray-600 text-sm">{{ uc.description }}</p>
+                    <span class="mt-auto pt-2 text-indigo-600 text-sm font-semibold flex items-center gap-2">
+                        View use case
+                        <span class="w-4 h-4">{% include "components/icons/arrow-right.svg" %}</span>
+                    </span>
+                </a>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+
+    <!-- ============================================================
+         REPRESENTATIVE FOCUS AREAS (outline, same shape per vertical)
+    ============================================================ -->
+    <div class="w-full py-16 sm:py-24 px-6 bg-white">
+        <div class="max-w-screen-lg mx-auto">
+            <h2 class="max-md:text-center">Representative focus areas</h2>
+            <p class="text-gray-500 mt-2">Outline placeholder. The same capability checklist shape is shown for every vertical.</p>
+            <ul class="mt-8 grid grid-cols-1 md:grid-cols-2 gap-x-10 gap-y-4 list-none p-0 m-0">
+                {% set focusAreas = ["Connect OT data sources to IT systems", "Standardize data into a consistent model", "Event-driven orchestration of operational workflows", "Guided operator actions at the point of work", "Repeatable deployment across sites", "Governance, access control and audit"] %}
+                {% for area in focusAreas %}
+                <li class="flex items-start gap-3">
+                    <span class="flex-shrink-0 w-6 h-6 text-indigo-500 mt-0.5">{% include "components/icons/check-circle.svg" %}</span>
+                    <span class="text-gray-700">{{ area }} <span class="text-gray-400">(placeholder)</span></span>
+                </li>
+                {% endfor %}
+            </ul>
+        </div>
+    </div>
+
+    <!-- ============================================================
+         PROOF / OUTCOMES BAND (skeleton scaffold, no names, no numbers)
+    ============================================================ -->
+    <div class="w-full py-16 px-6 bg-gray-50 border-y border-gray-100">
+        <div class="max-w-screen-lg mx-auto text-center">
+            <p class="uppercase tracking-widest text-xs font-semibold text-gray-400 mb-8">Representative outcomes (placeholder)</p>
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-6">
+                {% set proofTiles = proof or [{label: "Outcome metric"}, {label: "Scale metric"}, {label: "Efficiency metric"}, {label: "Reliability metric"}] %}
+                {% for tile in proofTiles %}
+                <div class="rounded-xl bg-white border border-gray-200 p-6 flex flex-col items-center gap-2">
+                    <span class="text-3xl font-semibold text-indigo-300">[ - ]</span>
+                    <span class="text-sm text-gray-500">{{ tile.label }}</span>
+                </div>
+                {% endfor %}
+            </div>
+            <p class="mt-6 text-xs text-gray-400 italic">No customer names, logos, or real figures. Values are placeholders to be populated later.</p>
+        </div>
+    </div>
+
+    <!-- ============================================================
+         RELATED RESOURCES (empty "More coming soon" state)
+    ============================================================ -->
+    {% set relatedTag = "industry:" + page.fileSlug %}
+    {% include "components/related-resources.njk" %}
+
+    <!-- ============================================================
+         EXPERT CTA BAND (non-sticky)
+    ============================================================ -->
+    <div class="w-full px-6 py-12">
+        <div class="ff-blue-card max-md:max-w-xl md:max-w-screen-lg mx-auto pt-10 pb-8 text-center">
+            <h3 class="mb-3 w-full text-center">Have a {{ verticalName | lower }} question?</h3>
+            <p class="text-gray-600 mb-6 max-w-xl mx-auto">Ask the FlowFuse Expert or talk to our team about operationalizing your workflows.</p>
+            <div class="flex justify-center">
+                <a class="ff-btn ff-btn--highlight min-h-[40px] uppercase"
+                    href="/contact-us/"
+                    onclick="capture('cta-talk-to-expert', {'position': 'mid-band', 'industry': '{{ page.fileSlug }}'})">
+                    Talk to an expert
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <!-- ============================================================
+         FOOTER CTA
+    ============================================================ -->
+    <div class="w-full px-6 pb-24">
+        <div class="max-w-screen-lg mx-auto text-center">
+            <h2 class="mb-4">Get started with FlowFuse</h2>
+            <p class="text-gray-600 mb-8 max-w-xl mx-auto">The Industrial Application Platform for building and operationalizing applications at scale.</p>
+            <div class="flex flex-wrap gap-4 justify-center">
+                <a class="ff-btn ff-btn--highlight min-h-[40px] uppercase" href="{% include "sign-up-url.njk" %}" onclick="capture('cta-join', {'position': 'footer', 'industry': '{{ page.fileSlug }}'})">Get started</a>
+                <a class="ff-btn ff-btn--primary-outlined min-h-[40px] uppercase" href="/book-demo/" onclick="capture('cta-book-demo', {'position': 'footer', 'industry': '{{ page.fileSlug }}'})">Book a demo</a>
+            </div>
+        </div>
+    </div>
+
+</div>

--- a/src/_includes/layouts/use-case.njk
+++ b/src/_includes/layouts/use-case.njk
@@ -1,0 +1,195 @@
+---
+layout: layouts/base.njk
+sitemapPriority: 0.7
+---
+{# ============================================================
+   USE CASE LAYOUT (skeleton, generic workflow pattern)
+   Per-page front-matter: problem, gap[], workflow[], outcomes[],
+   relatedIndustries[]. Sections 3 and 5 are fixed generic platform
+   positioning. No customer names, no quotes, no real numbers.
+   ============================================================ #}
+
+<div class="w-full">
+
+    <!-- ============================================================
+         HERO
+    ============================================================ -->
+    <div class="w-full px-6 bg-[radial-gradient(ellipse_120%_140%_at_50%_-20%,theme(colors.indigo.50)_0%,theme(colors.white)_60%)]">
+        <div class="max-w-screen-lg mx-auto py-16 sm:py-24 text-center">
+            <p class="uppercase tracking-widest text-sm font-semibold text-indigo-500 mb-4">Use case</p>
+            <h1 class="m-auto max-w-3xl font-medium"><span class="text-indigo-600">{{ title }}</span></h1>
+            <p class="mt-6 max-w-2xl mx-auto text-lg text-gray-600">{{ problem }}</p>
+            <div class="mt-10 flex flex-wrap gap-4 justify-center">
+                <a class="ff-btn ff-btn--highlight min-h-[40px] uppercase" href="/contact-us/" onclick="capture('cta-talk-to-expert', {'position': 'hero', 'usecase': '{{ page.fileSlug }}'})">Talk to an expert</a>
+                <a class="ff-btn ff-btn--primary-outlined min-h-[40px] uppercase flex items-center gap-2" href="/industries/" onclick="capture('cta-explore-industries', {'position': 'hero', 'usecase': '{{ page.fileSlug }}'})">
+                    Explore industries
+                    <span class="w-4 h-4">{% include "components/icons/arrow-right.svg" %}</span>
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <!-- ============================================================
+         1. THE OPERATIONAL GAP
+    ============================================================ -->
+    <div class="w-full py-16 sm:py-24 px-6 bg-white">
+        <div class="max-w-screen-lg mx-auto">
+            <h2 class="max-md:text-center"><span class="text-red-600">The operational</span> gap</h2>
+            <div class="mt-6 grid grid-cols-1 md:grid-cols-2 gap-8 max-w-4xl">
+                {% for paragraph in gap %}
+                <p class="text-gray-600 m-0">{{ paragraph }}</p>
+                {% endfor %}
+            </div>
+            <p class="mt-8 text-sm text-gray-400 italic">Placeholder copy. Generic operational framing for this workflow pattern.</p>
+        </div>
+    </div>
+
+    <!-- ============================================================
+         2. WHY EXISTING SYSTEMS DID NOT SOLVE IT (fixed, generic)
+    ============================================================ -->
+    <div class="w-full py-16 sm:py-24 px-6 bg-gray-50 border-y border-gray-100">
+        <div class="max-w-screen-lg mx-auto">
+            <h2 class="text-center">Why existing systems did not solve it</h2>
+            {% set reasons = [
+                {title: "MES is too rigid", detail: "Fixed workflows are slow and costly to change as operations evolve."},
+                {title: "Dashboards do not act", detail: "Visibility alone does not trigger or coordinate a response."},
+                {title: "Historians store but do not orchestrate", detail: "Data is captured for later, not turned into action in the moment."},
+                {title: "ERP does not execute", detail: "Business systems plan work but do not run the operational workflow."},
+                {title: "AI builds but does not operationalize", detail: "Generated logic still needs governance, deployment and scale."},
+                {title: "Scripts do not scale", detail: "One-off scripts are hard to manage, repeat and roll out across sites."}
+            ] %}
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-12">
+                {% for reason in reasons %}
+                <div class="rounded-xl bg-white border border-gray-200 p-6 flex flex-col gap-2">
+                    <div class="w-8 h-8 text-red-400">{% include "components/icons/x-circle.svg" %}</div>
+                    <h4 class="m-0 text-gray-800">{{ reason.title }}</h4>
+                    <p class="m-0 text-gray-600 text-sm">{{ reason.detail }}</p>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+
+    <!-- ============================================================
+         3. THE OPERATIONAL WORKFLOW (Event, Decision, Action)
+    ============================================================ -->
+    <div class="w-full bg-[radial-gradient(ellipse_120%_120%_at_50%_120%,theme(colors.indigo.600)_0%,theme(colors.indigo.900)_100%)] py-16 sm:py-24 px-6">
+        <div class="max-w-screen-lg mx-auto">
+            <h2 class="text-white text-center">The operational workflow</h2>
+            <p class="text-indigo-200 text-center max-w-2xl mx-auto mt-4">A pattern that turns industrial events into action.</p>
+            {% set steps = [
+                {label: "Event", icon: "components/icons/bolt.svg", detail: "An industrial event triggers the workflow from a machine, sensor, broker or system signal."},
+                {label: "Decision", icon: "components/icons/arrows-right-left.svg", detail: "Event-driven orchestration applies logic, context and rules to decide what should happen."},
+                {label: "Action", icon: "components/icons/cursor-arrow-rays.svg", detail: "Guided operator actions and automated steps carry out the response where work happens."}
+            ] %}
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-12">
+                {% for step in steps %}
+                <div class="rounded-xl border border-indigo-400/40 bg-indigo-950/30 p-6 flex flex-col gap-3">
+                    <div class="flex items-center gap-3">
+                        <div class="w-10 h-10 bg-indigo-50 rounded-full flex items-center justify-center text-indigo-600">
+                            <span class="w-5 h-5">{% include step.icon %}</span>
+                        </div>
+                        <span class="text-indigo-300 text-sm font-semibold uppercase tracking-widest">{{ loop.index }}</span>
+                    </div>
+                    <h4 class="text-white m-0">{{ step.label }}</h4>
+                    <p class="text-indigo-100 font-light m-0">{{ step.detail }}</p>
+                </div>
+                {% endfor %}
+            </div>
+            {% if workflow %}
+            <ul class="mt-10 max-w-3xl mx-auto flex flex-col gap-3 list-none p-0">
+                {% for item in workflow %}
+                <li class="flex items-start gap-3 text-indigo-100">
+                    <span class="flex-shrink-0 w-6 h-6 text-indigo-300 mt-0.5">{% include "components/icons/check.svg" %}</span>
+                    <span>{{ item }}</span>
+                </li>
+                {% endfor %}
+            </ul>
+            {% endif %}
+        </div>
+    </div>
+
+    <!-- ============================================================
+         4. HOW IT IS OPERATIONALIZED WITH FLOWFUSE (generic, no customer)
+    ============================================================ -->
+    <div class="w-full py-16 sm:py-24 px-6 bg-white">
+        <div class="max-w-screen-lg mx-auto">
+            <h2 class="max-md:text-center">How it is operationalized with FlowFuse</h2>
+            <p class="text-gray-500 mt-2">Generic platform capabilities. No named customer or attributed quotes.</p>
+            {% set ops = [
+                {title: "Deployment", detail: "Ship the workflow to cloud, on-premise or edge from one platform."},
+                {title: "Governance", detail: "Keep humans in control with approvals and audit trails."},
+                {title: "Role-based access", detail: "Scope who can view, edit and deploy across teams."},
+                {title: "Version control", detail: "Track changes and roll back safely."},
+                {title: "CI/CD pipelines", detail: "Promote from development to test to production."},
+                {title: "Multi-site rollout", detail: "Roll the same workflow out to every site in a controlled way."},
+                {title: "Reuse", detail: "Package the pattern as a reusable building block."}
+            ] %}
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-x-10 gap-y-5 mt-8">
+                {% for op in ops %}
+                <div class="flex items-start gap-4">
+                    <span class="flex-shrink-0 w-8 h-8 bg-indigo-50 rounded-full flex items-center justify-center text-indigo-600">
+                        <span class="w-4 h-4">{% include "components/icons/check.svg" %}</span>
+                    </span>
+                    <div>
+                        <h5 class="m-0 text-gray-800">{{ op.title }}</h5>
+                        <p class="m-0 text-gray-600 text-sm">{{ op.detail }}</p>
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+
+    <!-- ============================================================
+         5. OUTCOMES (generic placeholder bullets, no client, no numbers)
+    ============================================================ -->
+    <div class="w-full py-16 sm:py-24 px-6 comparison-section-bg">
+        <div class="max-w-screen-lg mx-auto">
+            <h2 class="text-indigo-600 max-md:text-center">Outcomes</h2>
+            <div class="mt-8 flex flex-col gap-4 max-w-3xl">
+                {% for outcome in outcomes %}
+                <div class="bg-white border border-indigo-100 rounded-lg p-5 flex items-center gap-4">
+                    <span class="flex-shrink-0 w-8 h-8 text-indigo-500">{% include "components/icons/arrow-trending-up.svg" %}</span>
+                    <p class="m-0 text-lg font-light text-gray-700">{{ outcome }}</p>
+                </div>
+                {% endfor %}
+            </div>
+            <p class="mt-6 text-xs text-gray-400 italic">Placeholder outcomes. No customer names or real figures.</p>
+        </div>
+    </div>
+
+    <!-- ============================================================
+         6. RELATED INDUSTRIES
+    ============================================================ -->
+    {% if relatedIndustries %}
+    <div class="w-full py-16 px-6 bg-white">
+        <div class="max-w-screen-lg mx-auto">
+            <h2 class="max-md:text-center">Related industries</h2>
+            <div class="mt-8 flex flex-wrap gap-3">
+                {% for ind in relatedIndustries %}
+                <a href="{{ ind.url }}" class="inline-flex items-center gap-2 rounded-full border border-indigo-200 bg-indigo-50 px-4 py-2 text-indigo-700 hover:border-indigo-400 transition-colors">
+                    {{ ind.name }}
+                    <span class="w-4 h-4">{% include "components/icons/arrow-right.svg" %}</span>
+                </a>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
+    <!-- ============================================================
+         7. RELATED RESOURCES (empty "More coming soon" state)
+    ============================================================ -->
+    {% set relatedTag = "usecase:" + page.fileSlug %}
+    {% include "components/related-resources.njk" %}
+
+    <!-- spacer so sticky dock never overlaps the final content -->
+    <div class="w-full h-28"></div>
+
+</div>
+
+<!-- ============================================================
+     STICKY FLOWFUSE EXPERT DOCK (use case pages only)
+============================================================ -->
+{% include "components/expert-dock.njk" %}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -871,6 +871,18 @@ h4:hover .header-anchor::before {
         @apply py-3 pl-3;
     }
 
+    /* Solutions dropdown: two labelled subgroups separated by a single
+       full-height divider. The titles align left with their list items and
+       the divider runs the full height between the columns. */
+    .ff-website header .ff-nav-dropdown ul.ff-nav-subgroups > li > span.title {
+        text-align: left;
+        @apply sm:pl-3 sm:pr-4 sm:pb-1;
+    }
+    .ff-website header .ff-nav-dropdown ul.ff-nav-subgroups > li.ff-nav-subgroup-divider {
+        border-left: 1px solid theme(colors.gray.200);
+        @apply sm:pl-6;
+    }
+
     .ff-website header .ff-nav-dropdown >ul li a .ff-icon--solid {
         fill: theme(colors.gray.700);
     }

--- a/src/industries/aerospace.njk
+++ b/src/industries/aerospace.njk
@@ -1,0 +1,34 @@
+---
+layout: industry
+tags:
+  - industry
+vertical: "Aerospace"
+title: "FlowFuse for Aerospace"
+meta:
+  title: "Aerospace | Industries | FlowFuse"
+  description: "Operationalize traceability, quality and controller monitoring workflows in aerospace operations with FlowFuse. Placeholder skeleton page."
+tagline: "Turn aerospace production events into governed action, with traceability and quality built into the workflow."
+gap:
+  - "Aerospace operations demand exacting traceability and quality, which is hard to sustain when records live across disconnected systems."
+  - "Low-volume, high-mix work makes rigid, one-off automation expensive to build and maintain."
+pillars:
+  - icon: "components/icons/rectangle-stack.svg"
+    title: "Manage aerospace applications at scale"
+    description: "Govern aerospace workflows with the traceability and control these operations require, across every site."
+  - icon: "components/icons/puzzle-piece.svg"
+    title: "Extend and adapt existing aerospace systems"
+    description: "Connect existing aerospace controllers, inspection systems and business systems rather than replacing them."
+  - icon: "components/icons/arrows-right-left.svg"
+    title: "Event-driven orchestration for quality"
+    description: "Trigger a recorded, guided response when an aerospace event requires quality or traceability action."
+featuredUseCases:
+  - title: "Quality Containment & Vision QA"
+    url: "/use-cases/quality-containment-vision-qa/"
+    description: "Detect, contain and record quality events."
+  - title: "Track and Trace"
+    url: "/use-cases/track-and-trace/"
+    description: "Maintain full genealogy across the build."
+  - title: "Controller Monitoring"
+    url: "/use-cases/controller-monitoring/"
+    description: "Watch controller health across the floor."
+---

--- a/src/industries/automotive.njk
+++ b/src/industries/automotive.njk
@@ -1,0 +1,34 @@
+---
+layout: industry
+tags:
+  - industry
+vertical: "Automotive"
+title: "FlowFuse for Automotive"
+meta:
+  title: "Automotive | Industries | FlowFuse"
+  description: "Operationalize line monitoring, andon and workforce workflows in automotive operations with FlowFuse. Placeholder skeleton page."
+tagline: "Turn automotive line events into action, from andon response to line performance, across every cell and plant."
+gap:
+  - "Automotive operations run high-tempo lines where a single stoppage propagates quickly, yet visibility and response are often disconnected."
+  - "Mixed vendors and aging controls make it hard to standardize and roll out changes across cells and plants."
+pillars:
+  - icon: "components/icons/rectangle-stack.svg"
+    title: "Manage automotive applications at scale"
+    description: "Run and govern automotive line applications across cells and plants from a single platform."
+  - icon: "components/icons/puzzle-piece.svg"
+    title: "Extend and adapt existing automotive systems"
+    description: "Connect existing automotive controllers, SCADA and MES instead of ripping and replacing."
+  - icon: "components/icons/arrows-right-left.svg"
+    title: "Event-driven orchestration for the line"
+    description: "Trigger an immediate, guided response when an automotive line event such as an andon call occurs."
+featuredUseCases:
+  - title: "Production Monitoring & OEE"
+    url: "/use-cases/production-monitoring-oee/"
+    description: "Track line performance and act on losses fast."
+  - title: "Shop Floor Andon"
+    url: "/use-cases/shop-floor-andon/"
+    description: "Escalate and resolve line calls without delay."
+  - title: "Workforce Allocation"
+    url: "/use-cases/workforce-allocation/"
+    description: "Direct people to where the line needs them."
+---

--- a/src/industries/food-beverage.njk
+++ b/src/industries/food-beverage.njk
@@ -1,0 +1,34 @@
+---
+layout: industry
+tags:
+  - industry
+vertical: "Food & Beverage"
+title: "FlowFuse for Food & Beverage"
+meta:
+  title: "Food & Beverage | Industries | FlowFuse"
+  description: "Operationalize line monitoring, quality and traceability across food and beverage operations with FlowFuse. Placeholder skeleton page."
+tagline: "Turn events on the food and beverage line into action, from monitoring to traceability, without rebuilding your stack."
+gap:
+  - "Food and beverage operations run across mixed equipment and legacy systems, which makes it hard to see and act on what is happening across every line and site."
+  - "Quality, compliance and changeover pressure add manual work for teams that are already stretched."
+pillars:
+  - icon: "components/icons/rectangle-stack.svg"
+    title: "Manage food and beverage applications at scale"
+    description: "Run and govern line monitoring and quality applications across every food and beverage site from one platform."
+  - icon: "components/icons/puzzle-piece.svg"
+    title: "Extend and adapt existing food and beverage systems"
+    description: "Connect existing PLCs, SCADA and business systems on the food and beverage floor instead of replacing them."
+  - icon: "components/icons/arrows-right-left.svg"
+    title: "Event-driven orchestration for the line"
+    description: "Trigger guided responses when a food and beverage event occurs, from a stoppage to a quality hold."
+featuredUseCases:
+  - title: "Production Monitoring & OEE"
+    url: "/use-cases/production-monitoring-oee/"
+    description: "See line performance and act on losses as they happen."
+  - title: "Track and Trace"
+    url: "/use-cases/track-and-trace/"
+    description: "Follow material and product through every step."
+  - title: "Quality Containment & Vision QA"
+    url: "/use-cases/quality-containment-vision-qa/"
+    description: "Catch and contain quality issues before they spread."
+---

--- a/src/industries/index.njk
+++ b/src/industries/index.njk
@@ -1,0 +1,61 @@
+---
+layout: layouts/base.njk
+sitemapPriority: 0.8
+title: "Industries"
+meta:
+  title: "Industries | FlowFuse"
+  description: "FlowFuse for industrial verticals. Operationalize applications at scale across your industry. Placeholder skeleton hub."
+---
+<div class="w-full">
+
+    <!-- HERO with CTA buttons -->
+    <div class="w-full px-6 bg-[radial-gradient(ellipse_120%_140%_at_50%_-20%,theme(colors.indigo.50)_0%,theme(colors.white)_60%)]">
+        <div class="max-w-screen-lg mx-auto py-16 sm:py-24 text-center">
+            <p class="uppercase tracking-widest text-sm font-semibold text-indigo-500 mb-4">Industries</p>
+            <h1 class="m-auto max-w-3xl font-medium">FlowFuse across <span class="text-indigo-600">industrial verticals</span></h1>
+            <p class="mt-6 max-w-2xl mx-auto text-lg text-gray-600">Building industrial applications is easy. Operationalizing them at scale is hard. Explore how FlowFuse helps in your industry.</p>
+            <div class="mt-10 flex flex-wrap gap-4 justify-center">
+                <a class="ff-btn ff-btn--highlight min-h-[40px] uppercase" href="/contact-us/" onclick="capture('cta-talk-to-expert', {'position': 'hero', 'page': 'industries-hub'})">Talk to an expert</a>
+                <a class="ff-btn ff-btn--primary-outlined min-h-[40px] uppercase flex items-center gap-2" href="/use-cases/" onclick="capture('cta-explore-use-cases', {'position': 'hero', 'page': 'industries-hub'})">
+                    Explore use cases
+                    <span class="w-4 h-4">{% include "components/icons/arrow-right.svg" %}</span>
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <!-- VERTICAL CARD GRID -->
+    <div class="w-full py-16 sm:py-24 px-6 bg-white">
+        <div class="max-w-screen-lg mx-auto">
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                {% for industry in collections.industry | sort(false, true, "data.vertical") %}
+                <a href="{{ industry.url }}" class="group flex flex-col gap-3 rounded-xl border border-gray-200 p-6 bg-white hover:border-indigo-300 hover:shadow-sm transition-all">
+                    <h3 class="m-0 text-gray-800 group-hover:text-indigo-600 transition-colors">{{ industry.data.vertical }}</h3>
+                    <p class="m-0 text-gray-600 text-sm flex-grow">{{ industry.data.tagline }}</p>
+                    <span class="mt-2 text-indigo-600 text-sm font-semibold flex items-center gap-2">
+                        View industry
+                        <span class="w-4 h-4">{% include "components/icons/arrow-right.svg" %}</span>
+                    </span>
+                </a>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+
+    <!-- RESOURCES BLOCK PLACEHOLDER -->
+    {% set relatedTag = "" %}
+    {% include "components/related-resources.njk" %}
+
+    <!-- CLOSING CTA BAND -->
+    <div class="w-full px-6 py-20">
+        <div class="ff-blue-card max-md:max-w-xl md:max-w-screen-lg mx-auto pt-12 pb-10 text-center">
+            <h3 class="mb-4 w-full text-center">Ready to operationalize at scale?</h3>
+            <p class="text-gray-600 mb-8 max-w-xl mx-auto">Talk to an expert about your industry, or get started with FlowFuse today.</p>
+            <div class="flex flex-wrap gap-4 justify-center">
+                <a class="ff-btn ff-btn--highlight min-h-[40px] uppercase" href="/contact-us/" onclick="capture('cta-talk-to-expert', {'position': 'footer', 'page': 'industries-hub'})">Talk to an expert</a>
+                <a class="ff-btn ff-btn--primary-outlined min-h-[40px] uppercase" href="{% include "sign-up-url.njk" %}" onclick="capture('cta-join', {'position': 'footer', 'page': 'industries-hub'})">Get started</a>
+            </div>
+        </div>
+    </div>
+
+</div>

--- a/src/industries/oil-gas.njk
+++ b/src/industries/oil-gas.njk
@@ -1,0 +1,34 @@
+---
+layout: industry
+tags:
+  - industry
+vertical: "Oil & Gas"
+title: "FlowFuse for Oil & Gas"
+meta:
+  title: "Oil & Gas | Industries | FlowFuse"
+  description: "Operationalize controller monitoring, production monitoring and improvement workflows in oil and gas operations with FlowFuse. Placeholder skeleton page."
+tagline: "Turn oil and gas operational events into action across distributed assets and sites."
+gap:
+  - "Oil and gas operations span remote, distributed assets where connecting and acting on data across sites is a persistent challenge."
+  - "Legacy controls and many vendors make standardized monitoring and response difficult to roll out at scale."
+pillars:
+  - icon: "components/icons/rectangle-stack.svg"
+    title: "Manage oil and gas applications at scale"
+    description: "Run and govern oil and gas monitoring applications across distributed sites from one platform."
+  - icon: "components/icons/puzzle-piece.svg"
+    title: "Extend and adapt existing oil and gas systems"
+    description: "Connect existing oil and gas controllers, SCADA and historians instead of replacing field infrastructure."
+  - icon: "components/icons/arrows-right-left.svg"
+    title: "Event-driven orchestration across assets"
+    description: "Trigger a guided response when an oil and gas event occurs at any asset or site."
+featuredUseCases:
+  - title: "Controller Monitoring"
+    url: "/use-cases/controller-monitoring/"
+    description: "Track controller health across distributed assets."
+  - title: "Production Monitoring & OEE"
+    url: "/use-cases/production-monitoring-oee/"
+    description: "See production performance across sites."
+  - title: "Continuous Improvement"
+    url: "/use-cases/continuous-improvement/"
+    description: "Turn operational insight into rollout-ready change."
+---

--- a/src/industries/pharmaceutical.njk
+++ b/src/industries/pharmaceutical.njk
@@ -1,0 +1,34 @@
+---
+layout: industry
+tags:
+  - industry
+vertical: "Pharmaceutical"
+title: "FlowFuse for Pharmaceutical"
+meta:
+  title: "Pharmaceutical | Industries | FlowFuse"
+  description: "Operationalize traceability, quality and compliance workflows in pharmaceutical operations with FlowFuse. Placeholder skeleton page."
+tagline: "Turn pharmaceutical production events into governed action, from batch traceability to quality containment."
+gap:
+  - "Pharmaceutical operations carry heavy traceability and compliance requirements that are hard to satisfy when data is fragmented across systems."
+  - "Validated, rigid systems make change slow, so teams fall back on manual steps and spreadsheets to fill the gaps."
+pillars:
+  - icon: "components/icons/rectangle-stack.svg"
+    title: "Manage pharmaceutical applications at scale"
+    description: "Deploy and govern pharmaceutical workflows consistently across lines and sites with full audit trails."
+  - icon: "components/icons/puzzle-piece.svg"
+    title: "Extend and adapt existing pharmaceutical systems"
+    description: "Connect existing pharmaceutical equipment, historians and business systems rather than replacing validated infrastructure."
+  - icon: "components/icons/arrows-right-left.svg"
+    title: "Event-driven orchestration for compliance"
+    description: "Trigger controlled, recorded responses when a pharmaceutical event requires a quality or compliance action."
+featuredUseCases:
+  - title: "Track and Trace"
+    url: "/use-cases/track-and-trace/"
+    description: "Maintain genealogy across the batch and supply chain."
+  - title: "Quality Containment & Vision QA"
+    url: "/use-cases/quality-containment-vision-qa/"
+    description: "Contain quality events with a recorded response."
+  - title: "Continuous Improvement"
+    url: "/use-cases/continuous-improvement/"
+    description: "Close the loop from insight to validated change."
+---

--- a/src/use-cases/continuous-improvement.njk
+++ b/src/use-cases/continuous-improvement.njk
@@ -1,0 +1,28 @@
+---
+layout: use-case
+tags:
+  - use-case
+title: "Continuous Improvement"
+meta:
+  title: "Continuous Improvement | Use Cases | FlowFuse"
+  description: "A generic operational workflow pattern for continuous improvement. Placeholder skeleton page."
+problem: "Improvement ideas are identified but not turned into rolled-out change."
+gap:
+  - "Teams spot opportunities to improve, but moving from insight to a change that runs everywhere is slow and inconsistent."
+  - "Without a repeatable path to rollout, improvements stall as one-off experiments."
+workflow:
+  - "Capture operational signals and improvement ideas."
+  - "Decide which changes are ready to standardize."
+  - "Roll out the change in a controlled, repeatable way."
+outcomes:
+  - "A repeatable path from insight to rollout."
+  - "Changes that reach every relevant site."
+  - "Less drift between improvement and standard work."
+relatedIndustries:
+  - name: "Pharmaceutical"
+    url: "/industries/pharmaceutical/"
+  - name: "Oil & Gas"
+    url: "/industries/oil-gas/"
+  - name: "Automotive"
+    url: "/industries/automotive/"
+---

--- a/src/use-cases/controller-monitoring.njk
+++ b/src/use-cases/controller-monitoring.njk
@@ -1,0 +1,28 @@
+---
+layout: use-case
+tags:
+  - use-case
+title: "Controller Monitoring"
+meta:
+  title: "Controller Monitoring | Use Cases | FlowFuse"
+  description: "A generic operational workflow pattern for controller monitoring. Placeholder skeleton page."
+problem: "Controller health issues are noticed too late to prevent disruption."
+gap:
+  - "Controllers and their connections are critical, but their health is often only checked after something has already gone wrong."
+  - "Without continuous monitoring and a response path, a single failure can disrupt the operation."
+workflow:
+  - "Capture controller status and connection health."
+  - "Detect degradation and decide when to act."
+  - "Guide the response and record the recovery."
+outcomes:
+  - "Earlier detection of controller issues."
+  - "A guided path to recovery."
+  - "A consistent view of controller health across sites."
+relatedIndustries:
+  - name: "Oil & Gas"
+    url: "/industries/oil-gas/"
+  - name: "Aerospace"
+    url: "/industries/aerospace/"
+  - name: "Automotive"
+    url: "/industries/automotive/"
+---

--- a/src/use-cases/index.njk
+++ b/src/use-cases/index.njk
@@ -1,0 +1,61 @@
+---
+layout: layouts/base.njk
+sitemapPriority: 0.8
+title: "Use Cases"
+meta:
+  title: "Use Cases | FlowFuse"
+  description: "Generic operational workflow patterns for industrial teams. Turn events into action with FlowFuse. Placeholder skeleton hub."
+---
+<div class="w-full">
+
+    <!-- HERO with CTA buttons -->
+    <div class="w-full px-6 bg-[radial-gradient(ellipse_120%_140%_at_50%_-20%,theme(colors.indigo.50)_0%,theme(colors.white)_60%)]">
+        <div class="max-w-screen-lg mx-auto py-16 sm:py-24 text-center">
+            <p class="uppercase tracking-widest text-sm font-semibold text-indigo-500 mb-4">Use cases</p>
+            <h1 class="m-auto max-w-3xl font-medium">Turn industrial events into <span class="text-indigo-600">action</span></h1>
+            <p class="mt-6 max-w-2xl mx-auto text-lg text-gray-600">Operational workflow patterns that follow Event, Decision, Action. Explore how each one is operationalized with FlowFuse.</p>
+            <div class="mt-10 flex flex-wrap gap-4 justify-center">
+                <a class="ff-btn ff-btn--highlight min-h-[40px] uppercase" href="/contact-us/" onclick="capture('cta-talk-to-expert', {'position': 'hero', 'page': 'use-cases-hub'})">Talk to an expert</a>
+                <a class="ff-btn ff-btn--primary-outlined min-h-[40px] uppercase flex items-center gap-2" href="/industries/" onclick="capture('cta-explore-industries', {'position': 'hero', 'page': 'use-cases-hub'})">
+                    Explore industries
+                    <span class="w-4 h-4">{% include "components/icons/arrow-right.svg" %}</span>
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <!-- USE CASE CARD GRID -->
+    <div class="w-full py-16 sm:py-24 px-6 bg-white">
+        <div class="max-w-screen-lg mx-auto">
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                {% for uc in collections["use-case"] | sort(false, true, "data.title") %}
+                <a href="{{ uc.url }}" class="group flex flex-col gap-3 rounded-xl border border-gray-200 p-6 bg-white hover:border-indigo-300 hover:shadow-sm transition-all">
+                    <h3 class="m-0 text-gray-800 group-hover:text-indigo-600 transition-colors">{{ uc.data.title }}</h3>
+                    <p class="m-0 text-gray-600 text-sm flex-grow">{{ uc.data.problem }}</p>
+                    <span class="mt-2 text-indigo-600 text-sm font-semibold flex items-center gap-2">
+                        View use case
+                        <span class="w-4 h-4">{% include "components/icons/arrow-right.svg" %}</span>
+                    </span>
+                </a>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+
+    <!-- RESOURCES BLOCK PLACEHOLDER -->
+    {% set relatedTag = "" %}
+    {% include "components/related-resources.njk" %}
+
+    <!-- CLOSING CTA BAND -->
+    <div class="w-full px-6 py-20">
+        <div class="ff-blue-card max-md:max-w-xl md:max-w-screen-lg mx-auto pt-12 pb-10 text-center">
+            <h3 class="mb-4 w-full text-center">See it on your workflow</h3>
+            <p class="text-gray-600 mb-8 max-w-xl mx-auto">Talk to an expert, or get started with FlowFuse today.</p>
+            <div class="flex flex-wrap gap-4 justify-center">
+                <a class="ff-btn ff-btn--highlight min-h-[40px] uppercase" href="/contact-us/" onclick="capture('cta-talk-to-expert', {'position': 'footer', 'page': 'use-cases-hub'})">Talk to an expert</a>
+                <a class="ff-btn ff-btn--primary-outlined min-h-[40px] uppercase" href="{% include "sign-up-url.njk" %}" onclick="capture('cta-join', {'position': 'footer', 'page': 'use-cases-hub'})">Get started</a>
+            </div>
+        </div>
+    </div>
+
+</div>

--- a/src/use-cases/production-monitoring-oee.njk
+++ b/src/use-cases/production-monitoring-oee.njk
@@ -1,0 +1,28 @@
+---
+layout: use-case
+tags:
+  - use-case
+title: "Production Monitoring & OEE"
+meta:
+  title: "Production Monitoring & OEE | Use Cases | FlowFuse"
+  description: "A generic operational workflow pattern for production monitoring and OEE. Placeholder skeleton page."
+problem: "Teams can see production data but cannot act on losses as they happen."
+gap:
+  - "Production data is scattered across machines and systems, so losses are understood after the fact rather than acted on in the moment."
+  - "Without a shared, real-time view, line stoppages and slow cycles go unaddressed for too long."
+workflow:
+  - "Capture machine state, counts and rate from the line."
+  - "Detect losses and classify downtime as it happens."
+  - "Surface the right context to the right operator to respond."
+outcomes:
+  - "Faster response to production losses."
+  - "A shared, real-time view of line performance."
+  - "Consistent loss classification across lines and sites."
+relatedIndustries:
+  - name: "Food & Beverage"
+    url: "/industries/food-beverage/"
+  - name: "Automotive"
+    url: "/industries/automotive/"
+  - name: "Oil & Gas"
+    url: "/industries/oil-gas/"
+---

--- a/src/use-cases/quality-containment-vision-qa.njk
+++ b/src/use-cases/quality-containment-vision-qa.njk
@@ -1,0 +1,28 @@
+---
+layout: use-case
+tags:
+  - use-case
+title: "Quality Containment & Vision QA"
+meta:
+  title: "Quality Containment & Vision QA | Use Cases | FlowFuse"
+  description: "A generic operational workflow pattern for quality containment and vision QA. Placeholder skeleton page."
+problem: "Quality issues are detected but not contained before they spread."
+gap:
+  - "Inspection results and quality signals are captured, but the response to contain an issue is manual and slow."
+  - "Without a coordinated containment step, a defect can move downstream before anyone acts."
+workflow:
+  - "Capture inspection and quality signals from the line."
+  - "Decide when an issue requires a containment response."
+  - "Guide operators through containment and record the action."
+outcomes:
+  - "Faster containment of quality issues."
+  - "A recorded, repeatable response."
+  - "Consistent quality handling across sites."
+relatedIndustries:
+  - name: "Pharmaceutical"
+    url: "/industries/pharmaceutical/"
+  - name: "Aerospace"
+    url: "/industries/aerospace/"
+  - name: "Food & Beverage"
+    url: "/industries/food-beverage/"
+---

--- a/src/use-cases/shop-floor-andon.njk
+++ b/src/use-cases/shop-floor-andon.njk
@@ -1,0 +1,28 @@
+---
+layout: use-case
+tags:
+  - use-case
+title: "Shop Floor Andon"
+meta:
+  title: "Shop Floor Andon | Use Cases | FlowFuse"
+  description: "A generic operational workflow pattern for shop floor andon. Placeholder skeleton page."
+problem: "Line calls for help are raised but not escalated or resolved quickly enough."
+gap:
+  - "When an operator raises a call, the signal often stays local and does not reach the right people fast enough."
+  - "Without a coordinated escalation, issues sit unresolved and the line keeps losing time."
+workflow:
+  - "Capture the andon call and its context from the line."
+  - "Escalate to the right responders based on the situation."
+  - "Guide the response and record how it was resolved."
+outcomes:
+  - "Faster escalation of line calls."
+  - "A clear, guided path to resolution."
+  - "A record of response across lines and sites."
+relatedIndustries:
+  - name: "Automotive"
+    url: "/industries/automotive/"
+  - name: "Food & Beverage"
+    url: "/industries/food-beverage/"
+  - name: "Aerospace"
+    url: "/industries/aerospace/"
+---

--- a/src/use-cases/track-and-trace.njk
+++ b/src/use-cases/track-and-trace.njk
@@ -1,0 +1,28 @@
+---
+layout: use-case
+tags:
+  - use-case
+title: "Track and Trace"
+meta:
+  title: "Track and Trace | Use Cases | FlowFuse"
+  description: "A generic operational workflow pattern for track and trace. Placeholder skeleton page."
+problem: "Material and product genealogy is hard to follow across steps and systems."
+gap:
+  - "Traceability data is recorded in different systems at each step, so building a complete genealogy is slow and manual."
+  - "When a trace is needed, teams scramble to stitch records together instead of querying one consistent view."
+workflow:
+  - "Record material and product identity at each step."
+  - "Link steps into a continuous genealogy as work proceeds."
+  - "Make the trace available when an event or query requires it."
+outcomes:
+  - "A continuous genealogy across steps and systems."
+  - "Faster response when a trace is needed."
+  - "Consistent traceability records across sites."
+relatedIndustries:
+  - name: "Food & Beverage"
+    url: "/industries/food-beverage/"
+  - name: "Pharmaceutical"
+    url: "/industries/pharmaceutical/"
+  - name: "Aerospace"
+    url: "/industries/aerospace/"
+---

--- a/src/use-cases/workforce-allocation.njk
+++ b/src/use-cases/workforce-allocation.njk
@@ -1,0 +1,28 @@
+---
+layout: use-case
+tags:
+  - use-case
+title: "Workforce Allocation"
+meta:
+  title: "Workforce Allocation | Use Cases | FlowFuse"
+  description: "A generic operational workflow pattern for workforce allocation. Placeholder skeleton page."
+problem: "People are not directed to where the operation needs them in time."
+gap:
+  - "Operational demand shifts through the day, but allocation decisions rely on manual checks and stale information."
+  - "Without a real-time view of need, people end up in the wrong place at the wrong time."
+workflow:
+  - "Capture operational demand and status from the floor."
+  - "Decide where attention and people are needed next."
+  - "Guide reallocation and record what changed."
+outcomes:
+  - "Better matching of people to operational need."
+  - "Faster reallocation as conditions change."
+  - "A consistent allocation process across sites."
+relatedIndustries:
+  - name: "Automotive"
+    url: "/industries/automotive/"
+  - name: "Food & Beverage"
+    url: "/industries/food-beverage/"
+  - name: "Oil & Gas"
+    url: "/industries/oil-gas/"
+---


### PR DESCRIPTION
## Summary

Skeleton scaffold for two new top-level content shapes on the marketing site, plus a floating Expert dock on use-case pages. Content is intentionally placeholder; this PR is for shape review.

- **Industries** section: hub + one page per vertical (food-beverage, pharmaceutical, automotive, aerospace, oil-gas), sharing a new `industry.njk` layout.
- **Use Cases** section: hub + per-pattern pages (production monitoring & OEE, track and trace, shop floor andon, quality containment & vision QA, workforce allocation, continuous improvement, controller monitoring), sharing a new `use-case.njk` layout.
- **Floating Expert dock** on every use-case page, reusing the existing AI Expert chat experience.
- Two new tag namespaces (`industry:slug`, `usecase:slug`) wired into a shared related-resources block (case studies / white papers / blog) reusing existing collection logic.
- **Solutions** dropdown restructured into two labelled subgroups (By architecture, By use case). New **Industries** top-level dropdown inserted between Industries and Solutions.

Reference PR — does not need to be merged as-is; follow-up PRs will narrow scope.
