### PR TITLE
docs(handbook): migrate SDR job description to Nuxt

### DIFF
--- a/nuxt/content/handbook/peopleops/job-descriptions/sales-development-representative.md
+++ b/nuxt/content/handbook/peopleops/job-descriptions/sales-development-representative.md
@@ -1,6 +1,5 @@
 ---
-navTitle: Sales Development Representative (SDR)
-navGroup: Job Descriptions
+title: "Sales Development Representative (SDR)"
 ---
 
 # Sales Development Representative


### PR DESCRIPTION
Moves sales-development-representative.md from src/handbook/ to nuxt/content/handbook/ and updates frontmatter to use title instead of navTitle/navGroup.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

