### PR TITLE
Update Cloud Pro trial length from 14 to 30 days

### DIFF
--- a/src/blog/2025/08/pareto-chart-manufacturing-guide.md
+++ b/src/blog/2025/08/pareto-chart-manufacturing-guide.md
@@ -186,4 +186,4 @@ The first step is always the hardest—and the most important. Choose one persis
 
 **Ready to transform your manufacturing data into actionable insights?** 
 
-Stop guessing which problems to tackle first. [Try FlowFuse free for 14 days]({% include "sign-up-url.njk" %}) and build automated Pareto Charts that connect directly to your production data, or [see a live demo](/book-demo/) of how leading manufacturers identify their vital few problems in real-time.
+Stop guessing which problems to tackle first. [Try FlowFuse free for 30 days]({% include "sign-up-url.njk" %}) and build automated Pareto Charts that connect directly to your production data, or [see a live demo](/book-demo/) of how leading manufacturers identify their vital few problems in real-time.

--- a/src/blog/2025/09/creating-pareto-chart.md
+++ b/src/blog/2025/09/creating-pareto-chart.md
@@ -23,7 +23,7 @@ _Pareto Chart showing defect categories in manufacturing with bars for scratches
 
 ## Getting Started
 
-To create a Pareto Chart for manufacturing data, you'll need access to industrial data platforms that can connect to your production systems. This guide uses FlowFuse, a low-code platform that simplifies industrial data workflows. If you don't have an account yet, you can [sign up for a 14-day free trial](https://app.flowfuse.com/).
+To create a Pareto Chart for manufacturing data, you'll need access to industrial data platforms that can connect to your production systems. This guide uses FlowFuse, a low-code platform that simplifies industrial data workflows. If you don't have an account yet, you can [sign up for a 30-day free trial](https://app.flowfuse.com/).
 
 ### Step 1: Connect to Your Data Source
 

--- a/src/blog/2025/09/installing-node-red.md
+++ b/src/blog/2025/09/installing-node-red.md
@@ -53,7 +53,7 @@ As the official enterprise solution developed by Node-RED's creator, FlowFuse re
 
 ## Setting Up FlowFuse
 
-Sign up for the [14-day trial]({% include "sign-up-url.njk" %}) at FlowFuse, and you can get started immediately.
+Sign up for the [30-day trial]({% include "sign-up-url.njk" %}) at FlowFuse, and you can get started immediately.
 
 ### Step 1: Add Remote Instance
 

--- a/src/blog/2025/11/building-label-scanner-with-flowfuse.md
+++ b/src/blog/2025/11/building-label-scanner-with-flowfuse.md
@@ -32,7 +32,7 @@ This tutorial shows you how you can build an OCR system using FlowFuse that can 
 ## Getting Started
 
 Before we dive in, make sure you have a running FlowFuse instance.
-If you do not have one yet, you can [sign up for the 14-day free trial](https://app.flowfuse.com/) and get a hosted instance running in under two minutes.
+If you do not have one yet, you can [sign up for the 30-day free trial](https://app.flowfuse.com/) and get a hosted instance running in under two minutes.
 
 ### Installing Required Nodes
 
@@ -185,4 +185,4 @@ FlowFuse helps manufacturers like you break down data silos and build connected,
 
 **See it in action.** [Book a demo](/book-demo/) and discover how FlowFuse can transform your entire facility—not just your label scanning.
 
-Or start building today with our [14-day free trial](https://app.flowfuse.com/).
+Or start building today with our [30-day free trial](https://app.flowfuse.com/).

--- a/src/blog/2026/02/edge-ai-is-80-percent-pipeline-and-20-percent-ai.md
+++ b/src/blog/2026/02/edge-ai-is-80-percent-pipeline-and-20-percent-ai.md
@@ -76,4 +76,4 @@ What separates them is the plumbing.
 
 Build it on something that understands where you are starting from.
 
-*If you are running Node-RED in production today, or trying to, FlowFuse is the operational layer that makes it scale. Device management, snapshot deployments, DevOps pipelines, ONNX-based AI inference, and the FlowFuse Expert to build faster, all built specifically for industrial environments. [Start a 14-day free trial today]({% include "sign-up-url.njk" %}). No abstractions. No greenfield assumptions. Just the infrastructure your plant actually needs.*
+*If you are running Node-RED in production today, or trying to, FlowFuse is the operational layer that makes it scale. Device management, snapshot deployments, DevOps pipelines, ONNX-based AI inference, and the FlowFuse Expert to build faster, all built specifically for industrial environments. [Start a 30-day free trial today]({% include "sign-up-url.njk" %}). No abstractions. No greenfield assumptions. Just the infrastructure your plant actually needs.*

--- a/src/handbook/sales/meetings/poc.md
+++ b/src/handbook/sales/meetings/poc.md
@@ -6,7 +6,7 @@ navTitle: Proof of Concept
 
 ### Cloud trial
 
-If the prospect would like to trial FlowFuse Cloud, they are able to self-service at https://app.flowfuse.com/account/create. This will give them a 14-day trial of the Pro tier. If they would like to test with Enterprise features, you can apply a coupon code to their Stripe account and elevate their Tier, after they create their trial account.
+If the prospect would like to trial FlowFuse Cloud, they are able to self-service at https://app.flowfuse.com/account/create. This will give them a 30-day trial of the Pro tier. If they would like to test with Enterprise features, you can apply a coupon code to their Stripe account and elevate their Tier, after they create their trial account.
 
 #### Extending a trial
 

--- a/src/pricing/index.njk
+++ b/src/pricing/index.njk
@@ -5,7 +5,7 @@ sitemapPriority: 0.90
 faqTitle: "Frequently Asked <span class='text-indigo-600'>Questions</span>"
 faqSubtitle: "If you have any questions not addressed here, don't hesitate to contact us through our <a href='/contact-us'>Contact Us</a> page"
 meta:
-    description: Discover the pricing options for FlowFuse, featuring Starter, Pro, and Enterprise plans. Benefit from volume discounts on Pro and Enterprise plans. Get started with a 14-day trial period for the Pro plan.
+    description: Discover the pricing options for FlowFuse, featuring Starter, Pro, and Enterprise plans. Benefit from volume discounts on Pro and Enterprise plans. Get started with a 30-day trial period for the Pro plan.
     keywords: FlowFuse pricing, Cost, Plans, Features, Cloud, Self-hosted
     faq:
         - question: "Does FlowFuse offer annual discounts for FlowFuse Cloud?"


### PR DESCRIPTION
## Description

Updates all FlowFuse Cloud Pro free-trial references from 14 days to 30 days, reflecting the extension of the trial period.

Changed surfaces:
- `src/pricing/index.njk` — pricing page meta description
- `src/handbook/sales/meetings/poc.md` — sales POC self-service trial note
- Blog post CTAs (5 posts, 6 links): pareto-chart-manufacturing-guide, creating-pareto-chart, installing-node-red, building-label-scanner-with-flowfuse (x2), edge-ai-is-80-percent-pipeline-and-20-percent-ai

Left untouched (verified as a different trial): the Self-Hosted Enterprise "30-day Trial License" on the pricing page and the matching sales handbook note.

Note: the `/docs/cloud/introduction.md` "14-day Free Trial" section is also affected, but `src/docs/*` is gitignored here and synced from the `FlowFuse/flowfuse` repo at build time, so that change requires a separate PR in that repo.

## Related Issue(s)

<!-- none -->

## Checklist

 - [x] Documentation has been updated <!-- pending separate FlowFuse/flowfuse docs PR -->