### PR TITLE
Restructure Solutions dropdown into 'By architecture' + 'By use case'

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -221,6 +221,7 @@ module.exports = function(eleventyConfig) {
     eleventyConfig.addLayoutAlias('page', 'layouts/page.njk');
     eleventyConfig.addLayoutAlias('nohero', 'layouts/nohero.njk');
     eleventyConfig.addLayoutAlias('solution', 'layouts/solution.njk');
+    eleventyConfig.addLayoutAlias('use-case', 'layouts/use-case.njk');
     eleventyConfig.addLayoutAlias('catalog', 'layouts/catalog.njk');
     eleventyConfig.addLayoutAlias('redirect', 'layouts/redirect.njk');
 

--- a/src/_includes/components/related-resources.njk
+++ b/src/_includes/components/related-resources.njk
@@ -1,0 +1,56 @@
+{# ============================================================
+   RELATED RESOURCES (skeleton)
+   Three columns: Case studies / White papers / Blog.
+   Driven by a tag passed in as `relatedTag` (e.g. "industry:food-beverage"
+   or "usecase:track-and-trace"). Resources opt in later by adding that tag;
+   the matching tag collection is then split by section.
+   No existing customer stories are tagged, so every column renders the
+   empty "More coming soon" state.
+   ============================================================ #}
+{% set relatedTag = relatedTag or "" %}
+{% set tagged = collections[relatedTag] or [] %}
+
+{% set caseStudies = [] %}
+{% set whitepapers = [] %}
+{% set blogPosts = [] %}
+{% for item in tagged %}
+    {% if "/customer-stories/" in item.url %}
+        {% set caseStudies = (caseStudies.push(item), caseStudies) %}
+    {% elif "/whitepaper/" in item.url %}
+        {% set whitepapers = (whitepapers.push(item), whitepapers) %}
+    {% elif "/blog/" in item.url %}
+        {% set blogPosts = (blogPosts.push(item), blogPosts) %}
+    {% endif %}
+{% endfor %}
+
+{% set columns = [
+    {heading: "Case studies", items: caseStudies},
+    {heading: "White papers", items: whitepapers},
+    {heading: "Blog", items: blogPosts}
+] %}
+
+<div class="w-full py-16 sm:py-24 px-6 bg-gray-50 border-y border-gray-100">
+    <div class="max-w-screen-lg mx-auto">
+        <h2 class="max-md:text-center">Related resources</h2>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-8 mt-10">
+            {% for column in columns %}
+            <div>
+                <h4 class="text-gray-800 border-b border-gray-200 pb-3 mb-4">{{ column.heading }}</h4>
+                {% if column.items.length %}
+                <ul class="flex flex-col gap-3 list-none p-0 m-0">
+                    {% for item in column.items %}
+                    <li>
+                        <a href="{{ item.url }}" class="text-indigo-600 hover:text-indigo-800">{{ item.data.title }}</a>
+                    </li>
+                    {% endfor %}
+                </ul>
+                {% else %}
+                <div class="rounded-lg border border-dashed border-gray-300 bg-white p-6 text-center">
+                    <p class="m-0 text-gray-400 text-sm">More coming soon</p>
+                </div>
+                {% endif %}
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+</div>

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -271,13 +271,25 @@ eleventyComputed:
                         </ul>
                         {% endnavoption %}
                         {% navoption "Solutions", null, 0 %}
-                            <ul class="sm:grid sm:grid-flow-col sm:grid-rows-3 sm:grid-cols-1 sm:pr-9 align-left">
-                                {% navoption "IT/OT middleware", "/solutions/it-ot-middleware/", 1, "cog" %}{% endnavoption %}
-                                {% navoption "Unified Namespace", "/solutions/uns/", 1, "uns" %}{% endnavoption %}
-                                {% navoption "SCADA", "/solutions/scada/", 1, "adjustments-horizontal" %}{% endnavoption %}
-                                {% navoption "MES", "/solutions/mes/", 1, "chart" %}{% endnavoption %}
-                                {% navoption "Edge Connectivity", "/solutions/edge-connectivity/", 1, "chip" %}{% endnavoption %}
-                                {% navoption "Data integration", "/solutions/data-integration/", 1, "db" %}{% endnavoption %}
+                            <ul class="ff-nav-subgroups sm:grid sm:grid-flow-col sm:auto-cols-max sm:gap-x-8 sm:pr-6 align-left items-stretch">
+                                <li class="!bg-transparent">
+                                    <span class="title block">By architecture</span>
+                                    <ul class="sub-menu">
+                                        {% navoption "IT/OT middleware", "/solutions/it-ot-middleware/", 1, "cog" %}{% endnavoption %}
+                                        {% navoption "Unified Namespace", "/solutions/uns/", 1, "uns" %}{% endnavoption %}
+                                        {% navoption "SCADA", "/solutions/scada/", 1, "adjustments-horizontal" %}{% endnavoption %}
+                                        {% navoption "MES", "/solutions/mes/", 1, "chart" %}{% endnavoption %}
+                                        {% navoption "Edge Connectivity", "/solutions/edge-connectivity/", 1, "chip" %}{% endnavoption %}
+                                        {% navoption "Data integration", "/solutions/data-integration/", 1, "db" %}{% endnavoption %}
+                                    </ul>
+                                </li>
+                                <li class="!bg-transparent ff-nav-subgroup-divider">
+                                    <span class="title block">By use case</span>
+                                    <ul class="sub-menu">
+                                        {% navoption "Production Monitoring", "/use-cases/production-monitoring/", 1, "chart" %}{% endnavoption %}
+                                        {% navoption "All use cases", "/use-cases/", 1, "squares-2x2" %}{% endnavoption %}
+                                    </ul>
+                                </li>
                             </ul>
                         {% endnavoption %}
                         {% navoption "Resources", null, 0 %}

--- a/src/_includes/layouts/use-case.njk
+++ b/src/_includes/layouts/use-case.njk
@@ -3,11 +3,29 @@ layout: layouts/base.njk
 sitemapPriority: 0.7
 ---
 {# ============================================================
-   USE CASE LAYOUT (skeleton, generic workflow pattern)
-   Per-page front-matter: problem, gap[], workflow[], outcomes[].
-   Sections 3 and 5 are fixed generic platform positioning.
-   No customer names, no quotes, no real numbers.
+   USE CASE LAYOUT (content-driven, pain-led narrative)
+
+   Per-page front-matter (rich, preferred):
+     problem        hero sub-headline (the pain in one line)
+     customerPain   { heading, intro[], cards[ {icon,title,detail} ] }
+     outcomeFirst   { heading, intro, dimensions[ {label,title,detail} ] }
+     whyItMatters   { heading, intro, points[ {title,detail} ] }
+     competition    { heading, intro, traps[ {label,title,detail} ] }
+     comparison     { without[ {title,detail} ], with[ {title,detail} ] }
+
+   Legacy fall-back front-matter (simple skeleton, still supported):
+     gap[], workflow[], outcomes[]
+
+   No customer names and no attributed quotes on the public page.
    ============================================================ #}
+
+{# --- build the sticky section nav from the blocks that exist --- #}
+{% set nav = [] %}
+{% if customerPain %}{% set nav = nav.concat([{ id: "customer-pain", label: "Customer Pain" }]) %}{% endif %}
+{% if outcomeFirst %}{% set nav = nav.concat([{ id: "outcome-first", label: "Outcome First" }]) %}{% endif %}
+{% if whyItMatters %}{% set nav = nav.concat([{ id: "why-it-matters", label: "Why It Matters" }]) %}{% endif %}
+{% if competition %}{% set nav = nav.concat([{ id: "competition", label: "Why Off-the-Shelf Fails" }]) %}{% endif %}
+{% if comparison %}{% set nav = nav.concat([{ id: "with-without", label: "With / Without FlowFuse" }]) %}{% endif %}
 
 <div class="w-full">
 
@@ -25,141 +43,234 @@ sitemapPriority: 0.7
         </div>
     </div>
 
+    {% if nav.length %}
     <!-- ============================================================
-         1. THE OPERATIONAL GAP
+         STICKY SECTION NAV
     ============================================================ -->
-    <div class="w-full py-16 sm:py-24 px-6 bg-white">
-        <div class="max-w-screen-lg mx-auto">
-            <h2 class="max-md:text-center"><span class="text-red-600">The operational</span> gap</h2>
-            <div class="mt-6 grid grid-cols-1 md:grid-cols-2 gap-8 max-w-4xl">
-                {% for paragraph in gap %}
-                <p class="text-gray-600 m-0">{{ paragraph }}</p>
-                {% endfor %}
-            </div>
-            <p class="mt-8 text-sm text-gray-400 italic">Placeholder copy. Generic operational framing for this workflow pattern.</p>
-        </div>
-    </div>
-
-    <!-- ============================================================
-         2. WHY EXISTING SYSTEMS DID NOT SOLVE IT (fixed, generic)
-    ============================================================ -->
-    <div class="w-full py-16 sm:py-24 px-6 bg-gray-50 border-y border-gray-100">
-        <div class="max-w-screen-lg mx-auto">
-            <h2 class="text-center">Why existing systems did not solve it</h2>
-            {% set reasons = [
-                {title: "MES is too rigid", detail: "Fixed workflows are slow and costly to change as operations evolve."},
-                {title: "Dashboards do not act", detail: "Visibility alone does not trigger or coordinate a response."},
-                {title: "Historians store but do not orchestrate", detail: "Data is captured for later, not turned into action in the moment."},
-                {title: "ERP does not execute", detail: "Business systems plan work but do not run the operational workflow."},
-                {title: "AI builds but does not operationalize", detail: "Generated logic still needs governance, deployment and scale."},
-                {title: "Scripts do not scale", detail: "One-off scripts are hard to manage, repeat and roll out across sites."}
-            ] %}
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-12">
-                {% for reason in reasons %}
-                <div class="rounded-xl bg-white border border-gray-200 p-6 flex flex-col gap-2">
-                    <div class="w-8 h-8 text-red-400">{% include "components/icons/x-circle.svg" %}</div>
-                    <h4 class="m-0 text-gray-800">{{ reason.title }}</h4>
-                    <p class="m-0 text-gray-600 text-sm">{{ reason.detail }}</p>
-                </div>
-                {% endfor %}
-            </div>
-        </div>
-    </div>
-
-    <!-- ============================================================
-         3. THE OPERATIONAL WORKFLOW (Event, Decision, Action)
-    ============================================================ -->
-    <div class="w-full bg-[radial-gradient(ellipse_120%_120%_at_50%_120%,theme(colors.indigo.600)_0%,theme(colors.indigo.900)_100%)] py-16 sm:py-24 px-6">
-        <div class="max-w-screen-lg mx-auto">
-            <h2 class="text-white text-center">The operational workflow</h2>
-            <p class="text-indigo-200 text-center max-w-2xl mx-auto mt-4">A pattern that turns industrial events into action.</p>
-            {% set steps = [
-                {label: "Event", icon: "components/icons/bolt.svg", detail: "An industrial event triggers the workflow from a machine, sensor, broker or system signal."},
-                {label: "Decision", icon: "components/icons/arrows-right-left.svg", detail: "Event-driven orchestration applies logic, context and rules to decide what should happen."},
-                {label: "Action", icon: "components/icons/cursor-arrow-rays.svg", detail: "Guided operator actions and automated steps carry out the response where work happens."}
-            ] %}
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-12">
-                {% for step in steps %}
-                <div class="rounded-xl border border-indigo-400/40 bg-indigo-950/30 p-6 flex flex-col gap-3">
-                    <div class="flex items-center gap-3">
-                        <div class="w-10 h-10 bg-indigo-50 rounded-full flex items-center justify-center text-indigo-600">
-                            <span class="w-5 h-5">{% include step.icon %}</span>
-                        </div>
-                        <span class="text-indigo-300 text-sm font-semibold uppercase tracking-widest">{{ loop.index }}</span>
-                    </div>
-                    <h4 class="text-white m-0">{{ step.label }}</h4>
-                    <p class="text-indigo-100 font-light m-0">{{ step.detail }}</p>
-                </div>
-                {% endfor %}
-            </div>
-            {% if workflow %}
-            <ul class="mt-10 max-w-3xl mx-auto flex flex-col gap-3 list-none p-0">
-                {% for item in workflow %}
-                <li class="flex items-start gap-3 text-indigo-100">
-                    <span class="flex-shrink-0 w-6 h-6 text-indigo-300 mt-0.5">{% include "components/icons/check.svg" %}</span>
-                    <span>{{ item }}</span>
+    <nav class="sticky top-0 z-30 w-full bg-white/90 backdrop-blur border-y border-gray-100">
+        <div class="max-w-screen-lg mx-auto px-6">
+            <ul class="flex gap-1 sm:gap-2 overflow-x-auto list-none m-0 p-0 py-2 text-sm">
+                {% for item in nav %}
+                <li class="flex-shrink-0">
+                    <a href="#{{ item.id }}" class="flex items-center gap-2 px-3 py-1.5 rounded-full text-gray-500 hover:text-indigo-600 hover:bg-indigo-50 transition-colors">
+                        <span class="font-semibold text-indigo-400">{% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
+                        <span class="whitespace-nowrap">{{ item.label }}</span>
+                    </a>
                 </li>
                 {% endfor %}
             </ul>
-            {% endif %}
+        </div>
+    </nav>
+    {% endif %}
+
+    {% if customerPain %}
+    <!-- ============================================================
+         01. CUSTOMER PAIN
+    ============================================================ -->
+    <div id="customer-pain" class="w-full py-16 sm:py-24 px-6 bg-white scroll-mt-16">
+        <div class="max-w-screen-lg mx-auto">
+            <p class="uppercase tracking-widest text-xs font-semibold text-indigo-400 mb-2">01 · Customer pain</p>
+            <h2 class="max-md:text-center"><span class="text-red-600">{{ customerPain.heading }}</span></h2>
+            <div class="mt-6 grid grid-cols-1 md:grid-cols-2 gap-6 max-w-4xl">
+                {% for paragraph in customerPain.intro %}
+                <p class="text-gray-600 m-0">{{ paragraph }}</p>
+                {% endfor %}
+            </div>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 mt-12">
+                {% for card in customerPain.cards %}
+                <div class="rounded-xl bg-gray-50 border border-gray-200 p-6 flex flex-col gap-3">
+                    <div class="w-9 h-9 bg-white rounded-lg border border-gray-200 flex items-center justify-center text-red-500">
+                        <span class="w-5 h-5">{% include "components/icons/" + card.icon + ".svg" %}</span>
+                    </div>
+                    <h4 class="m-0 text-gray-800">{{ card.title }}</h4>
+                    <p class="m-0 text-gray-600 text-sm">{{ card.detail }}</p>
+                </div>
+                {% endfor %}
+            </div>
         </div>
     </div>
+    {% endif %}
 
+    {% if outcomeFirst %}
     <!-- ============================================================
-         4. HOW IT IS OPERATIONALIZED WITH FLOWFUSE (generic, no customer)
+         02. OUTCOME FIRST
     ============================================================ -->
-    <div class="w-full py-16 sm:py-24 px-6 bg-white">
+    <div id="outcome-first" class="w-full py-16 sm:py-24 px-6 bg-gray-50 border-y border-gray-100 scroll-mt-16">
         <div class="max-w-screen-lg mx-auto">
-            <h2 class="max-md:text-center">How it is operationalized with FlowFuse</h2>
-            <p class="text-gray-500 mt-2">Generic platform capabilities. No named customer or attributed quotes.</p>
-            {% set ops = [
-                {title: "Deployment", detail: "Ship the workflow to cloud, on-premise or edge from one platform."},
-                {title: "Governance", detail: "Keep humans in control with approvals and audit trails."},
-                {title: "Role-based access", detail: "Scope who can view, edit and deploy across teams."},
-                {title: "Version control", detail: "Track changes and roll back safely."},
-                {title: "CI/CD pipelines", detail: "Promote from development to test to production."},
-                {title: "Multi-site rollout", detail: "Roll the same workflow out to every site in a controlled way."},
-                {title: "Reuse", detail: "Package the pattern as a reusable building block."}
-            ] %}
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-x-10 gap-y-5 mt-8">
-                {% for op in ops %}
-                <div class="flex items-start gap-4">
-                    <span class="flex-shrink-0 w-8 h-8 bg-indigo-50 rounded-full flex items-center justify-center text-indigo-600">
-                        <span class="w-4 h-4">{% include "components/icons/check.svg" %}</span>
-                    </span>
+            <p class="uppercase tracking-widest text-xs font-semibold text-indigo-400 mb-2">02 · Outcome first</p>
+            <h2 class="max-md:text-center">{{ outcomeFirst.heading }}</h2>
+            <p class="mt-4 max-w-3xl text-gray-600">{{ outcomeFirst.intro }}</p>
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mt-12">
+                {% for dim in outcomeFirst.dimensions %}
+                <div class="rounded-xl bg-white border border-gray-200 p-6 flex flex-col gap-2">
+                    <span class="text-indigo-500 text-xs font-semibold uppercase tracking-widest">{{ dim.label }}</span>
+                    <h4 class="m-0 text-gray-800">{{ dim.title }}</h4>
+                    <p class="m-0 text-gray-600 text-sm">{{ dim.detail }}</p>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
+    {% if whyItMatters %}
+    <!-- ============================================================
+         03. WHY IT MATTERS
+    ============================================================ -->
+    <div id="why-it-matters" class="w-full bg-[radial-gradient(ellipse_120%_120%_at_50%_120%,theme(colors.indigo.600)_0%,theme(colors.indigo.900)_100%)] py-16 sm:py-24 px-6 scroll-mt-16">
+        <div class="max-w-screen-lg mx-auto">
+            <p class="uppercase tracking-widest text-xs font-semibold text-indigo-300 mb-2">03 · Why this is important</p>
+            <h2 class="text-white max-md:text-center">{{ whyItMatters.heading }}</h2>
+            <p class="mt-4 max-w-3xl text-indigo-100 font-light">{{ whyItMatters.intro }}</p>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-12">
+                {% for point in whyItMatters.points %}
+                <div class="rounded-xl border border-indigo-400/40 bg-indigo-950/30 p-6 flex gap-4">
+                    <span class="text-indigo-300 text-2xl font-semibold leading-none">{% if loop.index < 10 %}0{% endif %}{{ loop.index }}</span>
                     <div>
-                        <h5 class="m-0 text-gray-800">{{ op.title }}</h5>
-                        <p class="m-0 text-gray-600 text-sm">{{ op.detail }}</p>
+                        <h4 class="text-white m-0">{{ point.title }}</h4>
+                        <p class="text-indigo-100 font-light m-0 mt-1 text-sm">{{ point.detail }}</p>
                     </div>
                 </div>
                 {% endfor %}
             </div>
         </div>
     </div>
+    {% endif %}
 
+    {% if competition %}
     <!-- ============================================================
-         5. OUTCOMES (generic placeholder bullets, no client, no numbers)
+         04. WHY OFF-THE-SHELF / COMPETITION FAILS
     ============================================================ -->
-    <div class="w-full py-16 sm:py-24 px-6 comparison-section-bg">
+    <div id="competition" class="w-full py-16 sm:py-24 px-6 bg-white scroll-mt-16">
         <div class="max-w-screen-lg mx-auto">
-            <h2 class="text-indigo-600 max-md:text-center">Outcomes</h2>
-            <div class="mt-8 flex flex-col gap-4 max-w-3xl">
-                {% for outcome in outcomes %}
-                <div class="bg-white border border-indigo-100 rounded-lg p-5 flex items-center gap-4">
-                    <span class="flex-shrink-0 w-8 h-8 text-indigo-500">{% include "components/icons/arrow-trending-up.svg" %}</span>
-                    <p class="m-0 text-lg font-light text-gray-700">{{ outcome }}</p>
+            <p class="uppercase tracking-widest text-xs font-semibold text-indigo-400 mb-2">04 · Why off-the-shelf doesn't work</p>
+            <h2 class="max-md:text-center">{{ competition.heading }}</h2>
+            <p class="mt-4 max-w-3xl text-gray-600">{{ competition.intro }}</p>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-12">
+                {% for trap in competition.traps %}
+                <div class="rounded-xl bg-gray-50 border border-gray-200 p-6 flex flex-col gap-2">
+                    <div class="flex items-center gap-2">
+                        <span class="w-6 h-6 text-red-400">{% include "components/icons/x-circle.svg" %}</span>
+                        <span class="text-red-500 text-xs font-semibold uppercase tracking-widest">{{ trap.label }}</span>
+                    </div>
+                    <h4 class="m-0 text-gray-800">{{ trap.title }}</h4>
+                    <p class="m-0 text-gray-600 text-sm">{{ trap.detail }}</p>
                 </div>
                 {% endfor %}
             </div>
-            <p class="mt-6 text-xs text-gray-400 italic">Placeholder outcomes. No customer names or real figures.</p>
         </div>
     </div>
+    {% endif %}
+
+    {% if comparison %}
+    <!-- ============================================================
+         05. WITH / WITHOUT FLOWFUSE
+    ============================================================ -->
+    <div id="with-without" class="w-full py-16 sm:py-24 px-6 comparison-section-bg scroll-mt-16">
+        <div class="max-w-screen-lg mx-auto">
+            <p class="uppercase tracking-widest text-xs font-semibold text-indigo-400 mb-2">05 · With / without FlowFuse</p>
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 mt-6">
+                <div>
+                    <h3 class="text-gray-500 m-0">Without FlowFuse</h3>
+                    <div class="mt-6 flex flex-col gap-4">
+                        {% for row in comparison.without %}
+                        <div class="bg-white border border-gray-200 rounded-lg p-5 flex items-start gap-4">
+                            <span class="flex-shrink-0 w-6 h-6 text-red-400 mt-0.5">{% include "components/icons/x-mark.svg" %}</span>
+                            <div>
+                                <h5 class="m-0 text-gray-800">{{ row.title }}</h5>
+                                <p class="m-0 mt-1 text-gray-600 text-sm">{{ row.detail }}</p>
+                            </div>
+                        </div>
+                        {% endfor %}
+                    </div>
+                </div>
+                <div>
+                    <h3 class="text-indigo-600 m-0">With FlowFuse</h3>
+                    <div class="mt-6 flex flex-col gap-4">
+                        {% for row in comparison.with %}
+                        <div class="bg-white border border-indigo-100 rounded-lg p-5 flex items-start gap-4">
+                            <span class="flex-shrink-0 w-6 h-6 text-indigo-500 mt-0.5">{% include "components/icons/check-circle.svg" %}</span>
+                            <div>
+                                <h5 class="m-0 text-gray-800">{{ row.title }}</h5>
+                                <p class="m-0 mt-1 text-gray-600 text-sm">{{ row.detail }}</p>
+                            </div>
+                        </div>
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
+    {# ============================================================
+       LEGACY SKELETON FALL-BACK (only when no rich blocks defined)
+    ============================================================ #}
+    {% if not nav.length %}
+        {% if gap %}
+        <div class="w-full py-16 sm:py-24 px-6 bg-white">
+            <div class="max-w-screen-lg mx-auto">
+                <h2 class="max-md:text-center"><span class="text-red-600">The operational</span> gap</h2>
+                <div class="mt-6 grid grid-cols-1 md:grid-cols-2 gap-8 max-w-4xl">
+                    {% for paragraph in gap %}
+                    <p class="text-gray-600 m-0">{{ paragraph }}</p>
+                    {% endfor %}
+                </div>
+                <p class="mt-8 text-sm text-gray-400 italic">Placeholder copy. Generic operational framing for this workflow pattern.</p>
+            </div>
+        </div>
+        {% endif %}
+        {% if workflow %}
+        <div class="w-full bg-indigo-900 py-16 sm:py-24 px-6">
+            <div class="max-w-screen-lg mx-auto">
+                <h2 class="text-white text-center">The operational workflow</h2>
+                <ul class="mt-10 max-w-3xl mx-auto flex flex-col gap-3 list-none p-0">
+                    {% for item in workflow %}
+                    <li class="flex items-start gap-3 text-indigo-100">
+                        <span class="flex-shrink-0 w-6 h-6 text-indigo-300 mt-0.5">{% include "components/icons/check.svg" %}</span>
+                        <span>{{ item }}</span>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+        </div>
+        {% endif %}
+        {% if outcomes %}
+        <div class="w-full py-16 sm:py-24 px-6 comparison-section-bg">
+            <div class="max-w-screen-lg mx-auto">
+                <h2 class="text-indigo-600 max-md:text-center">Outcomes</h2>
+                <div class="mt-8 flex flex-col gap-4 max-w-3xl">
+                    {% for outcome in outcomes %}
+                    <div class="bg-white border border-indigo-100 rounded-lg p-5 flex items-center gap-4">
+                        <span class="flex-shrink-0 w-8 h-8 text-indigo-500">{% include "components/icons/arrow-trending-up.svg" %}</span>
+                        <p class="m-0 text-lg font-light text-gray-700">{{ outcome }}</p>
+                    </div>
+                    {% endfor %}
+                </div>
+                <p class="mt-6 text-xs text-gray-400 italic">Placeholder outcomes. No customer names or real figures.</p>
+            </div>
+        </div>
+        {% endif %}
+    {% endif %}
 
     <!-- ============================================================
-         6. RELATED RESOURCES (empty "More coming soon" state)
+         RELATED RESOURCES (empty "More coming soon" state)
     ============================================================ -->
     {% set relatedTag = "usecase:" + page.fileSlug %}
     {% include "components/related-resources.njk" %}
 
-    <!-- spacer so sticky dock never overlaps the final content -->
+    <!-- ============================================================
+         CLOSING CTA
+    ============================================================ -->
+    <div class="w-full px-6 py-20">
+        <div class="ff-blue-card max-md:max-w-xl md:max-w-screen-lg mx-auto pt-12 pb-10 text-center">
+            <h3 class="mb-4 w-full text-center">See it on your operation</h3>
+            <p class="text-gray-600 mb-8 max-w-xl mx-auto">Talk to an expert, or get started with FlowFuse today.</p>
+            <div class="flex flex-wrap gap-4 justify-center">
+                <a class="ff-btn ff-btn--highlight min-h-[40px] uppercase" href="/contact-us/" onclick="capture('cta-talk-to-expert', {'position': 'footer', 'usecase': '{{ page.fileSlug }}'})">Talk to an expert</a>
+                <a class="ff-btn ff-btn--primary-outlined min-h-[40px] uppercase" href="{% include "sign-up-url.njk" %}" onclick="capture('cta-join', {'position': 'footer', 'usecase': '{{ page.fileSlug }}'})">Get started</a>
+            </div>
+        </div>
+    </div>
+
 </div>

--- a/src/_includes/layouts/use-case.njk
+++ b/src/_includes/layouts/use-case.njk
@@ -1,0 +1,165 @@
+---
+layout: layouts/base.njk
+sitemapPriority: 0.7
+---
+{# ============================================================
+   USE CASE LAYOUT (skeleton, generic workflow pattern)
+   Per-page front-matter: problem, gap[], workflow[], outcomes[].
+   Sections 3 and 5 are fixed generic platform positioning.
+   No customer names, no quotes, no real numbers.
+   ============================================================ #}
+
+<div class="w-full">
+
+    <!-- ============================================================
+         HERO
+    ============================================================ -->
+    <div class="w-full px-6 bg-[radial-gradient(ellipse_120%_140%_at_50%_-20%,theme(colors.indigo.50)_0%,theme(colors.white)_60%)]">
+        <div class="max-w-screen-lg mx-auto py-16 sm:py-24 text-center">
+            <p class="uppercase tracking-widest text-sm font-semibold text-indigo-500 mb-4">Use case</p>
+            <h1 class="m-auto max-w-3xl font-medium"><span class="text-indigo-600">{{ title }}</span></h1>
+            <p class="mt-6 max-w-2xl mx-auto text-lg text-gray-600">{{ problem }}</p>
+            <div class="mt-10 flex flex-wrap gap-4 justify-center">
+                <a class="ff-btn ff-btn--highlight min-h-[40px] uppercase" href="/contact-us/" onclick="capture('cta-talk-to-expert', {'position': 'hero', 'usecase': '{{ page.fileSlug }}'})">Talk to an expert</a>
+            </div>
+        </div>
+    </div>
+
+    <!-- ============================================================
+         1. THE OPERATIONAL GAP
+    ============================================================ -->
+    <div class="w-full py-16 sm:py-24 px-6 bg-white">
+        <div class="max-w-screen-lg mx-auto">
+            <h2 class="max-md:text-center"><span class="text-red-600">The operational</span> gap</h2>
+            <div class="mt-6 grid grid-cols-1 md:grid-cols-2 gap-8 max-w-4xl">
+                {% for paragraph in gap %}
+                <p class="text-gray-600 m-0">{{ paragraph }}</p>
+                {% endfor %}
+            </div>
+            <p class="mt-8 text-sm text-gray-400 italic">Placeholder copy. Generic operational framing for this workflow pattern.</p>
+        </div>
+    </div>
+
+    <!-- ============================================================
+         2. WHY EXISTING SYSTEMS DID NOT SOLVE IT (fixed, generic)
+    ============================================================ -->
+    <div class="w-full py-16 sm:py-24 px-6 bg-gray-50 border-y border-gray-100">
+        <div class="max-w-screen-lg mx-auto">
+            <h2 class="text-center">Why existing systems did not solve it</h2>
+            {% set reasons = [
+                {title: "MES is too rigid", detail: "Fixed workflows are slow and costly to change as operations evolve."},
+                {title: "Dashboards do not act", detail: "Visibility alone does not trigger or coordinate a response."},
+                {title: "Historians store but do not orchestrate", detail: "Data is captured for later, not turned into action in the moment."},
+                {title: "ERP does not execute", detail: "Business systems plan work but do not run the operational workflow."},
+                {title: "AI builds but does not operationalize", detail: "Generated logic still needs governance, deployment and scale."},
+                {title: "Scripts do not scale", detail: "One-off scripts are hard to manage, repeat and roll out across sites."}
+            ] %}
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-12">
+                {% for reason in reasons %}
+                <div class="rounded-xl bg-white border border-gray-200 p-6 flex flex-col gap-2">
+                    <div class="w-8 h-8 text-red-400">{% include "components/icons/x-circle.svg" %}</div>
+                    <h4 class="m-0 text-gray-800">{{ reason.title }}</h4>
+                    <p class="m-0 text-gray-600 text-sm">{{ reason.detail }}</p>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+
+    <!-- ============================================================
+         3. THE OPERATIONAL WORKFLOW (Event, Decision, Action)
+    ============================================================ -->
+    <div class="w-full bg-[radial-gradient(ellipse_120%_120%_at_50%_120%,theme(colors.indigo.600)_0%,theme(colors.indigo.900)_100%)] py-16 sm:py-24 px-6">
+        <div class="max-w-screen-lg mx-auto">
+            <h2 class="text-white text-center">The operational workflow</h2>
+            <p class="text-indigo-200 text-center max-w-2xl mx-auto mt-4">A pattern that turns industrial events into action.</p>
+            {% set steps = [
+                {label: "Event", icon: "components/icons/bolt.svg", detail: "An industrial event triggers the workflow from a machine, sensor, broker or system signal."},
+                {label: "Decision", icon: "components/icons/arrows-right-left.svg", detail: "Event-driven orchestration applies logic, context and rules to decide what should happen."},
+                {label: "Action", icon: "components/icons/cursor-arrow-rays.svg", detail: "Guided operator actions and automated steps carry out the response where work happens."}
+            ] %}
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-12">
+                {% for step in steps %}
+                <div class="rounded-xl border border-indigo-400/40 bg-indigo-950/30 p-6 flex flex-col gap-3">
+                    <div class="flex items-center gap-3">
+                        <div class="w-10 h-10 bg-indigo-50 rounded-full flex items-center justify-center text-indigo-600">
+                            <span class="w-5 h-5">{% include step.icon %}</span>
+                        </div>
+                        <span class="text-indigo-300 text-sm font-semibold uppercase tracking-widest">{{ loop.index }}</span>
+                    </div>
+                    <h4 class="text-white m-0">{{ step.label }}</h4>
+                    <p class="text-indigo-100 font-light m-0">{{ step.detail }}</p>
+                </div>
+                {% endfor %}
+            </div>
+            {% if workflow %}
+            <ul class="mt-10 max-w-3xl mx-auto flex flex-col gap-3 list-none p-0">
+                {% for item in workflow %}
+                <li class="flex items-start gap-3 text-indigo-100">
+                    <span class="flex-shrink-0 w-6 h-6 text-indigo-300 mt-0.5">{% include "components/icons/check.svg" %}</span>
+                    <span>{{ item }}</span>
+                </li>
+                {% endfor %}
+            </ul>
+            {% endif %}
+        </div>
+    </div>
+
+    <!-- ============================================================
+         4. HOW IT IS OPERATIONALIZED WITH FLOWFUSE (generic, no customer)
+    ============================================================ -->
+    <div class="w-full py-16 sm:py-24 px-6 bg-white">
+        <div class="max-w-screen-lg mx-auto">
+            <h2 class="max-md:text-center">How it is operationalized with FlowFuse</h2>
+            <p class="text-gray-500 mt-2">Generic platform capabilities. No named customer or attributed quotes.</p>
+            {% set ops = [
+                {title: "Deployment", detail: "Ship the workflow to cloud, on-premise or edge from one platform."},
+                {title: "Governance", detail: "Keep humans in control with approvals and audit trails."},
+                {title: "Role-based access", detail: "Scope who can view, edit and deploy across teams."},
+                {title: "Version control", detail: "Track changes and roll back safely."},
+                {title: "CI/CD pipelines", detail: "Promote from development to test to production."},
+                {title: "Multi-site rollout", detail: "Roll the same workflow out to every site in a controlled way."},
+                {title: "Reuse", detail: "Package the pattern as a reusable building block."}
+            ] %}
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-x-10 gap-y-5 mt-8">
+                {% for op in ops %}
+                <div class="flex items-start gap-4">
+                    <span class="flex-shrink-0 w-8 h-8 bg-indigo-50 rounded-full flex items-center justify-center text-indigo-600">
+                        <span class="w-4 h-4">{% include "components/icons/check.svg" %}</span>
+                    </span>
+                    <div>
+                        <h5 class="m-0 text-gray-800">{{ op.title }}</h5>
+                        <p class="m-0 text-gray-600 text-sm">{{ op.detail }}</p>
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+
+    <!-- ============================================================
+         5. OUTCOMES (generic placeholder bullets, no client, no numbers)
+    ============================================================ -->
+    <div class="w-full py-16 sm:py-24 px-6 comparison-section-bg">
+        <div class="max-w-screen-lg mx-auto">
+            <h2 class="text-indigo-600 max-md:text-center">Outcomes</h2>
+            <div class="mt-8 flex flex-col gap-4 max-w-3xl">
+                {% for outcome in outcomes %}
+                <div class="bg-white border border-indigo-100 rounded-lg p-5 flex items-center gap-4">
+                    <span class="flex-shrink-0 w-8 h-8 text-indigo-500">{% include "components/icons/arrow-trending-up.svg" %}</span>
+                    <p class="m-0 text-lg font-light text-gray-700">{{ outcome }}</p>
+                </div>
+                {% endfor %}
+            </div>
+            <p class="mt-6 text-xs text-gray-400 italic">Placeholder outcomes. No customer names or real figures.</p>
+        </div>
+    </div>
+
+    <!-- ============================================================
+         6. RELATED RESOURCES (empty "More coming soon" state)
+    ============================================================ -->
+    {% set relatedTag = "usecase:" + page.fileSlug %}
+    {% include "components/related-resources.njk" %}
+
+    <!-- spacer so sticky dock never overlaps the final content -->
+</div>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -871,6 +871,18 @@ h4:hover .header-anchor::before {
         @apply py-3 pl-3;
     }
 
+    /* Solutions dropdown: two labelled subgroups separated by a single
+       full-height divider. The titles align left with their list items and
+       the divider runs the full height between the columns. */
+    .ff-website header .ff-nav-dropdown ul.ff-nav-subgroups > li > span.title {
+        text-align: left;
+        @apply sm:pl-3 sm:pr-4 sm:pb-1;
+    }
+    .ff-website header .ff-nav-dropdown ul.ff-nav-subgroups > li.ff-nav-subgroup-divider {
+        border-left: 1px solid theme(colors.gray.200);
+        @apply sm:pl-6;
+    }
+
     .ff-website header .ff-nav-dropdown >ul li a .ff-icon--solid {
         fill: theme(colors.gray.700);
     }

--- a/src/use-cases/_template.njk
+++ b/src/use-cases/_template.njk
@@ -11,6 +11,14 @@
 #   2. Replace the placeholder values below
 #   3. Make sure `tags` keeps `use-case` so the page appears in the
 #      `/use-cases/` hub grid
+#
+# The layout renders a pain-led narrative from the rich blocks below
+# (customerPain, outcomeFirst, whyItMatters, competition, comparison)
+# plus a sticky section nav. Every block is optional: a section only
+# renders when its block is present. Keep copy generic, with no
+# customer names and no attributed quotes.
+#
+# Icon names refer to files in src/_includes/components/icons/.
 # ===================================================================
 permalink: false
 eleventyExcludeFromCollections: true
@@ -20,17 +28,75 @@ tags:
 title: "[Use case title]"
 meta:
   title: "[Use case title] | Use Cases | FlowFuse"
-  description: "[One-sentence summary of the workflow pattern. Placeholder.]"
-problem: "[One short sentence stating the operational problem this pattern addresses. Placeholder.]"
-gap:
-  - "[First paragraph describing the operational gap. Placeholder.]"
-  - "[Second paragraph. Placeholder.]"
-workflow:
-  - "[First concrete step in the workflow. Placeholder.]"
-  - "[Second step. Placeholder.]"
-  - "[Third step. Placeholder.]"
-outcomes:
-  - "[First outcome bullet. Placeholder.]"
-  - "[Second outcome bullet. Placeholder.]"
-  - "[Third outcome bullet. Placeholder.]"
+  description: "[One-sentence summary of the use case. Placeholder.]"
+problem: "[The pain in one line. This is the hero sub-headline. Placeholder.]"
+
+# 01 -- Customer pain
+customerPain:
+  heading: "[One-line statement of the core pain.]"
+  intro:
+    - "[First framing paragraph.]"
+    - "[Second framing paragraph.]"
+  cards:
+    - icon: "clock"
+      title: "[Pain symptom.]"
+      detail: "[One or two sentences.]"
+    - icon: "clip-list"
+      title: "[Pain symptom.]"
+      detail: "[One or two sentences.]"
+
+# 02 -- Outcome first
+outcomeFirst:
+  heading: "[Reframe around the outcome the buyer defines.]"
+  intro: "[Why there is no one-size-fits-all answer.]"
+  dimensions:
+    - label: "Operational"
+      title: "[Outcome.]"
+      detail: "[One or two sentences.]"
+    - label: "Financial"
+      title: "[Outcome.]"
+      detail: "[One or two sentences.]"
+
+# 03 -- Why this is important
+whyItMatters:
+  heading: "[Why the gap compounds if left unaddressed.]"
+  intro: "[One framing sentence.]"
+  points:
+    - title: "[Reason.]"
+      detail: "[One or two sentences.]"
+    - title: "[Reason.]"
+      detail: "[One or two sentences.]"
+
+# 04 -- Why off-the-shelf / competition does not work
+competition:
+  heading: "[Why generic tools fit this operation poorly.]"
+  intro: "[One framing sentence.]"
+  traps:
+    - label: "Trap 01"
+      title: "[Trap.]"
+      detail: "[One or two sentences.]"
+    - label: "Trap 02"
+      title: "[Trap.]"
+      detail: "[One or two sentences.]"
+
+# 05 -- With / without FlowFuse
+comparison:
+  without:
+    - title: "[Status quo pain.]"
+      detail: "[One or two sentences.]"
+  with:
+    - title: "[FlowFuse capability.]"
+      detail: "[One or two sentences.]"
+
+# ---------------------------------------------------------------
+# Legacy minimal fall-back (still supported). If you only set these
+# and omit the rich blocks above, the layout renders a simple
+# gap / workflow / outcomes skeleton instead.
+# ---------------------------------------------------------------
+# gap:
+#   - "[Paragraph.]"
+# workflow:
+#   - "[Step.]"
+# outcomes:
+#   - "[Outcome.]"
 ---

--- a/src/use-cases/_template.njk
+++ b/src/use-cases/_template.njk
@@ -1,0 +1,36 @@
+---
+# ===================================================================
+# Use-case page TEMPLATE.
+#
+# This file is intentionally NOT rendered (permalink: false) and is
+# NOT included in the `use-case` collection. It exists as a copy-and-
+# rename starting point for new use-case pages.
+#
+# To create a new use-case page:
+#   1. Copy this file to `src/use-cases/<slug>.njk`
+#   2. Replace the placeholder values below
+#   3. Make sure `tags` keeps `use-case` so the page appears in the
+#      `/use-cases/` hub grid
+# ===================================================================
+permalink: false
+eleventyExcludeFromCollections: true
+layout: use-case
+tags:
+  - use-case
+title: "[Use case title]"
+meta:
+  title: "[Use case title] | Use Cases | FlowFuse"
+  description: "[One-sentence summary of the workflow pattern. Placeholder.]"
+problem: "[One short sentence stating the operational problem this pattern addresses. Placeholder.]"
+gap:
+  - "[First paragraph describing the operational gap. Placeholder.]"
+  - "[Second paragraph. Placeholder.]"
+workflow:
+  - "[First concrete step in the workflow. Placeholder.]"
+  - "[Second step. Placeholder.]"
+  - "[Third step. Placeholder.]"
+outcomes:
+  - "[First outcome bullet. Placeholder.]"
+  - "[Second outcome bullet. Placeholder.]"
+  - "[Third outcome bullet. Placeholder.]"
+---

--- a/src/use-cases/index.njk
+++ b/src/use-cases/index.njk
@@ -1,0 +1,57 @@
+---
+layout: layouts/base.njk
+sitemapPriority: 0.8
+title: "Use Cases"
+meta:
+  title: "Use Cases | FlowFuse"
+  description: "Generic operational workflow patterns for industrial teams. Turn events into action with FlowFuse. Placeholder skeleton hub."
+---
+<div class="w-full">
+
+    <!-- HERO with CTA buttons -->
+    <div class="w-full px-6 bg-[radial-gradient(ellipse_120%_140%_at_50%_-20%,theme(colors.indigo.50)_0%,theme(colors.white)_60%)]">
+        <div class="max-w-screen-lg mx-auto py-16 sm:py-24 text-center">
+            <p class="uppercase tracking-widest text-sm font-semibold text-indigo-500 mb-4">Use cases</p>
+            <h1 class="m-auto max-w-3xl font-medium">Turn industrial events into <span class="text-indigo-600">action</span></h1>
+            <p class="mt-6 max-w-2xl mx-auto text-lg text-gray-600">Operational workflow patterns that follow Event, Decision, Action. Explore how each one is operationalized with FlowFuse.</p>
+            <div class="mt-10 flex flex-wrap gap-4 justify-center">
+                <a class="ff-btn ff-btn--highlight min-h-[40px] uppercase" href="/contact-us/" onclick="capture('cta-talk-to-expert', {'position': 'hero', 'page': 'use-cases-hub'})">Talk to an expert</a>
+            </div>
+        </div>
+    </div>
+
+    <!-- USE CASE CARD GRID -->
+    <div class="w-full py-16 sm:py-24 px-6 bg-white">
+        <div class="max-w-screen-lg mx-auto">
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                {% for uc in collections["use-case"] | sort(false, true, "data.title") %}
+                <a href="{{ uc.url }}" class="group flex flex-col gap-3 rounded-xl border border-gray-200 p-6 bg-white hover:border-indigo-300 hover:shadow-sm transition-all">
+                    <h3 class="m-0 text-gray-800 group-hover:text-indigo-600 transition-colors">{{ uc.data.title }}</h3>
+                    <p class="m-0 text-gray-600 text-sm flex-grow">{{ uc.data.problem }}</p>
+                    <span class="mt-2 text-indigo-600 text-sm font-semibold flex items-center gap-2">
+                        View use case
+                        <span class="w-4 h-4">{% include "components/icons/arrow-right.svg" %}</span>
+                    </span>
+                </a>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+
+    <!-- RESOURCES BLOCK PLACEHOLDER -->
+    {% set relatedTag = "" %}
+    {% include "components/related-resources.njk" %}
+
+    <!-- CLOSING CTA BAND -->
+    <div class="w-full px-6 py-20">
+        <div class="ff-blue-card max-md:max-w-xl md:max-w-screen-lg mx-auto pt-12 pb-10 text-center">
+            <h3 class="mb-4 w-full text-center">See it on your workflow</h3>
+            <p class="text-gray-600 mb-8 max-w-xl mx-auto">Talk to an expert, or get started with FlowFuse today.</p>
+            <div class="flex flex-wrap gap-4 justify-center">
+                <a class="ff-btn ff-btn--highlight min-h-[40px] uppercase" href="/contact-us/" onclick="capture('cta-talk-to-expert', {'position': 'footer', 'page': 'use-cases-hub'})">Talk to an expert</a>
+                <a class="ff-btn ff-btn--primary-outlined min-h-[40px] uppercase" href="{% include "sign-up-url.njk" %}" onclick="capture('cta-join', {'position': 'footer', 'page': 'use-cases-hub'})">Get started</a>
+            </div>
+        </div>
+    </div>
+
+</div>

--- a/src/use-cases/production-monitoring.njk
+++ b/src/use-cases/production-monitoring.njk
@@ -1,0 +1,125 @@
+---
+layout: use-case
+tags:
+  - use-case
+title: "Production Monitoring"
+meta:
+  title: "Production Monitoring | Use Cases | FlowFuse"
+  description: "Real-time visibility into what your production lines are actually doing. Build the monitoring app your operation needs with FlowFuse and Node-RED: connect any protocol, deploy at the edge or in the cloud, and roll out across sites."
+problem: "Your operation is running. You just can't see it clearly enough, until something breaks."
+
+customerPain:
+  heading: "Visibility gaps are expensive."
+  intro:
+    - "Production teams know their lines are running. What they don't always know is how well, until a supervisor walks the floor, a shift report lands, or a machine stops."
+    - "By then, the window to intervene is gone. Decisions get made on lag, instinct, and tribal knowledge instead of data."
+    - "The pain isn't unique to any one industry. It surfaces wherever machines produce output and humans are responsible for the result."
+  cards:
+    - icon: "clock"
+      title: "Reactive firefighting"
+      detail: "Problems are discovered after the fact, via alarms, operator reports, or finished-goods inspection. The response is always late."
+    - icon: "clip-list"
+      title: "Manual data collection"
+      detail: "Operators log counts, cycle times, and downtime events by hand. Numbers are inconsistent, delayed, and disconnected from the actual machine record."
+    - icon: "link-slash"
+      title: "Data that doesn't talk"
+      detail: "PLCs, SCADA, MES, and ERP each hold a piece of the picture. Nobody has connected them. Each system speaks a different protocol."
+    - icon: "chart"
+      title: "Reporting built on stale data"
+      detail: "Shift summaries and OEE reports tell you what happened yesterday. Nobody is watching what is happening now."
+
+outcomeFirst:
+  heading: "Define what \"monitored\" means for your operation."
+  intro: "There is no universal production monitoring app, because every operation measures success differently. The value FlowFuse delivers isn't a fixed dashboard. It is the ability to build exactly the one your operation needs."
+  dimensions:
+    - label: "Operational"
+      title: "Know what every line is producing, right now"
+      detail: "Live counts, cycle times, and throughput visible to anyone who needs them, from the floor to the control room."
+    - label: "Financial"
+      title: "Turn downtime from a cost center into a managed metric"
+      detail: "When you can see and categorize downtime events as they happen, you can act on them, and start reducing them systematically."
+    - label: "Organizational"
+      title: "Replace floor walks with live visibility"
+      detail: "Supervisors and engineers spend less time gathering data and more time acting on it. The floor reports to them, not the other way around."
+    - label: "Quality"
+      title: "Catch deviations before they become defects"
+      detail: "Monitoring process conditions in real time means anomalies surface early, before they have run through a full batch or shift."
+    - label: "Strategic"
+      title: "Build a data foundation you actually own"
+      detail: "Contextualized, historian-backed production data that feeds into MES, ERP, or AI tools, on your terms, not a vendor's."
+    - label: "Flexibility"
+      title: "Start where the pain is, scale from there"
+      detail: "One line, one shift, one KPI. Prove value fast, then expand. You are not locked into a one-size-fits-all deployment model."
+
+whyItMatters:
+  heading: "Blind production is a compounding liability."
+  intro: "Every hour a line runs without real-time visibility, the cost of the gap grows, not just in lost output, but in the decisions that never got made."
+  points:
+    - title: "Downtime is under-reported by design"
+      detail: "Manual logging creates pressure to minimize recorded stops. The real downtime picture is almost always worse than the data shows, which means improvement programs are built on a false baseline."
+    - title: "Reactive maintenance costs more than planned"
+      detail: "When you can't see a machine degrading, you can't schedule around it. You respond to failures instead of preventing them, and pay the premium every time."
+    - title: "OEE without live data is a lagging indicator"
+      detail: "A shift report tells you your OEE was 68%. Live monitoring tells you it dropped to 51% at 10:42 and you can still do something about it."
+    - title: "Digitization pressure isn't going away"
+      detail: "Customer requirements, ESG commitments, and internal efficiency mandates all require production data. The longer it takes to build the foundation, the further behind you fall."
+    - title: "The talent that knows your machines is leaving"
+      detail: "Experienced operators carry decades of institutional knowledge. Without a system to capture and surface what they know, that knowledge walks out the door at retirement."
+
+competition:
+  heading: "Your operation isn't a template."
+  intro: "Off-the-shelf monitoring platforms are built to fit the widest possible audience, which means they fit your specific operation poorly. You end up adapting your processes to the tool, not the other way around."
+  traps:
+    - label: "Trap 01"
+      title: "Rigid data models that don't match your machines"
+      detail: "Pre-built solutions assume standard signals, standard naming conventions, and standard equipment hierarchies. Your PLC speaks Siemens S7. Your historian uses a custom tag structure built in 2009. The integration becomes a months-long professional-services engagement, if it is even possible."
+    - label: "Trap 02"
+      title: "One dashboard for everyone means optimal for no one"
+      detail: "The shift supervisor needs a line overview. The maintenance engineer needs trend data on a specific axis. The plant manager needs a KPI roll-up. Off-the-shelf tools offer one fixed view, or an expensive configuration layer to build the others."
+    - label: "Trap 03"
+      title: "Time-to-value measured in quarters, not weeks"
+      detail: "Configuration, data mapping, and integration scoping turn into a professional-services engagement that drags on. The pilot budget runs out before anyone sees a working dashboard, and the project quietly stalls before it ever proves value."
+    - label: "Trap 04"
+      title: "Deployment models built for greenfield, not the shop floor"
+      detail: "Cloud-first SaaS tools were not designed for air-gapped networks, aging edge hardware, or mixed OT/IT environments where every change requires a change-management process. Getting them deployed takes longer than the pilot budget allows."
+
+comparison:
+  without:
+    - title: "Visibility on a delay"
+      detail: "Production status comes from shift reports, floor walks, and end-of-day summaries. By the time you know something went wrong, the shift is over."
+    - title: "Integrations that never close"
+      detail: "Every protocol difference, every legacy PLC, every proprietary historian adds months to a monitoring project. Most stall in pilot."
+    - title: "Apps built for someone else's operation"
+      detail: "The vendor's dashboard shows what they thought you would want to see. Your real KPIs live in a spreadsheet someone updates manually every morning."
+    - title: "IT projects that outpace OT readiness"
+      detail: "Cloud-native tools land in environments that were not built for them. Security reviews, network changes, and change management consume the timeline."
+    - title: "One site at a time, forever"
+      detail: "Even if a monitoring app works well in one facility, replicating it means rebuilding it. Nothing transfers. Every deployment is a new project."
+  with:
+    - title: "Live production data, where you need it"
+      detail: "Node-RED flows collect, contextualize, and surface machine data in real time, on the floor, in the control room, or wherever your team works."
+    - title: "Connect anything, regardless of protocol"
+      detail: "OPC-UA, Modbus, S7, MQTT, REST: Node-RED speaks them all. FlowFuse manages the infrastructure so your integrations stay running."
+    - title: "Build the app your operation actually needs"
+      detail: "FlowFuse Dashboard gives your team the tools to build purpose-fit interfaces, without a dedicated front-end developer or a six-figure SI engagement."
+    - title: "Runs at the edge, in the cloud, or both"
+      detail: "Deploy the Device Agent on existing edge hardware. Run instances in FlowFuse Cloud. Mix and match based on what your network allows."
+    - title: "Snapshot, replicate, and roll out at scale"
+      detail: "Once your monitoring app works on one line, FlowFuse lets you snapshot it and push it across every site, with environment-specific variables, centrally managed. Built on open Node-RED, the foundation stays yours."
+---
+{#
+  INTERNAL, NOT RENDERED. Marketing guidance for the next content pass.
+
+  Sections 6 to 10 still to be built:
+  - Lead with a crawl/walk/run framing: one line, one data source, one KPI,
+    building to multi-site. Avoid a big-bang deployment tone.
+  - Show how we do it: 2 to 3 reference flows from the Pulse flows JSON
+    (data collection, dashboard logic, alerting). Screenshots or embedded
+    flow diagrams work here.
+  - FlowFuse expert enablement: link certified nodes (OPC-UA, S7, MQTT),
+    Dashboard docs, and SE-led workshop content.
+  - Customer success / credibility: case study or sanitized reference
+    (e.g. "global automotive manufacturer") rather than a blank page.
+  - SEO aliasing: this same buyer pain also reads as "Machine Monitoring",
+    "Line Visibility", "OEE Tracking", "Real-Time Production Intelligence".
+#}


### PR DESCRIPTION
## Summary

Stacked on top of the **Use Cases structure** PR (#5079). Splits the existing flat **Solutions** dropdown into two labelled subgroups:

- **By architecture** — the existing six architecture solution links, unchanged.
- **By use case** — links to the seven use-case pattern pages + an "All use cases" link to the `/use-cases/` hub.

Adds the supporting subgroup divider CSS so the two columns sit side by side with a single full-height divider between them.

**Base:** `feat/use-cases-structure`. Use-case links resolve as the per-pattern content PRs land. **No other nav changes** in this PR (Industries dropdown / nav reorder ship separately).
