### PR TITLE
Skip Netlify image provider outside production builds

### DIFF
--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -87,7 +87,10 @@ export default defineNuxtConfig({
     },
 
     image: {
-        provider: process.env.SKIP_IMAGES === 'true' ? 'none' : 'netlify',
+        // The Netlify image provider proxies through a Netlify Image CDN function that only
+        // exists on deployed/Netlify-run infra, so it 404s under plain `nuxt dev`. Fall back to
+        // the passthrough provider outside production builds, or when SKIP_IMAGES is set.
+        provider: (process.env.NODE_ENV !== 'production' || process.env.SKIP_IMAGES === 'true') ? 'none' : 'netlify',
         domains: ['flowfuse.com', 'www.flowfuse.com'],
         quality: 80,
     },


### PR DESCRIPTION
## Description

- `@nuxt/image` was configured to always use the `netlify` provider unless `SKIP_IMAGES=true` was set explicitly. That provider proxies images through a Netlify Image CDN function that only exists on deployed/Netlify-run infra, so under plain `nuxt dev` every image request 404s (e.g. `/.netlify/images?url=...`).
- This affected any image rendered through `@nuxt/content` markdown (handbook pages use `ProseImg` → `NuxtImg`), making handbook images invisible in local dev — noticeable on `/handbook/design/branding/`, which is mostly logo images.
- Now falls back to the `none` (passthrough) provider automatically whenever `NODE_ENV !== 'production'`, in addition to the existing `SKIP_IMAGES=true` override. Production builds (`NODE_ENV=production`, set explicitly by `build:nuxt`) are unaffected.


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

