### PR TITLE
Fix logo and update colors in handbook OG image

### DIFF
--- a/nuxt/components/OgImage/Default.satori.vue
+++ b/nuxt/components/OgImage/Default.satori.vue
@@ -6,11 +6,11 @@ defineProps<{
 </script>
 
 <template>
-  <div style="display:flex;flex-direction:column;width:100%;height:100%;background:#1a1a2e;padding:60px 70px;font-family:sans-serif;color:white;">
+  <div style="display:flex;flex-direction:column;width:100%;height:100%;background:#312E81;padding:60px 70px;font-family:sans-serif;color:white;">
     <!-- Header: logo + site name -->
     <div style="display:flex;align-items:center;gap:16px;margin-bottom:auto;">
       <img
-        src="https://flowfuse.com/handbook/images/logos/ff-logo--square--dark.png"
+        src="https://flowfuse.com/images/ff-minimal-red.svg"
         style="width:52px;height:52px;"
       />
       <span style="font-size:26px;font-weight:700;color:#ffffff;">FlowFuse</span>
@@ -21,7 +21,7 @@ defineProps<{
       <div style="font-size:54px;font-weight:800;color:#ffffff;line-height:1.15;max-width:900px;">
         {{ title }}
       </div>
-      <div style="font-size:22px;color:#64ffda;font-weight:500;">flowfuse.com</div>
+      <div style="font-size:22px;color:#A5B4FC;font-weight:500;">flowfuse.com</div>
     </div>
   </div>
 </template>

--- a/nuxt/server/middleware/legacy.ts
+++ b/nuxt/server/middleware/legacy.ts
@@ -16,7 +16,7 @@ export default defineEventHandler(async (event) => {
     const path = event.path ?? '/'
 
     // Let Nuxt handle its own internal assets and API routes
-    if (path.startsWith('/_nuxt/') || path.startsWith('/api/') || path.startsWith('/__') || path.startsWith('/_studio')) return
+    if (path.startsWith('/_nuxt/') || path.startsWith('/api/') || path.startsWith('/__') || path.startsWith('/_studio') || path.startsWith('/_og/')) return
 
     // Let Nuxt handle migrated pages (strip trailing slash and query string before matching)
     const pathWithoutQuery = path.split('?')[0]


### PR DESCRIPTION
## Description

- Replace the handbook OG image logo with the existing vector icon (`ff-minimal-red.svg`) — the previous PNG was non-square (529×287) and got visibly deformed/pixelated when scaled down to 52px; the SVG renders crisp at any size.
- Update OG image color scheme: background to `#312E81`, `flowfuse.com` text to `#A5B4FC`.
- Fix `nuxt/server/middleware/legacy.ts` dev proxy to let `/_og/**` requests be handled by Nuxt instead of being forwarded to the 11ty dev server — this is what makes it possible to preview handbook OG images locally at all (dev-only, no effect on production).

The image changes from 
<img width="378" height="196" alt="Screenshot 2026-07-06 at 11 17 36" src="https://github.com/user-attachments/assets/f3149fd4-d1b8-4155-8dae-10ae7596a198" />
 to
<img width="378" height="196" alt="c_Default,title_Handbook,section_Handbook,p_Ii9oYW5kYm9vay8i" src="https://github.com/user-attachments/assets/da0a459a-72db-4f80-9b4f-f42b6acf9e33" />


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

