### PR TITLE
handbook: fix broken product metrics dashboard URL

### DIFF
--- a/nuxt/content/handbook/engineering/product/metrics.md
+++ b/nuxt/content/handbook/engineering/product/metrics.md
@@ -26,12 +26,12 @@ Higher tiers are weighted more heavily because of their greater impact on revenu
 
 WCI is a **lagging business metric, not a product outcome.** Per our [methodology](./methodology.md), the outcomes we steer by are changes in customer behaviour; WCI is the business result those behaviours are meant to produce. We track it to confirm that our product work is translating into business value, but an Objective is never "increase WCI" directly: it is the customer-behaviour change that moves it.
 
-WCI can be found on the [product metrics dashboard](https://new-product-metrics.flowfuse.cloud/dashboard/product).
+WCI can be found on the [product metrics dashboard](https://product-metrics.flowfuse.cloud/dashboard/product).
 
 ## Available Metrics
 
 
-The set below is reviewed against the [product metrics dashboard](https://new-product-metrics.flowfuse.cloud/dashboard/product); validate the tier names and the list against current data before relying on them:
+The set below is reviewed against the [product metrics dashboard](https://product-metrics.flowfuse.cloud/dashboard/product); validate the tier names and the list against current data before relying on them:
 
 1. **Applications with Multiple Instances**: Applications were designed to group Node-RED instances for enhanced organization, thus serving as a foundational element for numerous other features.
 


### PR DESCRIPTION
## Description

Both dashboard links on the Product > Metrics handbook page pointed at `https://new-product-metrics.flowfuse.cloud/dashboard/product`, which returns 404. Corrected both to the live host `https://product-metrics.flowfuse.cloud/dashboard/product` (verified HTTP 200), the same host already used throughout the Telemetry page.

## Related Issue(s)

None.

## Checklist

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))
