### PR TITLE
fix: remove prose max-width and fix link colors

### DIFF
--- a/src/_includes/layouts/webinar.njk
+++ b/src/_includes/layouts/webinar.njk
@@ -37,8 +37,10 @@ layout: layouts/base.njk
                     </div>
                     {% endif %}
                 {% endif %}
-                <div class="prose">
-                    {{ content | safe }}
+                <div class="max-w-[706px]">
+                    <div class="prose">
+                        {{ content | safe }}
+                    </div>
                 </div>
             </div>
             <div class="w-72 max-w-full">

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -81,16 +81,12 @@
 @source not "../../nuxt/.netlify/**";
 @source "../../nuxt/**";
 
-@layer components {
-    .prose {
-        max-width: 80ch;
-    }
-}
-
 @layer overrides {
     .prose {
+        max-width: none;
         --tw-prose-body: var(--color-gray-700);
         --tw-prose-headings: var(--color-gray-600);
+        --tw-prose-links: var(--color-blue-600);
         --tw-prose-code: var(--color-red-700);
         --tw-prose-bold: var(--color-gray-500);
     }

--- a/src/partners/ctrlx.njk
+++ b/src/partners/ctrlx.njk
@@ -38,9 +38,9 @@ sitemapPriority: 0.6
         <div class="text-center mt-4 md:mt-6 mb-6">
             <h2>What FlowFuse Offers</h2>
         </div>
-        <div class="container m-auto max-w-4xl prose">
+        <div class="container m-auto max-w-4xl">
             <div class="grid px-6 md:px-0 grid-cols-1 md:grid-cols-2 gap-6 md:gap-10 sm:gap-x-8 sm:gap-y-0 mb-10">
-                <div class="text-left self-start">
+                <div class="prose text-left self-start">
                     <h3 class="flex items-center gap-4">
                         <div class="w-16">
                             {% image "./images/pictograms/results_blue.png", "Graphics depicting low-code programming.", [64] %}
@@ -53,7 +53,7 @@ sitemapPriority: 0.6
                         FlowFuse reduces the risk of using Node-RED in production. We offer professional support for Node-RED deployments on the crtlX platform. Customers have direct access to Node-RED experts who can help with development and production deployment issues.
                     </p>
                 </div>
-                <div class="text-left self-start">
+                <div class="prose text-left self-start">
                     <h3 class="flex items-center gap-4">
                         <div class="w-16">
                             {% image "./images/pictograms/node_catalog_blue.png", "Graphics depicting connectivity and integration.", [64] %}

--- a/src/professional-services.njk
+++ b/src/professional-services.njk
@@ -50,7 +50,7 @@ hubspot:
         <h2>Contact us</h2>
         <p>Reach out to discuss how FlowFuse experts can help with your FlowFuse and Node-RED projects.</p>
       </div>
-      <div class="container m-auto md:max-w-xl prose">
+      <div class="container m-auto md:max-w-xl">
         <div class="px-6 mb-16">
           {% include hubspot.script %}
         </div>


### PR DESCRIPTION
## Description

This PR fixes a few styles that changed as a consequence of migrating to Tailwind 4.
 
- Removes the global `max-width` override on `.prose` so it no longer conflicts with layout constraints set by parent containers
- Adds `--tw-prose-links` to `@layer overrides` to restore blue link color inside prose (the typography plugin default was nearly black)
- Wraps webinar prose content in a `max-w-[706px]` container to match the video/image width
- Fixes `partners/ctrlx.njk` and `professional-services.njk` where `.prose` was incorrectly applied to layout containers instead of text content

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

