### PR TITLE
ci: Fix paths to handbook files in the `generate_handbook_urls` script

### DIFF
--- a/.github/scripts/generate_handbook_urls.sh
+++ b/.github/scripts/generate_handbook_urls.sh
@@ -5,10 +5,10 @@ set -e
 
 if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
   echo "Running on main branch, comparing with previous commit"
-  MODIFIED_FILES=$(git diff --name-only --diff-filter=AM HEAD^ HEAD -- src/handbook/)
+  MODIFIED_FILES=$(git diff --name-only --diff-filter=AM HEAD^ HEAD -- nuxt/content/handbook/)
 else
   echo "Running on non-default branch, comparing with $GITHUB_BASE_REF branch"
-  MODIFIED_FILES=$(git diff --name-only --diff-filter=AM origin/$GITHUB_BASE_REF...HEAD -- src/handbook/)
+  MODIFIED_FILES=$(git diff --name-only --diff-filter=AM origin/$GITHUB_BASE_REF...HEAD -- nuxt/content/handbook/)
 fi
 
 echo "Modified files in the PR:"
@@ -24,7 +24,7 @@ fi
 ALL_URLS="" 
 
 for FILE in $MODIFIED_MD_FILES; do
-    RELATIVE_PATH=${FILE#src/handbook/}
+    RELATIVE_PATH=${FILE#nuxt/content/handbook/}
     
     URL_PATH=${RELATIVE_PATH%.md}
     


### PR DESCRIPTION
## Description

This pull request sets proper path to the handbook source files in the `generate_handbook_urls.sh` shell script to ensure valid hyperlinks are generated for a slack notification.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

