### PR TITLE
Update FlowFuse version requirement for tokens

### DIFF
--- a/nuxt/content/handbook/engineering/ops/certified-nodes.md
+++ b/nuxt/content/handbook/engineering/ops/certified-nodes.md
@@ -23,7 +23,7 @@ Nodes are grouped into two categories
     - Make required changes ff-certified-nodes instance
     - For Self Hosted customer provide token to Sales to pass to the customer
     - For Teams on FFC go to Team Settings -> Danger -> Edit Usage limits, tick Certifed nodes and add the required catalogue URLS to the box at bottom
-6. Sales provide the token to Self Hosted cutsomers. The token is to be entered on the Admin Settings -> FlowFuse Nodes page. **NOTE:** the cusomer **MUST** be running FlowFue 2.31.2 or newer before applying the token and they will need to restart Instances to pick up the new catalogues.
+6. Sales provide the token to Self Hosted cutsomers. The token is to be entered on the Admin Settings -> FlowFuse Nodes page. **NOTE:** the cusomer **MUST** be running FlowFue 2.32.0 or newer before applying the token and they will need to restart Instances to pick up the new catalogues.
 
 ![Screenshot of Certified Nodes token](../../engineering/images/certified-nodes-token.png)
 _Screnshot of where to enter Certfied Nodes Token_


### PR DESCRIPTION
Updated the required FlowFuse version for token application from 2.31.2 to 2.32.0 for Self Hosted customers.

2.31.3 is enough. but better to push to latest (2.32)

