### PR TITLE
fix: run Algolia indexing on every production deploy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -65,7 +65,7 @@ command = "npx @11ty/eleventy --quiet --watch"
 autoLaunch = false
 
 [build]
-command = "npm run build:nuxt:skip-images"
+command = "npm run build:nuxt:skip-images && npm run index:algolia"
 publish = "nuxt/dist"
 
 [build.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -65,7 +65,7 @@ command = "npx @11ty/eleventy --quiet --watch"
 autoLaunch = false
 
 [build]
-command = "npm run build:nuxt:skip-images && npm run index:algolia"
+command = "npm run build:nuxt:skip-images"
 publish = "nuxt/dist"
 
 [build.environment]

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
         "prod:postcss-nuxt": "postcss ./src/css/style.css -o ./nuxt/public/css/style.css --config ./postcss.config.js",
         "prod:eleventy-nuxt": "npx @11ty/eleventy --output=./nuxt/public/",
         "prod:nuxt": "npm run build --workspace=nuxt",
-        "build:nuxt": "dotenv -v NODE_ENV=production -- npm-run-all2 clean:nuxt build:js:nuxt docs blueprints prod:postcss-nuxt prod:eleventy-nuxt prod:nuxt",
-        "build:nuxt:skip-images": "dotenv -v SKIP_IMAGES=true -v NODE_ENV=production -- npm-run-all2 clean:nuxt build:js:nuxt docs blueprints prod:postcss-nuxt prod:eleventy-nuxt prod:nuxt"
+        "build:nuxt": "dotenv -v NODE_ENV=production -- npm-run-all2 clean:nuxt build:js:nuxt docs blueprints prod:postcss-nuxt prod:eleventy-nuxt prod:nuxt index:algolia",
+        "build:nuxt:skip-images": "dotenv -v SKIP_IMAGES=true -v NODE_ENV=production -- npm-run-all2 clean:nuxt build:js:nuxt docs blueprints prod:postcss-nuxt prod:eleventy-nuxt prod:nuxt index:algolia"
     },
     "devDependencies": {
         "@11ty/eleventy": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
         "prod:postcss-nuxt": "postcss ./src/css/style.css -o ./nuxt/public/css/style.css --config ./postcss.config.js",
         "prod:eleventy-nuxt": "npx @11ty/eleventy --output=./nuxt/public/",
         "prod:nuxt": "npm run build --workspace=nuxt",
-        "build:nuxt": "dotenv -v NODE_ENV=production -- npm-run-all2 clean:nuxt build:js:nuxt docs blueprints prod:postcss-nuxt prod:eleventy-nuxt prod:nuxt index:algolia",
-        "build:nuxt:skip-images": "dotenv -v SKIP_IMAGES=true -v NODE_ENV=production -- npm-run-all2 clean:nuxt build:js:nuxt docs blueprints prod:postcss-nuxt prod:eleventy-nuxt prod:nuxt index:algolia"
+        "build:nuxt": "dotenv -v NODE_ENV=production -- npm-run-all2 clean:nuxt build:js:nuxt docs blueprints prod:postcss-nuxt prod:eleventy-nuxt prod:nuxt",
+        "build:nuxt:skip-images": "dotenv -v SKIP_IMAGES=true -v NODE_ENV=production -- npm-run-all2 clean:nuxt build:js:nuxt docs blueprints prod:postcss-nuxt prod:eleventy-nuxt prod:nuxt"
     },
     "devDependencies": {
         "@11ty/eleventy": "^3.1.2",


### PR DESCRIPTION
## Summary

- The Netlify build command (`build:nuxt:skip-images`) was missing the `index:algolia` step after the Nuxt migration
- As a result, the Algolia search index has not been updated since the Nuxt migration
- This adds `&& npm run index:algolia` to the production build command so the index syncs on every deploy

Note: `deploy-preview` and `branch-deploy` contexts are intentionally left without the indexing step.

## Test plan

- [ ] Merge and confirm the next production deploy updates the Algolia index (Last build timestamp in Algolia dashboard should update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)