### PR TITLE
nuxt: Remove server warning

### DIFF
--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -92,6 +92,15 @@ export default defineNuxtConfig({
         },
     },
 
+    vite: {
+        optimizeDeps: {
+            include: [
+                '@vue/devtools-core',
+                '@vue/devtools-kit',
+            ],
+        },
+    },
+
     // Dev proxying to 11ty is handled by server/middleware/legacy.ts
     // to allow per-route exclusions as pages are migrated.
 })


### PR DESCRIPTION
## Description

Fixes the following warning:

```
  [3] ℹ Vite discovered new dependencies at runtime:
  [3]   %2Fwebsite%2Fnuxt%2F.nuxt%2Fruntime.vue-devtools-client.PTZmGbtFo4n5JwXrxRiG_CsM15UIcTdMfSs_K5A53sE.js
  [3]     @vue/devtools-core
  [3]     @vue/devtools-kit
  [3]
  [3] Pre-bundle them in your nuxt.config.ts to avoid page reloads:
  [3]
  [3] export default defineNuxtConfig({
  [3]   vite: {
  [3]     optimizeDeps: {
  [3]       include: [
  [3]         '@vue/devtools-core',
  [3]         '@vue/devtools-kit',
  [3]       ]
  [3]     }
  [3]   }
  [3] })
  [3]
  [3] Learn more: https://vite.dev/guide/dep-pre-bundling.html
```
