### PR TITLE
Document callout boxes and unify their style across Nuxt and 11ty

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,13 +5,15 @@
       "name": "eleventy",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev:eleventy"],
-      "port": 8080
+      "port": 8080,
+      "autoPort": true
     },
     {
       "name": "nuxt",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev:nuxt"],
-      "port": 3000
+      "runtimeArgs": ["run", "--workspace=nuxt", "dev"],
+      "port": 3000,
+      "autoPort": true
     }
   ]
 }

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -28,12 +28,18 @@ const eleventyNavigationPlugin = require("@11ty/eleventy-navigation");
 // Documentation alert boxes
 const shortcodeMarkdown = new markdownIt()
 
-function renderDocsAlertBox(content, tone = 'note', title = '') {
-    const normalizedTone = tone.toLowerCase();
-    const resolvedTitle = title
-    const markdownContent = shortcodeMarkdown.render(content)
+const CALLOUT_ICONS = {
+    note: `<svg class="ff-callout__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>`,
+    warning: `<svg class="ff-callout__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg>`,
+    caution: `<svg class="ff-callout__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="12" x2="12" y1="8" y2="12"/><line x1="12" x2="12.01" y1="16" y2="16"/></svg>`,
+}
 
-    return `<div class="ff-callout ff-callout--${normalizedTone}"><p class="ff-callout__title">${resolvedTitle}</p><div class="ff-callout__content">${markdownContent}</div></div>`
+function renderDocsAlertBox(content, tone = 'note') {
+    const normalizedTone = tone.toLowerCase();
+    const icon = CALLOUT_ICONS[normalizedTone] || CALLOUT_ICONS.note
+    const markdownContent = shortcodeMarkdown.render(content)
+    const contentWithIcon = markdownContent.replace(/^(<\w[^>]*>)/, `$1${icon}`)
+    return `<div class="ff-callout ff-callout--${normalizedTone}"><div class="ff-callout__content">${contentWithIcon}</div></div>`
 }
 
 // Skip slow optimizations when developing i.e. serve/watch or Netlify deploy preview
@@ -155,16 +161,16 @@ module.exports = function(eleventyConfig) {
     });
 
     // Documentation alert boxes
-    eleventyConfig.addPairedLiquidShortcode('note', function (content, title = '') {
-        return renderDocsAlertBox(content, 'note', "Note")
+    eleventyConfig.addPairedLiquidShortcode('note', function (content) {
+        return renderDocsAlertBox(content, 'note')
     })
 
-    eleventyConfig.addPairedLiquidShortcode('warning', function (content, title = '') {
-        return renderDocsAlertBox(content, 'warning', "Warning")
+    eleventyConfig.addPairedLiquidShortcode('warning', function (content) {
+        return renderDocsAlertBox(content, 'warning')
     })
 
-    eleventyConfig.addPairedLiquidShortcode('critical', function (content, title = '') {
-        return renderDocsAlertBox(content, 'critical', "Critical")
+    eleventyConfig.addPairedLiquidShortcode('caution', function (content) {
+        return renderDocsAlertBox(content, 'caution')
     })
 
 

--- a/nuxt/components/content/Note.vue
+++ b/nuxt/components/content/Note.vue
@@ -1,8 +1,0 @@
-<template>
-  <div class="ff-callout ff-callout--note">
-    <p class="ff-callout__title">Note</p>
-    <div class="ff-callout__content">
-      <slot />
-    </div>
-  </div>
-</template>

--- a/nuxt/content/handbook/company/guides/markdown.md
+++ b/nuxt/content/handbook/company/guides/markdown.md
@@ -151,3 +151,55 @@ console.log("Hello, world!")
 console.log("Hello, world!")
 ```
 ````
+
+## Callout boxes
+
+Use callout boxes to highlight important information that readers might otherwise skip. Three types are available:
+
+::note
+This is a **note** callout. Use it for general information worth calling out.
+::
+
+::warning
+This is a **warning** callout. Use it for something the reader should be careful about.
+::
+
+::caution
+This is a **caution** callout. Use it for potential data loss, security risks, or irreversible actions.
+::
+
+### Which syntax to use
+
+Since we're in the middle of a migration from 11ty to Nuxt, there are two syntaxes available, pick the one you need according to the location of the files.
+
+**Handbook pages** (`nuxt/content/handbook/`):
+
+```md
+::note
+Content here.
+::
+
+::warning
+Content here.
+::
+
+::caution
+Content here.
+::
+```
+
+**Docs, blog, and changelog pages** (`src/docs/`, `src/blog/`, `src/changelog/`):
+
+```
+{% note %}
+Content here.
+{% endnote %}
+
+{% warning %}
+Content here.
+{% endwarning %}
+
+{% caution %}
+Content here.
+{% endcaution %}
+```

--- a/src/css/style.docs.css
+++ b/src/css/style.docs.css
@@ -89,51 +89,39 @@
 }
 
 .ff-callout {
-    @apply my-6 border-l-2 px-4 py-3;
+    @apply my-5 rounded-md border px-4 py-3 text-sm/6;
 }
 
-.main-content .ff-callout {
-    @apply mb-6;
-}
-
-.ff-callout__title {
-    @apply mt-0 mb-1 text-sm font-bold uppercase tracking-wide;
+.ff-callout__icon {
+    @apply inline-block size-4 shrink-0;
+    vertical-align: sub;
+    margin-right: 0.375rem;
 }
 
 .ff-callout__content > * {
     @apply text-left;
 }
 
-.ff-callout--note {
-    background-color: var(--color-blue-50);
-    border-left-color: var(--color-blue-500);
-}
+.ff-callout .ff-callout__content > :first-child { margin-top: 0 !important; }
+.ff-callout .ff-callout__content > :last-child { margin-bottom: 0 !important; }
+.ff-callout .ff-callout__content * { color: inherit; font-size: inherit !important; line-height: inherit !important; }
 
-.ff-callout--note .ff-callout__title {
-    color: var(--color-blue-700);
+.ff-callout--note {
+    background-color: color-mix(in srgb, var(--color-blue-500) 10%, transparent);
+    border-color: color-mix(in srgb, var(--color-blue-500) 25%, transparent);
+    color: var(--color-blue-600);
 }
 
 .ff-callout--warning {
-    background-color: var(--color-yellow-50);
-    border-left-color: var(--color-yellow-500);
+    background-color: color-mix(in srgb, var(--color-yellow-500) 10%, transparent);
+    border-color: color-mix(in srgb, var(--color-yellow-500) 25%, transparent);
+    color: var(--color-yellow-600);
 }
 
-.ff-callout--warning .ff-callout__title {
-    color: var(--color-yellow-700);
-}
-
-.ff-callout--critical {
-    background-color: var(--color-red-50);
-    border-left-color: var(--color-red-500);
-}
-
-.ff-callout--critical .ff-callout__title {
-    color: var(--color-red-700);
+.ff-callout--caution {
+    background-color: color-mix(in srgb, var(--color-red-500) 10%, transparent);
+    border-color: color-mix(in srgb, var(--color-red-500) 25%, transparent);
+    color: var(--color-red-600);
 }
 
 } /* end @layer components */
-
-@layer overrides {
-    .prose .ff-callout__content > :first-child { margin-top: 0; }
-    .prose .ff-callout__content > :last-child { margin-bottom: 0; }
-}


### PR DESCRIPTION
## Description

- Add callout boxes section to handbook Markdown Guide with live examples and syntax reference for both frameworks
- Unify visual style: Nuxt UI rounded/border/opacity look with blue/yellow/red color scheme, inline icon layout so wrapped text returns to the left edge
- Match Nuxt UI typography: text-sm/6 (14px, 24px line-height), forcing font-size and line-height inheritance over prose overrides
- Rename `critical` shortcode to `caution` to align with Nuxt UI naming
- Update caution icon to circle-alert (matching i-lucide-circle-alert)
- Remove Note.vue component (Nuxt UI ProseCallout handles ::note natively)
- Fix launch.json to use autoPort to avoid port conflicts


<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

