### PR TITLE
fix: Add background color to <body>

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -141,6 +141,7 @@ html, body {
     font-size: 16px;
     font-family: var(--font-sans);
     scroll-padding-top: 75px;
+    background-color: white;
 }
 
 *{


### PR DESCRIPTION
## Description

Many pages had a defined background, but for those that didn't, it was transparent, causing them to adopt the browser's default color. In dark mode browsers, this resulted in pages appearing with a dark background.

This sets a white background-color on body as a default for all pages.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

