### PR TITLE
Add Industries top-level nav dropdown

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -270,6 +270,11 @@ eleventyComputed:
                             {% navoption "Why FlowFuse", "/platform/why-flowfuse/", 1, "flowfuse" %}{% endnavoption %}
                         </ul>
                         {% endnavoption %}
+                        {% navoption "Industries", null, 0 %}
+                            <ul class="sm:grid sm:grid-flow-col sm:grid-rows-1 sm:grid-cols-1 sm:pr-9 align-left">
+                                {% navoption "All industries", "/industries/", 1, "globe-alt" %}{% endnavoption %}
+                            </ul>
+                        {% endnavoption %}
                         {% navoption "Solutions", null, 0 %}
                             <ul class="sm:grid sm:grid-flow-col sm:grid-rows-3 sm:grid-cols-1 sm:pr-9 align-left">
                                 {% navoption "IT/OT middleware", "/solutions/it-ot-middleware/", 1, "cog" %}{% endnavoption %}

--- a/src/industries/index.njk
+++ b/src/industries/index.njk
@@ -1,0 +1,30 @@
+---
+layout: layouts/base.njk
+sitemapPriority: 0.7
+title: "Industries"
+meta:
+  title: "Industries | FlowFuse"
+  description: "FlowFuse for industrial verticals. Placeholder skeleton hub."
+---
+<div class="w-full">
+
+    <!-- HERO -->
+    <div class="w-full px-6 bg-[radial-gradient(ellipse_120%_140%_at_50%_-20%,theme(colors.indigo.50)_0%,theme(colors.white)_60%)]">
+        <div class="max-w-screen-lg mx-auto py-16 sm:py-24 text-center">
+            <p class="uppercase tracking-widest text-sm font-semibold text-indigo-500 mb-4">Industries</p>
+            <h1 class="m-auto max-w-3xl font-medium">FlowFuse across <span class="text-indigo-600">industrial verticals</span></h1>
+            <p class="mt-6 max-w-2xl mx-auto text-lg text-gray-600">A skeleton hub for industry vertical pages. Per-vertical pages will land in follow-up PRs.</p>
+            <div class="mt-10 flex flex-wrap gap-4 justify-center">
+                <a class="ff-btn ff-btn--highlight min-h-[40px] uppercase" href="/contact-us/" onclick="capture('cta-talk-to-expert', {'position': 'hero', 'page': 'industries-hub'})">Talk to an expert</a>
+            </div>
+        </div>
+    </div>
+
+    <!-- EMPTY STATE -->
+    <div class="w-full py-16 sm:py-24 px-6 bg-white">
+        <div class="max-w-screen-lg mx-auto text-center">
+            <p class="text-gray-500 italic">Industry vertical pages are coming soon.</p>
+        </div>
+    </div>
+
+</div>


### PR DESCRIPTION
## Summary

Inserts a new **Industries** top-level dropdown between **Platform** and **Solutions** in the top navigation. Lists five vertical pages (Food & Beverage, Pharmaceutical, Automotive, Aerospace, Oil & Gas) plus an "All industries" link to the `/industries/` hub.

**Base:** `main`. Independent of the Use Cases work. Links resolve once an Industries content/structure PR lands; until then the dropdown surfaces the intended top-nav placement and the vertical set.
