### PR TITLE
Update calendar for booking meetings

### DIFF
--- a/src/_includes/hubspot/consent-fallback.njk
+++ b/src/_includes/hubspot/consent-fallback.njk
@@ -9,7 +9,7 @@
         <p class="text-indigo-200">
             30-minute session with our team.
         </p>
-        <a href="https://meetings-eu1.hubspot.com/michael-davis/contact-us-scheduler"
+        <a href="https://meetings-eu1.hubspot.com/michael-davis/round-robin-sales-team"
            class="inline-block ff-btn ff-btn--highlight uppercase mb-2"
            style="cursor: pointer;"
            onclick="if(typeof capture==='function') capture('calendar_fallback_cta_clicked')">

--- a/src/book-demo.njk
+++ b/src/book-demo.njk
@@ -8,7 +8,7 @@ meta:
   description: Book a demo to understand how FlowFuse helps you professionalize your Node-RED deployment.
 hubspot:
     script: "hubspot/hs-book-meeting.njk"
-    dataSrc: https://meetings-eu1.hubspot.com/michael-davis/contact-us-scheduler?embed=true
+    dataSrc: https://meetings-eu1.hubspot.com/michael-davis/round-robin-sales-team?embed=true
 otherChannels:
   - title: Prefer to start with a message?
     description: Share your use case and we’ll get back to you shortly.

--- a/src/contact-us.njk
+++ b/src/contact-us.njk
@@ -14,7 +14,7 @@ otherChannels:
   - title: Want to talk it through live?
     description: Book a session and we'll go through your setup together.
     buttonText: Book a session
-    buttonLink: https://meetings-eu1.hubspot.com/michael-davis/contact-us-scheduler
+    buttonLink: https://meetings-eu1.hubspot.com/michael-davis/round-robin-sales-team
     icon: calendar
   - title: Need technical help instead?
     description: Visit our Help Center for docs, guides and access to our support team.


### PR DESCRIPTION
## Description

This updates the meeting scheduler to one that includes all members of the sales team, as provided by Michael.

One difference in the flow is that it now asks for the visitor’s email address before displaying the calendar. Michael explained that the intention is to enable follow-up if someone abandons the booking flow after submitting their email.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

