### PR TITLE
fix: contain prose images within flex containers

### DIFF
--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -46,7 +46,7 @@
     {% endif %}
     <div class="blog nohero w-full pb-24">
         <div class="container flex flex-col md:flex-row m-auto text-left max-lg:px-6 md:max-w-screen-lg gap-8 items-stretch">
-            <div class="ff-prose">
+            <div class="ff-prose min-w-0">
                 <a class="inline-flex align-center gap-1 mb-4" href="/blog">
                     {% include "components/icons/chevron-left.svg" %}
                     Back to Blog Posts

--- a/src/_includes/layouts/webinar.njk
+++ b/src/_includes/layouts/webinar.njk
@@ -21,7 +21,7 @@ layout: layouts/base.njk
     {% endif %}
     <div class="blog nohero w-full pt-6 pb-24">
         <div class="container flex flex-col md:flex-row m-auto text-left max-lg:px-6 md:max-w-screen-lg gap-8">
-            <div>
+            <div class="min-w-0">
                 <a class="mb-4 inline-flex align-center gap-1" href="/webinars/">
                     {% include "components/icons/chevron-left.svg" %}
                     Back to Webinars

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -90,6 +90,7 @@
         --tw-prose-code: var(--color-red-700);
         --tw-prose-bold: var(--color-gray-500);
     }
+    .prose img { max-width: 100%; }
 }
 
 @import "./style.page.css";


### PR DESCRIPTION
## Description

This PR fixes a style regression introduced by removing the global  max-width from .prose in the Tailwind 4 migration.

- Adds `min-w-0` to the `.ff-prose` flex child in `post.njk` and the content wrapper in `webinar.njk` to prevent prose content from overflowing its flex container when no max-width is set

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

