### PR TITLE
fix: bundle analytics HTML as Nitro server assets

### DIFF
--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -56,6 +56,12 @@ export default defineNuxtConfig({
 
     nitro: {
         preset: 'netlify',
+        serverAssets: [
+            {
+                baseName: 'analytics',
+                dir: '../src/_includes/analytics'
+            }
+        ],
         prerender: {
             routes: [
                 '/terms',

--- a/nuxt/server/plugins/analytics.ts
+++ b/nuxt/server/plugins/analytics.ts
@@ -1,16 +1,19 @@
-import { readFileSync } from 'fs'
-import { resolve } from 'path'
-
-const headHtml = readFileSync(resolve(process.cwd(), '../src/_includes/analytics/head.html'), 'utf-8')
-const bodyHtml = readFileSync(resolve(process.cwd(), '../src/_includes/analytics/body.html'), 'utf-8')
-    .replace('{{ POSTHOG_APIKEY }}', process.env.POSTHOG_APIKEY || '')
+let headHtml: string | null = null
+let bodyHtml: string | null = null
 
 export default defineNitroPlugin((nitroApp) => {
     if (process.env.NODE_ENV !== 'production') return
 
-    nitroApp.hooks.hook('render:html', (html) => {
-        // Guard against double injection from dev mode plugin reloads
+    nitroApp.hooks.hook('render:html', async (html) => {
         if (html.bodyAppend.some(s => s.includes('cc.min.js'))) return
+
+        if (!headHtml || !bodyHtml) {
+            const storage = useStorage('assets:analytics')
+            headHtml = await storage.getItem<string>('head.html') ?? ''
+            bodyHtml = (await storage.getItem<string>('body.html') ?? '')
+                .replace('{{ POSTHOG_APIKEY }}', process.env.POSTHOG_APIKEY || '')
+        }
+
         html.head.push(headHtml)
         html.bodyAppend.push(bodyHtml)
     })


### PR DESCRIPTION
Top-level readFileSync calls resolved relative to process.cwd(), which is /var/task in Netlify's serverless runtime — not the repo root. Use Nitro serverAssets to bundle the files into the deployment and read them lazily via useStorage at render time.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

