### PR TITLE
Add use case page: Production Monitoring & OEE

### DIFF
--- a/src/use-cases/production-monitoring-oee.njk
+++ b/src/use-cases/production-monitoring-oee.njk
@@ -1,0 +1,21 @@
+---
+layout: use-case
+tags:
+  - use-case
+title: "Production Monitoring & OEE"
+meta:
+  title: "Production Monitoring & OEE | Use Cases | FlowFuse"
+  description: "A generic operational workflow pattern for production monitoring and OEE. Placeholder skeleton page."
+problem: "Teams can see production data but cannot act on losses as they happen."
+gap:
+  - "Production data is scattered across machines and systems, so losses are understood after the fact rather than acted on in the moment."
+  - "Without a shared, real-time view, line stoppages and slow cycles go unaddressed for too long."
+workflow:
+  - "Capture machine state, counts and rate from the line."
+  - "Detect losses and classify downtime as it happens."
+  - "Surface the right context to the right operator to respond."
+outcomes:
+  - "Faster response to production losses."
+  - "A shared, real-time view of line performance."
+  - "Consistent loss classification across lines and sites."
+---


### PR DESCRIPTION
## Summary

First per-pattern content page on top of the **Use Cases structure** PR (#5079). Adds `/use-cases/production-monitoring-oee/` using the new `use-case` layout.

- Placeholder copy only (no client names, no real numbers, no attributed quotes).
- Mirrors the shape defined by `src/use-cases/_template.njk` in the structure PR.
- Renders into the `/use-cases/` hub grid automatically via the `use-case` collection tag.

**Base:** `feat/use-cases-structure`. Merge order: structure first, then this. To be replaced with real sales content when available.
