### PR TITLE
handbook: single canonical home for the Cloud change-request flow

### DIFF
--- a/nuxt/content/handbook/engineering/ops/self-hosted-assistant.md
+++ b/nuxt/content/handbook/engineering/ops/self-hosted-assistant.md
@@ -16,7 +16,7 @@ The FlowFuse Expert consists of two internal components that each need to be ena
 
 1. Customer emails `support@flowfuse.com`
 2. Support/Sales needs to verify that the customer has a current Enterprise License
-3. Once confirmed, they raise a [Production Change Request](https://github.com/FlowFuse/CloudProject/issues/new?assignees=&labels=change-request&projects=&template=change-request.yml&title=Change%3A+) providing details of the Customer and post a message to `#dept-engineering` with a link.
+3. Once confirmed, they raise a [Production Change Request](/handbook/operations/change/#flowfuse-cloud-change-control) providing details of the Customer and post a message to `#dept-engineering` with a link.
 4. Engineering needs to create **two** access tokens for the customer.
    1. **Assistant**: Open the Instance Settings for the `flow-gen` instance in the `Internal Tools` Application. Under the Security settings create a new HTTP Bearer Token using the customer name as the token name. The token will only be displayed once, so make a note of it - this is the **Assistant Token**.
    2. **Expert**: Open the Instance Settings for the `flowfuse-expert-api` instance in the `Internal Tools` Application. Under the Security settings create a new HTTP Bearer Token using the customer name as the token name. The token will only be displayed once, so make a note of it - this is the **Expert Token**.

--- a/nuxt/content/handbook/engineering/product/blueprints.md
+++ b/nuxt/content/handbook/engineering/product/blueprints.md
@@ -112,7 +112,7 @@ You can import the required comment node by importing the following JSON:
 
 #### Submitting a Change Request
 
-To add a Blueprint to FlowFuse Cloud, a [Change Request](https://github.com/FlowFuse/CloudProject/issues/new?assignees=&labels=change-request&projects=&template=change-request.yml&title=Change%3A+) must be submitted. 
+To add a Blueprint to FlowFuse Cloud, submit a Change Request following the [Change Control process](/handbook/operations/change/#flowfuse-cloud-change-control).
 
 Example Change Request: Change: Add OEE Dashboard Blueprint to production
 ```

--- a/nuxt/content/handbook/engineering/product/blueprints.md
+++ b/nuxt/content/handbook/engineering/product/blueprints.md
@@ -27,7 +27,7 @@ We encourage Blueprint submissions from our customers, partners, and the wider c
 
 ### Internal Development
 
-If a Blueprint is being developed internally, it should be added to the `blueprint-library` repository via a Pull Request. First, create an issue in the same repository to track its progress and ensure alignment with product and company strategy. The Pull Request must be reviewed and tested by another team member. Once approved, [submit a Change Request](#submitting-a-change-request). When the responsible admin adds the Blueprint to the platform, they will share the Blueprint ID with the author, who should then include it in the Blueprint's README file:
+If a Blueprint is being developed internally, it should be added to the `blueprint-library` repository via a Pull Request. First, create an issue in the same repository to track its progress and ensure alignment with product and company strategy. The Pull Request must be reviewed and tested by another team member. Once approved, [submit a Change Request](/handbook/operations/change/#flowfuse-cloud-change-control). When the responsible admin adds the Blueprint to the platform, they will share the Blueprint ID with the author, who should then include it in the Blueprint's README file:
 
 ```markdown
 ---
@@ -110,9 +110,7 @@ You can import the required comment node by importing the following JSON:
 
 ### Platform
 
-#### Submitting a Change Request
-
-To add a Blueprint to FlowFuse Cloud, submit a Change Request following the [Change Control process](/handbook/operations/change/#flowfuse-cloud-change-control).
+To add a Blueprint to FlowFuse Cloud, submit a Change Request following the [Change Control process](/handbook/operations/change/#flowfuse-cloud-change-control). A blueprint change request looks like:
 
 Example Change Request: Change: Add OEE Dashboard Blueprint to production
 ```

--- a/nuxt/content/handbook/engineering/product/blueprints.md
+++ b/nuxt/content/handbook/engineering/product/blueprints.md
@@ -110,29 +110,7 @@ You can import the required comment node by importing the following JSON:
 
 ### Platform
 
-To add a Blueprint to FlowFuse Cloud, submit a Change Request following the [Change Control process](/handbook/operations/change/#flowfuse-cloud-change-control). A blueprint change request looks like:
-
-Example Change Request: Change: Add OEE Dashboard Blueprint to production
-```
-### Environment
-
-- [ ] Staging
-- [x] Production
-
-### Due Date
-
-_No response_
-
-### Change Description
-
-This PR (<PR_LINK>) adds a new blueprint flow, along with documentation on how to use it with both real-world and simulated data sources.
-
-### Validation Steps
-
-- [ ] Is the Blueprint PR approved?  
-- [ ] Is the blueprint added to the specified environment?  
-- [ ] Is the Blueprint PR documentation updated with the blueprint ID and merged?
-```
+To add a Blueprint to FlowFuse Cloud, submit a Change Request following the [Change Control process](/handbook/operations/change/#flowfuse-cloud-change-control), using the change request template in the CloudProject repository.
 
 The issue should include a link to the relevant Pull Request in the Blueprint Library repository where your Blueprint has been published.
 

--- a/nuxt/content/handbook/engineering/releases/process.md
+++ b/nuxt/content/handbook/engineering/releases/process.md
@@ -177,7 +177,7 @@ must be done manually.
    to update the version and `CHANGELOG.md` file with suitable details.
  - Create the GitHub release with the appropriate `vX.Y.Z` tag.
 
-Finally, create two [change requests](/handbook/operations/change/), one for
+Finally, create two [change requests](/handbook/operations/change/#flowfuse-cloud-change-control), one for
 staging and one for production to upgrade to the latest version.
 
 ### Unmanaged Releases

--- a/nuxt/content/handbook/engineering/releases/process.md
+++ b/nuxt/content/handbook/engineering/releases/process.md
@@ -146,7 +146,7 @@ Follow these steps to run the script:
 
 Once everything has been published, the Release Manager should:
 
-1. Raise a "FlowFuse Cloud Change Requests" Issue in [CloudProject Project](https://github.com/FlowFuse/CloudProject/issues/new/choose) to request Production to be updated to the new version. Stack update procedure can be found [here](../ops/production-stack-update.md)
+1. Raise a [FlowFuse Cloud Change Request](/handbook/operations/change/#flowfuse-cloud-change-control) to request Production to be updated to the new version. Stack update procedure can be found [here](../ops/production-stack-update.md)
 2. Notify the CTO/Senior Engineer that the release is ready to publish to production.
 
 Once Production has been updated and verified, the Release Manager should announce

--- a/nuxt/content/handbook/operations/accounts.md
+++ b/nuxt/content/handbook/operations/accounts.md
@@ -34,7 +34,7 @@ revenue tracking. This is achieved by placing the team into 'manual' billing mod
 For customers on contracted revenue, e.g. an annual deal made by an account
 executive, the team too is put into manual billing mode. 
 
-1. Raise a [Change Request](./change.md) with the name of the team and a request to move it to manual billing mode
+1. Raise a [Change Request](/handbook/operations/change/#flowfuse-cloud-change-control) with the name of the team and a request to move it to manual billing mode
 2. The request can be actioned by anyone with admin access to the platform. They will have access to admin-only
    tools on the Team Settings/Danger page, including the option to 'Setup Manual Billing'. As part of this process,
    they can pick what Team Type should be applied. Unless specifically requested otherwise, teams should always be

--- a/nuxt/content/handbook/sales/meetings/poc.md
+++ b/nuxt/content/handbook/sales/meetings/poc.md
@@ -10,7 +10,7 @@ If the prospect would like to trial FlowFuse Cloud, they are able to self-servic
 
 #### Extending a trial
 
-To extend the trial period, including if a trial has expired already, use the 'Extend Trial' button on the Team Settings page. This is only available to platform Administrators. If you do not have admin access, raise a [CloudProject change request](https://github.com/FlowFuse/CloudProject/issues/new?assignees=&labels=change-request&projects=&template=change-request.yml&title=Change%3A+) with details.
+To extend the trial period, including if a trial has expired already, use the 'Extend Trial' button on the Team Settings page. This is only available to platform Administrators. If you do not have admin access, raise a [CloudProject change request](/handbook/operations/change/#flowfuse-cloud-change-control) with details.
 
 ### Self-hosted trial
 


### PR DESCRIPTION
## Description

This PR makes the FlowFuse Cloud change request flow live in one place in the handbook, rather than being copied across several pages.

Before, the actual process and the change request issue link sat in `operations/change.md` (the canonical spot), but a handful of other pages had drifted from it:

- Release process, self-hosted assistant, and POC pages each re-pasted the raw GitHub new-issue URL
- Blueprints went further and re-described the whole thing with its own worked example

What it does:

- Points every one of those pages back at the canonical section (`/handbook/operations/change/#flowfuse-cloud-change-control`)
- Drops the duplicated example in blueprints, pointing instead to the change request template that already lives in the CloudProject repo

End result: the issue link and the steps exist in exactly one location. If the template or the process changes, we update `change.md` and nothing else goes stale.

## Related Issue(s)

None.

## Checklist

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215298579367712