### PR TITLE
Align Nuxt UI default styles with the rest of the site

### DIFF
--- a/nuxt/app.config.ts
+++ b/nuxt/app.config.ts
@@ -1,7 +1,8 @@
 export default defineAppConfig({
     ui: {
         colors: {
-            primary: 'red',
+            primary: 'blue',
+            neutral: 'gray',
         },
     },
 })

--- a/nuxt/assets/css/theme.css
+++ b/nuxt/assets/css/theme.css
@@ -4,6 +4,8 @@
 /* FlowFuse brand red scale — overrides Tailwind's default so Nuxt UI's
    primary color tokens match the palette from the branding handbook. */
 @theme {
+    --font-sans: 'Heebo', system-ui, sans-serif;
+
     --color-red-50:  #FFE8E5;
     --color-red-100: #FFBFB5;
     --color-red-200: #FF8A7B;
@@ -14,4 +16,12 @@
     --color-red-700: #B32E09;
     --color-red-800: #8D1F06;
     --color-red-900: #671506;
+}
+
+.handbook-content :is(h1, h2, h3, h4, h5, h6) {
+    @apply text-gray-700;
+}
+
+.handbook-content a {
+    @apply text-blue-700 no-underline border-none hover:underline;
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -308,7 +308,7 @@ html, body {
 
 @layer base {
     main a {
-        color: var(--color-blue-600);
+        color: var(--color-blue-700);
     }
     main a:hover {
         text-decoration: underline;
@@ -318,7 +318,7 @@ html, body {
     }
 
     main .ff-bg-dark a, main .ff-bg-mid a {
-        color: var(--color-blue-600);
+        color: var(--color-blue-700);
     }
     main .ff-bg-dark a:hover, main .ff-bg-mid a:hover {
         color: var(--color-teal-500);


### PR DESCRIPTION
## Description

PR #5196 introduced Nuxt UI with its default styles, which didn't match the rest of the site. This PR aligns fonts, link colors, and heading colors with the existing design.

## Related PR

https://github.com/FlowFuse/website/pull/5196

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

