### PR TITLE
[4972] Rework the install box on the integration detail page - fix img rendering 

### DIFF
--- a/src/_includes/layouts/integration.njk
+++ b/src/_includes/layouts/integration.njk
@@ -159,13 +159,9 @@ layout: layouts/base.njk
                         Installation
                     </h3>
                     <p class="text-sm text-gray-600 mb-3">Install in Node-RED via the <a href="https://flowfuse.com/node-red/getting-started/library/#using-the-palette-manager" class="text-indigo-600 hover:text-indigo-800 font-semibold" target="_blank" rel="noopener noreferrer">palette manager</a>.</p>
-                    <img
-                        src="/img/installing-node-red-node.gif"
-                        alt="Animation of the Node-RED palette manager: open Manage Palette, search for the node, then click Install."
-                        loading="lazy"
-                        width="1326"
-                        height="720"
-                        class="motion-reduce:hidden block w-full rounded border border-gray-200" />
+                    <div class="motion-reduce:hidden [&_img]:block [&_img]:w-full [&_img]:rounded [&_img]:border [&_img]:border-gray-200">
+                        {% image "./node-red/getting-started/library/images/installing-node-red-node.gif", "Animation of the Node-RED palette manager: open Manage Palette, search for the node, then click Install.", [707] %}
+                    </div>
                     <img
                         src="/images/integrations/palette-manager-install.png"
                         alt="Node-RED Palette Manager dialog with the node selected and the Install button visible."


### PR DESCRIPTION
## Description

The integration detail page's install box was rendering a broken-image placeholder in production because the template hardcoded `/img/installing-node-red-node.gif`, a URL that only exists when `DEV_MODE` skips the eleventy-image pipeline — in production the pipeline hashes the filename. 

Swapped the raw `<img>` for the `{% image %}` shortcode (matching how every other page references pipeline-processed images), with a `motion-reduce:hidden` wrapper div to preserve the existing accessibility dual-image pattern.

## Related Issue(s)

Relates to #4972 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

