### PR TITLE
Skip imgs in production

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -65,7 +65,7 @@ command = "npx @11ty/eleventy --quiet --watch"
 autoLaunch = false
 
 [build]
-command = "npm run build:nuxt"
+command = "npm run build:nuxt:skip-images"
 publish = "nuxt/dist"
 
 [functions]


### PR DESCRIPTION
## Description

Build time is 90min again, disabling img compression for now as we need to get the NR5 announcement live asap

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

