### PR TITLE
fix: restore handbook card colors (Tailwind purged nuxt/content classes)

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,7 @@
 const plugin = require('tailwindcss/plugin')
 
 module.exports = {
-    content: ['src/**/*.html','src/**/*.njk','src/**/*.md','src/**/*.svg','src/**/*.js','.eleventy.js','nuxt/**/*.vue','nuxt/**/*.ts'],
+    content: ['src/**/*.html','src/**/*.njk','src/**/*.md','src/**/*.svg','src/**/*.js','.eleventy.js','nuxt/**/*.vue','nuxt/**/*.ts','nuxt/content/**/*.md'],
     safelist: [
       'ml-4',
       'ml-8',


### PR DESCRIPTION
## Description

The handbook moved to `nuxt/content/**/*.md` during the Nuxt migration, but the Tailwind `content` globs were never updated to scan that directory. Utility classes used inside handbook markdown (e.g. the persona cards' `bg-gray-900`, `border-red-400`, `border-teal-400`) are therefore purged from the build. Because `text-white` is safelisted but the dark background is not, the persona cards render as white text on a light background. Adds `nuxt/content/**/*.md` to the content globs so handbook markdown classes are generated again.

Affects every handbook page that uses utility classes in its markup (personas, design thinking, etc.).

## Related Issue(s)

Reported: persona cards have broken colors at `/handbook/engineering/product/personas/`.

## Checklist

 - [ ] I have read the contribution guidelines
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created