### PR TITLE
FlowFuse 2.31 blog: featureCatalog badges + docs links + copy fixes (stacked on #5114)

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -727,6 +727,7 @@ module.exports = function(eleventyConfig) {
         if (pro && enterprise && !enterpriseDimmed) return "Pro+";
         if (enterprise === 'contact' || (typeof enterprise === 'string' && enterprise.toLowerCase().includes('contact'))) return "Enterprise (contact us)";
         if (enterpriseDimmed) return "Enterprise (on request)";
+        if (enterprise === 'time') return "Coming soon";
         if (enterprise) return "Enterprise";
         return "Not available";
     }

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -725,7 +725,7 @@ module.exports = function(eleventyConfig) {
         const enterpriseDimmed = tierData.enterprise && tierData.enterprise.dimmed;
         if (starter && pro && enterprise && !enterpriseDimmed) return "All tiers";
         if (pro && enterprise && !enterpriseDimmed) return "Pro+";
-        if (enterprise === 'contact' || (typeof enterprise === 'string' && enterprise.toLowerCase().includes('contact'))) return "Enterprise (on request)";
+        if (enterprise === 'contact' || (typeof enterprise === 'string' && enterprise.toLowerCase().includes('contact'))) return "Enterprise (contact us)";
         if (enterpriseDimmed) return "Enterprise (on request)";
         if (enterprise) return "Enterprise";
         return "Not available";

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -768,7 +768,13 @@ module.exports = function(eleventyConfig) {
         return html;
     }
 
-    // Inject tier badges and changelog links into release blog posts based on frontmatter
+    function renderDocsLink(feature) {
+        if (!feature || !feature.docsLink) return '';
+        const label = feature.label || 'Documentation';
+        return `<div class="ff-related-docs">Docs: <a href="${feature.docsLink}">${label}</a></div>`;
+    }
+
+    // Inject tier badges, changelog links, and a docs link into release blog posts based on frontmatter
     eleventyConfig.addTransform("releaseFeatures", function(content) {
         if (!this.page.outputPath || !this.page.outputPath.endsWith(".html")) return content;
 
@@ -793,6 +799,7 @@ module.exports = function(eleventyConfig) {
         for (const entry of features) {
             let badges = '';
             let changelogs = '';
+            let docs = '';
 
             if (entry.id) {
                 // Feature from featureCatalog
@@ -801,6 +808,7 @@ module.exports = function(eleventyConfig) {
                 badges = renderTierBadges(feature);
                 const changelogUrls = release ? getChangelogUrlsForRelease(feature, release) : getChangelogUrls(feature);
                 changelogs = renderChangelogLinks(changelogUrls);
+                docs = renderDocsLink(feature);
             } else if (entry.tiers) {
                 // Inline tier specification (no feature ID)
                 const inlineFeature = {};
@@ -824,8 +832,9 @@ module.exports = function(eleventyConfig) {
                 badges = renderTierBadges(inlineFeature);
             }
 
-            if (badges || changelogs) {
-                injections.push({ heading: entry.heading, badges, changelogs });
+            if (badges || changelogs || docs) {
+                // Docs link sits on its own line below the changelog line
+                injections.push({ heading: entry.heading, badges, related: changelogs + docs });
             }
         }
 
@@ -857,12 +866,12 @@ module.exports = function(eleventyConfig) {
                 ops.push({ index: heading.index + heading.length, html: badgesWithLevel });
             }
 
-            // Insert changelogs before the next heading at the same or higher level
-            // H2 changelogs go before the next H2; H3 changelogs go before the next H2 or H3
-            if (injection.changelogs) {
+            // Insert changelog + docs links before the next heading at the same or higher level
+            // H2 links go before the next H2; H3 links go before the next H2 or H3
+            if (injection.related) {
                 const nextPeer = headingMatches.find((h, i) => i > headingIdx && h.level <= heading.level);
                 const insertBefore = nextPeer ? nextPeer.index : content.length;
-                ops.push({ index: insertBefore, html: injection.changelogs });
+                ops.push({ index: insertBefore, html: injection.related });
             }
         }
 

--- a/src/_data/featureCatalog.yaml
+++ b/src/_data/featureCatalog.yaml
@@ -35,27 +35,26 @@ sections:
         changelog:
           - url: /changelog/2026/05/expert-application-building/
             release: "2.30"
+          - url: /changelog/2026/06/agentic-development-open-beta/  # TODO: match authored changelog slug
+            release: "2.31"
         subfeature: true
         solutions: [mes, scada, uns, edge-connectivity, it-ot-middleware, data-integration]
         showOnPricing: false
-        tags: [cloud]
+        tags: [cloud, self-hosted]
         cloud:
           starter:
             value: true
-            note: "On request"
           pro:
             value: true
-            note: "On request"
           enterprise:
             value: true
-            note: "On request"
         selfHosted:
           starter:
             value: null
           pro:
             value: null
           enterprise:
-            value: null
+            value: true
 
       - id: ff-expert-support
         label: Support Mode
@@ -1040,7 +1039,9 @@ sections:
         label: Certified Nodes
         description: "Officially supported Node-RED nodes with SLA-backed security patching and reliability guarantees for mission-critical production deployments."
         docsLink: /blog/2025/07/certified-nodes-v2/
-        changelog: null
+        changelog:
+          - url: /changelog/2026/06/certified-nodes/  # TODO: match authored changelog slug
+            release: "2.31"
         solutions: [mes, scada, edge-connectivity, it-ot-middleware]
         showOnPricing: true
         tags: [cloud, self-hosted]

--- a/src/_data/featureCatalog.yaml
+++ b/src/_data/featureCatalog.yaml
@@ -35,8 +35,6 @@ sections:
         changelog:
           - url: /changelog/2026/05/expert-application-building/
             release: "2.30"
-          - url: /changelog/2026/06/agentic-development-open-beta/  # TODO: match authored changelog slug
-            release: "2.31"
         subfeature: true
         solutions: [mes, scada, uns, edge-connectivity, it-ot-middleware, data-integration]
         showOnPricing: false
@@ -54,7 +52,8 @@ sections:
           pro:
             value: null
           enterprise:
-            value: true
+            value: 'contact'
+            note: "On request; requires assistant tokens and the Expert MQTT bridge"
 
       - id: ff-expert-support
         label: Support Mode
@@ -1039,9 +1038,7 @@ sections:
         label: Certified Nodes
         description: "Officially supported Node-RED nodes with SLA-backed security patching and reliability guarantees for mission-critical production deployments."
         docsLink: /blog/2025/07/certified-nodes-v2/
-        changelog:
-          - url: /changelog/2026/06/certified-nodes/  # TODO: match authored changelog slug
-            release: "2.31"
+        changelog: null
         solutions: [mes, scada, edge-connectivity, it-ot-middleware]
         showOnPricing: true
         tags: [cloud, self-hosted]
@@ -1058,7 +1055,8 @@ sections:
           pro:
             value: null
           enterprise:
-            value: true
+            value: 'time'
+            note: "Available from 2.32"
 
       - id: instance-monitoring
         label: Instance Monitoring

--- a/src/blog/2026/06/flowfuse-release-2-31.md
+++ b/src/blog/2026/06/flowfuse-release-2-31.md
@@ -13,12 +13,15 @@ release: "2.31"
 features:
    - id: ff-expert-application-building
      heading: "Let FlowFuse Expert build your industrial application"
-   - id: certified-nodes
-     heading: "Certified Nodes for industrial connectivity and AI"
+   - heading: "Certified Nodes for industrial connectivity and AI"
+     tiers:
+       cloud: enterprise
    - heading: "What else is new?"
      tiers:
        cloud: all
        selfHosted: all
+# Certified Nodes uses an inline Cloud-only badge because Self-Hosted lands in 2.32.
+# Switch to `id: certified-nodes` once Self-Hosted support ships.
 tldr: "FlowFuse 2.31 brings agentic application building to open beta: describe what you want and FlowFuse Expert builds it on your Node-RED workspace. Plus new Certified Nodes (RTSP, OPC UA, AI) and per-team and per-instance control over AI."
 cta:
   type: contact
@@ -34,9 +37,9 @@ FlowFuse 2.31 lets FlowFuse Expert build your industrial application for you, no
 
 *FlowFuse Expert is our integrated AI assistant, in the website, the platform, and the immersive Node-RED editor.*
 
-Describe what you want to build, an OEE dashboard, an MES handover screen, a UNS topic mapping, and FlowFuse Expert assembles the flow on your workspace for you. With 2.31 this moves out of soft launch into an open beta: switched on for your team on FlowFuse Cloud, no request needed. On Self-Hosted Enterprise, [contact us](/contact-us/) to enable it, and new self-hosted customers get it enabled automatically.
+Describe what you want to build, an OEE dashboard, an MES handover screen, a UNS topic mapping, and FlowFuse Expert assembles the flow on your workspace for you. With 2.31 this moves out of soft launch into an open beta: switched on for your team on FlowFuse Cloud, no request needed. On Self-Hosted Enterprise, [contact us](/contact-us/) to get it set up; self-hosted setup is not automatic, it requires a provisioning token and configuring the bridge.
 
-It now works on Remote Instances as well as Hosted Instances, so you get the same build-it-for-me experience across both.
+It now works on Remote Instances as well as Hosted Instances, so you get the same build-it-for-me experience across both. Agentic flow building requires the nr-assistant plugin at v0.16.0 or newer, and FlowFuse Expert will let you know when an update is available in your instance's immersive editor.
 
 ## Certified Nodes for industrial connectivity and AI {#certified-nodes}
 
@@ -52,7 +55,7 @@ FlowFuse now offers certified nodes: vetted, FlowFuse-supported nodes you can ad
 
   These first LLM nodes handle single-shot, text-in/text-out calls; see the [LLM nodes documentation](/node-red/flowfuse/ai/llm-nodes/) for details. Multimodal input, conversation history, and tool calling are planned for follow-up iterations. They join the FlowFuse AI Nodes package we [shipped in 2.23](/changelog/2025/10/onnx-nodes/), which already includes the ONNX Inference, Image Classification, Object Detection, and Image Depth Estimation nodes for running vision and custom models on-device, with no external API calls.
 
-Certified Nodes are available to FlowFuse Cloud customers. [Get in touch with sales](/contact-us/?subject=Certified%20Nodes) or your customer success manager, and we'll enable the ones your team needs.
+Certified Nodes are available to FlowFuse Cloud customers as of this release, with Self-Hosted Enterprise support arriving in the next release (2.32). [Get in touch with sales](/contact-us/?subject=Certified%20Nodes) or your customer success manager, and we'll enable the ones your team needs.
 
 ## What else is new?
 

--- a/src/blog/2026/06/flowfuse-release-2-31.md
+++ b/src/blog/2026/06/flowfuse-release-2-31.md
@@ -10,9 +10,15 @@ tags:
    - news
    - releases
 release: "2.31"
-# features + changelog interlinking deferred to a follow-up (stacked) PR, since it depends on the
-# 2.31 changelog entries that land with the release. Wire after merge: certified-nodes (entry exists),
-# ff-expert-application-building (needs open-beta cloud tier, self-hosted enterprise, and a 2.31 changelog).
+features:
+   - id: ff-expert-application-building
+     heading: "Let FlowFuse Expert build your industrial application"
+   - id: certified-nodes
+     heading: "Certified Nodes for industrial connectivity and AI"
+   - heading: "What else is new?"
+     tiers:
+       cloud: all
+       selfHosted: all
 tldr: "FlowFuse 2.31 brings agentic application building to open beta: describe what you want and FlowFuse Expert builds it on your Node-RED workspace. Plus new Certified Nodes (RTSP, OPC UA, AI) and per-team and per-instance control over AI."
 cta:
   type: contact

--- a/src/blog/2026/06/flowfuse-release-2-31.md
+++ b/src/blog/2026/06/flowfuse-release-2-31.md
@@ -13,15 +13,14 @@ release: "2.31"
 features:
    - id: ff-expert-application-building
      heading: "Let FlowFuse Expert build your industrial application"
-   - heading: "Certified Nodes for industrial connectivity and AI"
-     tiers:
-       cloud: enterprise
+   - id: certified-nodes
+     heading: "Certified Nodes for industrial connectivity and AI"
    - heading: "What else is new?"
      tiers:
        cloud: all
        selfHosted: all
-# Certified Nodes uses an inline Cloud-only badge because Self-Hosted lands in 2.32.
-# Switch to `id: certified-nodes` once Self-Hosted support ships.
+# Certified Nodes Self-Hosted renders "Coming soon" from the catalog SH value ('time').
+# Flip that tier to true in 2.32 when Self-Hosted support ships.
 tldr: "FlowFuse 2.31 brings agentic application building to open beta: describe what you want and FlowFuse Expert builds it on your Node-RED workspace. Plus new Certified Nodes (RTSP, OPC UA, AI) and per-team and per-instance control over AI."
 cta:
   type: contact

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1778,6 +1778,16 @@ h4:hover .header-anchor::before {
     color: #4338ca;
 }
 
+.ff-related-docs {
+    font-size: 0.875rem;
+    color: #6b7280;
+    margin: 0 0 8px 0;
+}
+
+.ff-related-docs a {
+    color: #4338ca;
+}
+
 pre.mermaid {
     background-color: #ffffff
 }


### PR DESCRIPTION
## Description

Stacked on #5114. Wires the 2.31 release blog into the featureCatalog so tier badges render per section, plus a few copy corrections and small tweaks to the release-blog transform.

- Badges via `features:` frontmatter: Expert Application Building (Cloud all tiers, Self-Hosted Enterprise contact us) and Certified Nodes (Cloud Enterprise, Self-Hosted "Coming soon"). "What else is new?" gets the all-tiers row.
- Self-hosted agentic copy fixed: setup is not automatic, it needs a provisioning token and the bridge configured. Matches the Expert docs in FlowFuse/flowfuse#7378.
- Added the nr-assistant v0.16.0 requirement, and Certified Nodes reads Cloud this release / Self-Hosted from 2.32 (blog prose + pricing catalog).
- `releaseFeatures` transform (`.eleventy.js`): contact-tier badge now reads "Enterprise (contact us)", roadmap-tier reads "Coming soon", and each section auto-injects a Docs link below the changelog line. These apply to all release posts, not just this one.

No changelog interlinking: there won't be 2.31 changelog pages for agentic open beta or certified nodes, so those refs are dropped. Badges and docs links still render.

## Related Issue(s)

- Stacked on #5114 (2.31 release blog)
- Expert docs: FlowFuse/flowfuse#7378 (merged)

## Checklist

- [ ] I have read the contribution guidelines
- [ ] I have considered the performance impact of these changes
- [ ] Suitable unit/system level tests have been added and they pass
- [ ] Documentation has been updated
- [ ] For blog PRs, an Art Request has been created
