### PR TITLE
Skip images in production

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -65,7 +65,7 @@ command = "npx @11ty/eleventy --quiet --watch"
 autoLaunch = false
 
 [build]
-command = "npm run build:nuxt"
+command = "npm run build:nuxt:skip-images"
 publish = "nuxt/dist"
 
 [functions]


### PR DESCRIPTION
## Description

Currently, the Netlify prod build (sometimes) clear the cached images, resulting in a 90min build.

This temporarily disables the image compression as we need to publish the release article asap. Will work on the actual later, as a follow up.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

