### PR TITLE
fix: resolve cookie banner style overrides after Tailwind v4 migration

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -109,7 +109,7 @@
 @import "./zoom-style.css";
 @import "./node-red-style.css";
 @import "../../node_modules/@flowforge/forge-ui-components/dist/forge-ui-components.css" layer(vendor);
-@import "../../node_modules/vanilla-cookieconsent/dist/cookieconsent.css" layer(vendor);
+@import "../../node_modules/vanilla-cookieconsent/dist/cookieconsent.css" layer(components);
 
 
 /* Skip to main content link */


### PR DESCRIPTION
## Description

After migrating to Tailwind v4, the cookie banner styles were being overridden by Tailwind's `base` layer resets (global `*`, `p`, heading color rules, etc.).

The root cause: `cookieconsent.css` was imported into the `vendor` layer, which is declared first in the layer order and therefore has the lowest cascade priority.

Fix: import `cookieconsent.css` into the `components` layer instead, which sits above `base` in the cascade and prevents Tailwind's resets from overriding the banner's own styles.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

