### PR TITLE
Hardcode opcua doc url

### DIFF
--- a/nuxt/utils/integrations.ts
+++ b/nuxt/utils/integrations.ts
@@ -24,6 +24,10 @@ function docPathFromCatalogueUrl (url: string | undefined): string | undefined {
     }
 }
 
+const DOCS_URL_OVERRIDES: Record<string, string> = {
+    '@flowfuse-certified-nodes/opcua': '/node-red/flowfuse/edge/opcua/'
+}
+
 function normalizeCertifiedModule (m: CertifiedCatalogueModule, collection: CertifiedCollection): IntegrationCatalogEntry {
     return {
         _id: m.id,
@@ -36,7 +40,7 @@ function normalizeCertifiedModule (m: CertifiedCatalogueModule, collection: Cert
         version: m.version,
         downloads: { week: 0 },
         updatedAt: m.updated_at,
-        docsUrl: docPathFromCatalogueUrl(m.url)
+        docsUrl: DOCS_URL_OVERRIDES[m.id] ?? docPathFromCatalogueUrl(m.url)
     }
 }
 


### PR DESCRIPTION
## Description

Add https://flowfuse.com/node-red/flowfuse/edge/opcua/ docs hardcoded to the opcua node on the integrations page. 

## Related Issue(s)

N/A

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

