### PR TITLE
Revert "fix: run Algolia indexing on every production deploy"

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -65,7 +65,7 @@ command = "npx @11ty/eleventy --quiet --watch"
 autoLaunch = false
 
 [build]
-command = "npm run build:nuxt:skip-images && npm run index:algolia"
+command = "npm run build:nuxt:skip-images"
 publish = "nuxt/dist"
 
 [build.environment]


### PR DESCRIPTION
It fails in production, it's looking for the file on an old path that was modified during the nuxt migration

Reverts FlowFuse/website#5198