### PR TITLE
handbook: link Edge pricing calculator sheet in Engagements & Pricing

### DIFF
--- a/nuxt/content/handbook/sales/engagements.md
+++ b/nuxt/content/handbook/sales/engagements.md
@@ -9,6 +9,10 @@ pricing with enterprise customers, make a copy of
 [our internal pricing template deck](https://docs.google.com/presentation/d/1kaW6aZxpnCaVuQVdVsi0RTulhRMbeqglhZHkzSP-2kM/)
 to discuss.
 
+For FlowFuse Edge deals, use the
+[Edge pricing calculator](https://docs.google.com/spreadsheets/d/1v8Eo8zcdVZZsHxdmqmc03EM1p3QUp0sln14IBpyoo4M/edit?gid=736958252#gid=736958252)
+(internal only) for current list prices and quote generation.
+
 ## Creating a Deal
 
 A deal is opened when an opportunity has achieved the Sales and Buyer Verifiers for a given [Sales Stage](https://docs.google.com/spreadsheets/d/1WKz_ll6bLxkkRlZ4K94Va1laGksHXleo8Pnv0aB08lU/).


### PR DESCRIPTION
Sales needs a single place to find current FlowFuse Edge list prices when quoting.
