### PR TITLE
fix: add custom Nuxt 404 page

### DIFF
--- a/nuxt/components/AppHeader.vue
+++ b/nuxt/components/AppHeader.vue
@@ -71,7 +71,7 @@ onMounted(() => {
 
 <template>
   <header id="ff-header" class="ff-header">
-    <nav class="relative w-full flex items-center justify-between mx-auto max-screen-none lg:max-w-screen-xl 2xl:max-w-[1920px]">
+    <nav class="relative w-full flex items-center justify-between xl:grid xl:grid-cols-header mx-auto max-screen-none lg:max-w-screen-xl 2xl:max-w-[1920px]">
 
       <!-- Wordmark: visible on mobile + desktop, hidden on tablet -->
       <a class="flex md:hidden lg:flex no-underline hover:no-underline font-bold h-8 w-40 flex-row" href="/" aria-label="FlowFuse Home" style="font-family:'Baloo 2', sans-serif">

--- a/nuxt/error.vue
+++ b/nuxt/error.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+defineProps<{ error: { statusCode: number; statusMessage: string } }>()
+</script>
+
+<template>
+  <NuxtLayout>
+    <div class="w-full h-full ff-full-bg">
+      <div class="flex flex-col justify-center px-6 pt-10 pb-24 md:py-16 max-w-sm md:max-w-lg m-auto text-center h-full">
+        <div class="w-full mx-auto md:-mt-6">
+          <img :src="'/images/pictograms/404_blue.png'" alt="404" width="465" />
+        </div>
+        <h1 class="mb-0 text-[2.75rem] leading-[3.1rem] font-normal text-gray-700">Ooops!</h1>
+        <h5 class="text-[1.1rem] leading-[1.85rem] font-semibold text-gray-700">Page not found</h5>
+        <!-- Plain <a> forces a full page navigation — / is served by 11ty and a
+             client-side Nuxt redirect would leave the page blank. -->
+        <a href="/" class="ff-btn ff-btn--primary mt-4">Return to homepage</a>
+      </div>
+    </div>
+  </NuxtLayout>
+</template>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -79,7 +79,7 @@
 @source inline("ml-4 ml-8 ml-6 mt-3 max-w-[90%] py-4 py-2 bg-indigo-600 text-white rounded-br-sm bg-gray-100 text-gray-800 rounded-bl-sm justify-end justify-start max-w-xs lg:max-w-md overflow-auto rounded-lg px-4 mb-4 flex hover:border-indigo-400 hover:bg-indigo-50 hover:bg-indigo-100 active:bg-indigo-100 active:border-indigo-500 transition-all duration-200 text-gray-600 hover:text-indigo-600 transition-colors");
 
 @source not "../../nuxt/.netlify/**";
-@source "../../nuxt/content/**/*.md";
+@source "../../nuxt/**";
 
 @layer components {
     .prose {


### PR DESCRIPTION
## Description

- Adds `nuxt/error.vue` — a custom 404 page matching the 11ty design (`src/404.njk`), with a plain `<a href="/">` instead of Nuxt's `clearError()` to force a full page navigation back to the homepage (which is served by 11ty)

## Related Issue(s)

closes https://github.com/FlowFuse/website/issues/5224

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

