### PR TITLE
ci: Set proper path to handbook files after Nuxt migration

### DIFF
--- a/.github/scripts/detect_changed_files.sh
+++ b/.github/scripts/detect_changed_files.sh
@@ -23,7 +23,7 @@ fi
 handbook_changed=false
 
 for file in $changed_files; do
-  if [[ $file == src/handbook/* ]]; then
+  if [[ $file == nuxt/content/handbook/* ]]; then
     handbook_changed=true
   fi
   


### PR DESCRIPTION
## Description

This pull request adjusts the path to the handbook files in the `detect_changed_files.sh` script to ensure that the `Notify on Handbook Changes` workflow works correctly.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

