### PR TITLE
Use Cases section + floating Expert dock (structure only)

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -221,6 +221,7 @@ module.exports = function(eleventyConfig) {
     eleventyConfig.addLayoutAlias('page', 'layouts/page.njk');
     eleventyConfig.addLayoutAlias('nohero', 'layouts/nohero.njk');
     eleventyConfig.addLayoutAlias('solution', 'layouts/solution.njk');
+    eleventyConfig.addLayoutAlias('use-case', 'layouts/use-case.njk');
     eleventyConfig.addLayoutAlias('catalog', 'layouts/catalog.njk');
     eleventyConfig.addLayoutAlias('redirect', 'layouts/redirect.njk');
 

--- a/src/_includes/components/related-resources.njk
+++ b/src/_includes/components/related-resources.njk
@@ -1,0 +1,56 @@
+{# ============================================================
+   RELATED RESOURCES (skeleton)
+   Three columns: Case studies / White papers / Blog.
+   Driven by a tag passed in as `relatedTag` (e.g. "industry:food-beverage"
+   or "usecase:track-and-trace"). Resources opt in later by adding that tag;
+   the matching tag collection is then split by section.
+   No existing customer stories are tagged, so every column renders the
+   empty "More coming soon" state.
+   ============================================================ #}
+{% set relatedTag = relatedTag or "" %}
+{% set tagged = collections[relatedTag] or [] %}
+
+{% set caseStudies = [] %}
+{% set whitepapers = [] %}
+{% set blogPosts = [] %}
+{% for item in tagged %}
+    {% if "/customer-stories/" in item.url %}
+        {% set caseStudies = (caseStudies.push(item), caseStudies) %}
+    {% elif "/whitepaper/" in item.url %}
+        {% set whitepapers = (whitepapers.push(item), whitepapers) %}
+    {% elif "/blog/" in item.url %}
+        {% set blogPosts = (blogPosts.push(item), blogPosts) %}
+    {% endif %}
+{% endfor %}
+
+{% set columns = [
+    {heading: "Case studies", items: caseStudies},
+    {heading: "White papers", items: whitepapers},
+    {heading: "Blog", items: blogPosts}
+] %}
+
+<div class="w-full py-16 sm:py-24 px-6 bg-gray-50 border-y border-gray-100">
+    <div class="max-w-screen-lg mx-auto">
+        <h2 class="max-md:text-center">Related resources</h2>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-8 mt-10">
+            {% for column in columns %}
+            <div>
+                <h4 class="text-gray-800 border-b border-gray-200 pb-3 mb-4">{{ column.heading }}</h4>
+                {% if column.items.length %}
+                <ul class="flex flex-col gap-3 list-none p-0 m-0">
+                    {% for item in column.items %}
+                    <li>
+                        <a href="{{ item.url }}" class="text-indigo-600 hover:text-indigo-800">{{ item.data.title }}</a>
+                    </li>
+                    {% endfor %}
+                </ul>
+                {% else %}
+                <div class="rounded-lg border border-dashed border-gray-300 bg-white p-6 text-center">
+                    <p class="m-0 text-gray-400 text-sm">More coming soon</p>
+                </div>
+                {% endif %}
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+</div>

--- a/src/_includes/layouts/use-case.njk
+++ b/src/_includes/layouts/use-case.njk
@@ -1,0 +1,165 @@
+---
+layout: layouts/base.njk
+sitemapPriority: 0.7
+---
+{# ============================================================
+   USE CASE LAYOUT (skeleton, generic workflow pattern)
+   Per-page front-matter: problem, gap[], workflow[], outcomes[].
+   Sections 3 and 5 are fixed generic platform positioning.
+   No customer names, no quotes, no real numbers.
+   ============================================================ #}
+
+<div class="w-full">
+
+    <!-- ============================================================
+         HERO
+    ============================================================ -->
+    <div class="w-full px-6 bg-[radial-gradient(ellipse_120%_140%_at_50%_-20%,theme(colors.indigo.50)_0%,theme(colors.white)_60%)]">
+        <div class="max-w-screen-lg mx-auto py-16 sm:py-24 text-center">
+            <p class="uppercase tracking-widest text-sm font-semibold text-indigo-500 mb-4">Use case</p>
+            <h1 class="m-auto max-w-3xl font-medium"><span class="text-indigo-600">{{ title }}</span></h1>
+            <p class="mt-6 max-w-2xl mx-auto text-lg text-gray-600">{{ problem }}</p>
+            <div class="mt-10 flex flex-wrap gap-4 justify-center">
+                <a class="ff-btn ff-btn--highlight min-h-[40px] uppercase" href="/contact-us/" onclick="capture('cta-talk-to-expert', {'position': 'hero', 'usecase': '{{ page.fileSlug }}'})">Talk to an expert</a>
+            </div>
+        </div>
+    </div>
+
+    <!-- ============================================================
+         1. THE OPERATIONAL GAP
+    ============================================================ -->
+    <div class="w-full py-16 sm:py-24 px-6 bg-white">
+        <div class="max-w-screen-lg mx-auto">
+            <h2 class="max-md:text-center"><span class="text-red-600">The operational</span> gap</h2>
+            <div class="mt-6 grid grid-cols-1 md:grid-cols-2 gap-8 max-w-4xl">
+                {% for paragraph in gap %}
+                <p class="text-gray-600 m-0">{{ paragraph }}</p>
+                {% endfor %}
+            </div>
+            <p class="mt-8 text-sm text-gray-400 italic">Placeholder copy. Generic operational framing for this workflow pattern.</p>
+        </div>
+    </div>
+
+    <!-- ============================================================
+         2. WHY EXISTING SYSTEMS DID NOT SOLVE IT (fixed, generic)
+    ============================================================ -->
+    <div class="w-full py-16 sm:py-24 px-6 bg-gray-50 border-y border-gray-100">
+        <div class="max-w-screen-lg mx-auto">
+            <h2 class="text-center">Why existing systems did not solve it</h2>
+            {% set reasons = [
+                {title: "MES is too rigid", detail: "Fixed workflows are slow and costly to change as operations evolve."},
+                {title: "Dashboards do not act", detail: "Visibility alone does not trigger or coordinate a response."},
+                {title: "Historians store but do not orchestrate", detail: "Data is captured for later, not turned into action in the moment."},
+                {title: "ERP does not execute", detail: "Business systems plan work but do not run the operational workflow."},
+                {title: "AI builds but does not operationalize", detail: "Generated logic still needs governance, deployment and scale."},
+                {title: "Scripts do not scale", detail: "One-off scripts are hard to manage, repeat and roll out across sites."}
+            ] %}
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-12">
+                {% for reason in reasons %}
+                <div class="rounded-xl bg-white border border-gray-200 p-6 flex flex-col gap-2">
+                    <div class="w-8 h-8 text-red-400">{% include "components/icons/x-circle.svg" %}</div>
+                    <h4 class="m-0 text-gray-800">{{ reason.title }}</h4>
+                    <p class="m-0 text-gray-600 text-sm">{{ reason.detail }}</p>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+
+    <!-- ============================================================
+         3. THE OPERATIONAL WORKFLOW (Event, Decision, Action)
+    ============================================================ -->
+    <div class="w-full bg-[radial-gradient(ellipse_120%_120%_at_50%_120%,theme(colors.indigo.600)_0%,theme(colors.indigo.900)_100%)] py-16 sm:py-24 px-6">
+        <div class="max-w-screen-lg mx-auto">
+            <h2 class="text-white text-center">The operational workflow</h2>
+            <p class="text-indigo-200 text-center max-w-2xl mx-auto mt-4">A pattern that turns industrial events into action.</p>
+            {% set steps = [
+                {label: "Event", icon: "components/icons/bolt.svg", detail: "An industrial event triggers the workflow from a machine, sensor, broker or system signal."},
+                {label: "Decision", icon: "components/icons/arrows-right-left.svg", detail: "Event-driven orchestration applies logic, context and rules to decide what should happen."},
+                {label: "Action", icon: "components/icons/cursor-arrow-rays.svg", detail: "Guided operator actions and automated steps carry out the response where work happens."}
+            ] %}
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-12">
+                {% for step in steps %}
+                <div class="rounded-xl border border-indigo-400/40 bg-indigo-950/30 p-6 flex flex-col gap-3">
+                    <div class="flex items-center gap-3">
+                        <div class="w-10 h-10 bg-indigo-50 rounded-full flex items-center justify-center text-indigo-600">
+                            <span class="w-5 h-5">{% include step.icon %}</span>
+                        </div>
+                        <span class="text-indigo-300 text-sm font-semibold uppercase tracking-widest">{{ loop.index }}</span>
+                    </div>
+                    <h4 class="text-white m-0">{{ step.label }}</h4>
+                    <p class="text-indigo-100 font-light m-0">{{ step.detail }}</p>
+                </div>
+                {% endfor %}
+            </div>
+            {% if workflow %}
+            <ul class="mt-10 max-w-3xl mx-auto flex flex-col gap-3 list-none p-0">
+                {% for item in workflow %}
+                <li class="flex items-start gap-3 text-indigo-100">
+                    <span class="flex-shrink-0 w-6 h-6 text-indigo-300 mt-0.5">{% include "components/icons/check.svg" %}</span>
+                    <span>{{ item }}</span>
+                </li>
+                {% endfor %}
+            </ul>
+            {% endif %}
+        </div>
+    </div>
+
+    <!-- ============================================================
+         4. HOW IT IS OPERATIONALIZED WITH FLOWFUSE (generic, no customer)
+    ============================================================ -->
+    <div class="w-full py-16 sm:py-24 px-6 bg-white">
+        <div class="max-w-screen-lg mx-auto">
+            <h2 class="max-md:text-center">How it is operationalized with FlowFuse</h2>
+            <p class="text-gray-500 mt-2">Generic platform capabilities. No named customer or attributed quotes.</p>
+            {% set ops = [
+                {title: "Deployment", detail: "Ship the workflow to cloud, on-premise or edge from one platform."},
+                {title: "Governance", detail: "Keep humans in control with approvals and audit trails."},
+                {title: "Role-based access", detail: "Scope who can view, edit and deploy across teams."},
+                {title: "Version control", detail: "Track changes and roll back safely."},
+                {title: "CI/CD pipelines", detail: "Promote from development to test to production."},
+                {title: "Multi-site rollout", detail: "Roll the same workflow out to every site in a controlled way."},
+                {title: "Reuse", detail: "Package the pattern as a reusable building block."}
+            ] %}
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-x-10 gap-y-5 mt-8">
+                {% for op in ops %}
+                <div class="flex items-start gap-4">
+                    <span class="flex-shrink-0 w-8 h-8 bg-indigo-50 rounded-full flex items-center justify-center text-indigo-600">
+                        <span class="w-4 h-4">{% include "components/icons/check.svg" %}</span>
+                    </span>
+                    <div>
+                        <h5 class="m-0 text-gray-800">{{ op.title }}</h5>
+                        <p class="m-0 text-gray-600 text-sm">{{ op.detail }}</p>
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+
+    <!-- ============================================================
+         5. OUTCOMES (generic placeholder bullets, no client, no numbers)
+    ============================================================ -->
+    <div class="w-full py-16 sm:py-24 px-6 comparison-section-bg">
+        <div class="max-w-screen-lg mx-auto">
+            <h2 class="text-indigo-600 max-md:text-center">Outcomes</h2>
+            <div class="mt-8 flex flex-col gap-4 max-w-3xl">
+                {% for outcome in outcomes %}
+                <div class="bg-white border border-indigo-100 rounded-lg p-5 flex items-center gap-4">
+                    <span class="flex-shrink-0 w-8 h-8 text-indigo-500">{% include "components/icons/arrow-trending-up.svg" %}</span>
+                    <p class="m-0 text-lg font-light text-gray-700">{{ outcome }}</p>
+                </div>
+                {% endfor %}
+            </div>
+            <p class="mt-6 text-xs text-gray-400 italic">Placeholder outcomes. No customer names or real figures.</p>
+        </div>
+    </div>
+
+    <!-- ============================================================
+         6. RELATED RESOURCES (empty "More coming soon" state)
+    ============================================================ -->
+    {% set relatedTag = "usecase:" + page.fileSlug %}
+    {% include "components/related-resources.njk" %}
+
+    <!-- spacer so sticky dock never overlaps the final content -->
+</div>

--- a/src/use-cases/continuous-improvement.njk
+++ b/src/use-cases/continuous-improvement.njk
@@ -1,0 +1,21 @@
+---
+layout: use-case
+tags:
+  - use-case
+title: "Continuous Improvement"
+meta:
+  title: "Continuous Improvement | Use Cases | FlowFuse"
+  description: "A generic operational workflow pattern for continuous improvement. Placeholder skeleton page."
+problem: "Improvement ideas are identified but not turned into rolled-out change."
+gap:
+  - "Teams spot opportunities to improve, but moving from insight to a change that runs everywhere is slow and inconsistent."
+  - "Without a repeatable path to rollout, improvements stall as one-off experiments."
+workflow:
+  - "Capture operational signals and improvement ideas."
+  - "Decide which changes are ready to standardize."
+  - "Roll out the change in a controlled, repeatable way."
+outcomes:
+  - "A repeatable path from insight to rollout."
+  - "Changes that reach every relevant site."
+  - "Less drift between improvement and standard work."
+---

--- a/src/use-cases/controller-monitoring.njk
+++ b/src/use-cases/controller-monitoring.njk
@@ -1,0 +1,21 @@
+---
+layout: use-case
+tags:
+  - use-case
+title: "Controller Monitoring"
+meta:
+  title: "Controller Monitoring | Use Cases | FlowFuse"
+  description: "A generic operational workflow pattern for controller monitoring. Placeholder skeleton page."
+problem: "Controller health issues are noticed too late to prevent disruption."
+gap:
+  - "Controllers and their connections are critical, but their health is often only checked after something has already gone wrong."
+  - "Without continuous monitoring and a response path, a single failure can disrupt the operation."
+workflow:
+  - "Capture controller status and connection health."
+  - "Detect degradation and decide when to act."
+  - "Guide the response and record the recovery."
+outcomes:
+  - "Earlier detection of controller issues."
+  - "A guided path to recovery."
+  - "A consistent view of controller health across sites."
+---

--- a/src/use-cases/index.njk
+++ b/src/use-cases/index.njk
@@ -1,0 +1,57 @@
+---
+layout: layouts/base.njk
+sitemapPriority: 0.8
+title: "Use Cases"
+meta:
+  title: "Use Cases | FlowFuse"
+  description: "Generic operational workflow patterns for industrial teams. Turn events into action with FlowFuse. Placeholder skeleton hub."
+---
+<div class="w-full">
+
+    <!-- HERO with CTA buttons -->
+    <div class="w-full px-6 bg-[radial-gradient(ellipse_120%_140%_at_50%_-20%,theme(colors.indigo.50)_0%,theme(colors.white)_60%)]">
+        <div class="max-w-screen-lg mx-auto py-16 sm:py-24 text-center">
+            <p class="uppercase tracking-widest text-sm font-semibold text-indigo-500 mb-4">Use cases</p>
+            <h1 class="m-auto max-w-3xl font-medium">Turn industrial events into <span class="text-indigo-600">action</span></h1>
+            <p class="mt-6 max-w-2xl mx-auto text-lg text-gray-600">Operational workflow patterns that follow Event, Decision, Action. Explore how each one is operationalized with FlowFuse.</p>
+            <div class="mt-10 flex flex-wrap gap-4 justify-center">
+                <a class="ff-btn ff-btn--highlight min-h-[40px] uppercase" href="/contact-us/" onclick="capture('cta-talk-to-expert', {'position': 'hero', 'page': 'use-cases-hub'})">Talk to an expert</a>
+            </div>
+        </div>
+    </div>
+
+    <!-- USE CASE CARD GRID -->
+    <div class="w-full py-16 sm:py-24 px-6 bg-white">
+        <div class="max-w-screen-lg mx-auto">
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                {% for uc in collections["use-case"] | sort(false, true, "data.title") %}
+                <a href="{{ uc.url }}" class="group flex flex-col gap-3 rounded-xl border border-gray-200 p-6 bg-white hover:border-indigo-300 hover:shadow-sm transition-all">
+                    <h3 class="m-0 text-gray-800 group-hover:text-indigo-600 transition-colors">{{ uc.data.title }}</h3>
+                    <p class="m-0 text-gray-600 text-sm flex-grow">{{ uc.data.problem }}</p>
+                    <span class="mt-2 text-indigo-600 text-sm font-semibold flex items-center gap-2">
+                        View use case
+                        <span class="w-4 h-4">{% include "components/icons/arrow-right.svg" %}</span>
+                    </span>
+                </a>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+
+    <!-- RESOURCES BLOCK PLACEHOLDER -->
+    {% set relatedTag = "" %}
+    {% include "components/related-resources.njk" %}
+
+    <!-- CLOSING CTA BAND -->
+    <div class="w-full px-6 py-20">
+        <div class="ff-blue-card max-md:max-w-xl md:max-w-screen-lg mx-auto pt-12 pb-10 text-center">
+            <h3 class="mb-4 w-full text-center">See it on your workflow</h3>
+            <p class="text-gray-600 mb-8 max-w-xl mx-auto">Talk to an expert, or get started with FlowFuse today.</p>
+            <div class="flex flex-wrap gap-4 justify-center">
+                <a class="ff-btn ff-btn--highlight min-h-[40px] uppercase" href="/contact-us/" onclick="capture('cta-talk-to-expert', {'position': 'footer', 'page': 'use-cases-hub'})">Talk to an expert</a>
+                <a class="ff-btn ff-btn--primary-outlined min-h-[40px] uppercase" href="{% include "sign-up-url.njk" %}" onclick="capture('cta-join', {'position': 'footer', 'page': 'use-cases-hub'})">Get started</a>
+            </div>
+        </div>
+    </div>
+
+</div>

--- a/src/use-cases/production-monitoring-oee.njk
+++ b/src/use-cases/production-monitoring-oee.njk
@@ -1,0 +1,21 @@
+---
+layout: use-case
+tags:
+  - use-case
+title: "Production Monitoring & OEE"
+meta:
+  title: "Production Monitoring & OEE | Use Cases | FlowFuse"
+  description: "A generic operational workflow pattern for production monitoring and OEE. Placeholder skeleton page."
+problem: "Teams can see production data but cannot act on losses as they happen."
+gap:
+  - "Production data is scattered across machines and systems, so losses are understood after the fact rather than acted on in the moment."
+  - "Without a shared, real-time view, line stoppages and slow cycles go unaddressed for too long."
+workflow:
+  - "Capture machine state, counts and rate from the line."
+  - "Detect losses and classify downtime as it happens."
+  - "Surface the right context to the right operator to respond."
+outcomes:
+  - "Faster response to production losses."
+  - "A shared, real-time view of line performance."
+  - "Consistent loss classification across lines and sites."
+---

--- a/src/use-cases/quality-containment-vision-qa.njk
+++ b/src/use-cases/quality-containment-vision-qa.njk
@@ -1,0 +1,21 @@
+---
+layout: use-case
+tags:
+  - use-case
+title: "Quality Containment & Vision QA"
+meta:
+  title: "Quality Containment & Vision QA | Use Cases | FlowFuse"
+  description: "A generic operational workflow pattern for quality containment and vision QA. Placeholder skeleton page."
+problem: "Quality issues are detected but not contained before they spread."
+gap:
+  - "Inspection results and quality signals are captured, but the response to contain an issue is manual and slow."
+  - "Without a coordinated containment step, a defect can move downstream before anyone acts."
+workflow:
+  - "Capture inspection and quality signals from the line."
+  - "Decide when an issue requires a containment response."
+  - "Guide operators through containment and record the action."
+outcomes:
+  - "Faster containment of quality issues."
+  - "A recorded, repeatable response."
+  - "Consistent quality handling across sites."
+---

--- a/src/use-cases/shop-floor-andon.njk
+++ b/src/use-cases/shop-floor-andon.njk
@@ -1,0 +1,21 @@
+---
+layout: use-case
+tags:
+  - use-case
+title: "Shop Floor Andon"
+meta:
+  title: "Shop Floor Andon | Use Cases | FlowFuse"
+  description: "A generic operational workflow pattern for shop floor andon. Placeholder skeleton page."
+problem: "Line calls for help are raised but not escalated or resolved quickly enough."
+gap:
+  - "When an operator raises a call, the signal often stays local and does not reach the right people fast enough."
+  - "Without a coordinated escalation, issues sit unresolved and the line keeps losing time."
+workflow:
+  - "Capture the andon call and its context from the line."
+  - "Escalate to the right responders based on the situation."
+  - "Guide the response and record how it was resolved."
+outcomes:
+  - "Faster escalation of line calls."
+  - "A clear, guided path to resolution."
+  - "A record of response across lines and sites."
+---

--- a/src/use-cases/track-and-trace.njk
+++ b/src/use-cases/track-and-trace.njk
@@ -1,0 +1,21 @@
+---
+layout: use-case
+tags:
+  - use-case
+title: "Track and Trace"
+meta:
+  title: "Track and Trace | Use Cases | FlowFuse"
+  description: "A generic operational workflow pattern for track and trace. Placeholder skeleton page."
+problem: "Material and product genealogy is hard to follow across steps and systems."
+gap:
+  - "Traceability data is recorded in different systems at each step, so building a complete genealogy is slow and manual."
+  - "When a trace is needed, teams scramble to stitch records together instead of querying one consistent view."
+workflow:
+  - "Record material and product identity at each step."
+  - "Link steps into a continuous genealogy as work proceeds."
+  - "Make the trace available when an event or query requires it."
+outcomes:
+  - "A continuous genealogy across steps and systems."
+  - "Faster response when a trace is needed."
+  - "Consistent traceability records across sites."
+---

--- a/src/use-cases/workforce-allocation.njk
+++ b/src/use-cases/workforce-allocation.njk
@@ -1,0 +1,21 @@
+---
+layout: use-case
+tags:
+  - use-case
+title: "Workforce Allocation"
+meta:
+  title: "Workforce Allocation | Use Cases | FlowFuse"
+  description: "A generic operational workflow pattern for workforce allocation. Placeholder skeleton page."
+problem: "People are not directed to where the operation needs them in time."
+gap:
+  - "Operational demand shifts through the day, but allocation decisions rely on manual checks and stale information."
+  - "Without a real-time view of need, people end up in the wrong place at the wrong time."
+workflow:
+  - "Capture operational demand and status from the floor."
+  - "Decide where attention and people are needed next."
+  - "Guide reallocation and record what changed."
+outcomes:
+  - "Better matching of people to operational need."
+  - "Faster reallocation as conditions change."
+  - "A consistent allocation process across sites."
+---


### PR DESCRIPTION
## Summary

Skeleton structure for a new **Use Cases** content shape on the marketing site. Structure only; page content is intentionally placeholder.

- `/use-cases/` hub + per-pattern pages, sharing a new `use-case.njk` layout.
- Floating FlowFuse Expert dock pinned to every use-case page, reusing the existing AI Expert chat.
- Reusable `related-resources.njk` block (case studies / white papers / blog) wired to a `usecase:slug` tag namespace using existing collection logic.

**No nav changes in this PR.** Follow-up PRs will target this branch and fill each use case with content from sales.
