### PR TITLE
Restore Netlify image cache between builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -65,7 +65,7 @@ command = "npx @11ty/eleventy --quiet --watch"
 autoLaunch = false
 
 [build]
-command = "npm run build:nuxt:skip-images"
+command = "npm run build:nuxt"
 publish = "nuxt/dist"
 
 [functions]

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "old_dev:eleventy": "dotenv -v NODE_ENV=development -- ELEVENTY_ENV=development npx @11ty/eleventy --serve --quiet",
         "prod:eleventy": "npx @11ty/eleventy",
         "prod:postcss": "postcss ./src/css/style.css -o ./_site/css/style.css --config ./postcss.config.js",
-        "clean:nuxt": "npx del-cli 'nuxt/public/!(img|handbook)' 'nuxt/.output' 'nuxt/.netlify' && npx mkdirp 'nuxt/public/js' 'nuxt/public/css' && find nuxt/public/img -name \"*'*\" -delete 2>/dev/null; true",
+        "clean:nuxt": "npx del-cli 'nuxt/public/!(img|handbook)' 'nuxt/.output' && npx mkdirp 'nuxt/public/js' 'nuxt/public/css'",
         "build:js:nuxt": "terser -c -m -o nuxt/public/js/cc.min.js node_modules/vanilla-cookieconsent/dist/cookieconsent.umd.js src/js/cookieconsent-config.js && cp node_modules/@flowfuse/flow-renderer/index.min.js nuxt/public/js/flowrenderer.min.js",
         "prod:postcss-nuxt": "postcss ./src/css/style.css -o ./nuxt/public/css/style.css --config ./postcss.config.js",
         "prod:eleventy-nuxt": "npx @11ty/eleventy --output=./nuxt/public/",


### PR DESCRIPTION
## Description

PR [#5122](https://github.com/FlowFuse/website/pull/5122) introduced:

- nuxt/.netlify was added to the clean targets, which wiped the Nitro/Netlify function build artifacts on every run — forcing a full rebuild and causing builds to take over an hour.
- A find-based deletion of images with apostrophes in their filenames was silently swallowing errors that should surface and be fixed at the source.

This PR removes both, restoring `clean:nuxt` to its previous behaviour

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

