### PR TITLE
handbook: Add Account-Based Marketing page

### DIFF
--- a/nuxt/content/handbook/marketing/account-based-marketing/index.md
+++ b/nuxt/content/handbook/marketing/account-based-marketing/index.md
@@ -17,7 +17,7 @@ ABM at FlowFuse is currently expressed through a few concrete activities
 rather than a single dedicated program page:
 
 - **Paid advertising**: targeted ABM campaigns on LinkedIn and Google Ads are
-  run as part of [Demand Generation](/handbook/marketing/programs/#1-demand-generation)
+  run as part of [Demand Generation](/handbook/marketing/programs/)
   to reach specific target accounts, drive traffic to key content, and
   generate MQLs.
 - **Intent signals**: ad interaction data from ABM platforms (e.g. ZenABM) is

--- a/nuxt/content/handbook/marketing/account-based-marketing/index.md
+++ b/nuxt/content/handbook/marketing/account-based-marketing/index.md
@@ -36,7 +36,9 @@ rather than a single dedicated program page:
 
 ## How it fits together
 
-1. Sales and marketing agree on a target account list, based on our
+1. Sales and marketing agree on a
+   [target account list](https://app-eu1.hubspot.com/contacts/26586079/objectLists/2463/filters),
+   based on our
    [Ideal Customer Profile (ICP)](/handbook/marketing/messaging/#ideal-customer-profile-icp).
 2. Marketing runs targeted paid campaigns (LinkedIn, Google Ads) against that
    account list as part of Demand Generation.
@@ -47,6 +49,7 @@ rather than a single dedicated program page:
 
 ## Related pages
 
+- [ABM target account list](https://app-eu1.hubspot.com/contacts/26586079/objectLists/2463/filters)
 - [Marketing Programs](/handbook/marketing/programs/)
 - [Lead Activation](/handbook/marketing/lead-activation/)
 - [Messaging & ICP](/handbook/marketing/messaging/)

--- a/nuxt/content/handbook/marketing/account-based-marketing/index.md
+++ b/nuxt/content/handbook/marketing/account-based-marketing/index.md
@@ -1,0 +1,53 @@
+---
+title: "Account-Based Marketing"
+---
+
+# Account-Based Marketing (ABM)
+
+Account-Based Marketing is one of the three pillars of the [Marketing
+department](/handbook/marketing/), alongside our
+[Content Strategy](/handbook/marketing/content-strategy/) and
+[Events](/handbook/marketing/events/) programs. Where content and events cast
+a wide net, ABM focuses marketing and sales effort on a defined list of
+high-value target accounts.
+
+## Where ABM shows up today
+
+ABM at FlowFuse is currently expressed through a few concrete activities
+rather than a single dedicated program page:
+
+- **Paid advertising**: targeted ABM campaigns on LinkedIn and Google Ads are
+  run as part of [Demand Generation](/handbook/marketing/programs/#1-demand-generation)
+  to reach specific target accounts, drive traffic to key content, and
+  generate MQLs.
+- **Intent signals**: ad interaction data from ABM platforms (e.g. ZenABM) is
+  one of the behavioral signals used to classify
+  [Intent Outbound leads](/handbook/marketing/lead-activation/#intent-outbound-push-based-on-behavior),
+  alongside website visit tracking (HubSpot Intent, Warmly) and content
+  engagement patterns.
+- **Sales execution**: Account Executives are directly responsible for
+  targeting key accounts using an ABM approach in their region — see the
+  [Account Executive job description](/handbook/peopleops/job-descriptions/account-executive/)
+  for the EMEA, US, and other regional variants.
+- **Digital marketing skills**: familiarity with LinkedIn ABM tooling is
+  listed as a core skill for the
+  [Developer Relations Advocate role](/handbook/peopleops/job-descriptions/developer-relations-advocate/),
+  reflecting how ABM campaigns are supported cross-functionally.
+
+## How it fits together
+
+1. Sales and marketing agree on a target account list, based on our
+   [Ideal Customer Profile (ICP)](/handbook/marketing/messaging/#ideal-customer-profile-icp).
+2. Marketing runs targeted paid campaigns (LinkedIn, Google Ads) against that
+   account list as part of Demand Generation.
+3. Engagement and ad-interaction data from ABM tooling feeds into lead
+   scoring, surfacing accounts as Intent Outbound leads for sales follow-up.
+4. Account Executives use ABM to prioritize and engage these key accounts
+   directly, tracking outcomes in [HubSpot](/handbook/sales/hubspot/).
+
+## Related pages
+
+- [Marketing Programs](/handbook/marketing/programs/)
+- [Lead Activation](/handbook/marketing/lead-activation/)
+- [Messaging & ICP](/handbook/marketing/messaging/)
+- [Account Executive job description](/handbook/peopleops/job-descriptions/account-executive/)

--- a/nuxt/content/handbook/marketing/index.md
+++ b/nuxt/content/handbook/marketing/index.md
@@ -12,7 +12,7 @@ of FlowFuse.
 
 There's 3 pillars we're heavily invested in:
 1. Our [Content Strategy](./content-strategy/)
-2. Account Based Marketing
+2. [Account Based Marketing](./account-based-marketing/)
 3. [Events](./events.md)
 
 Combined, these pillars are engaging with our audience at different stages of

--- a/nuxt/content/handbook/marketing/programs.md
+++ b/nuxt/content/handbook/marketing/programs.md
@@ -16,7 +16,7 @@ This area focuses on creating pipeline by attracting new prospects and capturing
 qualified leads.
 
 - **Paid Advertising Campaigns**: We run targeted digital ad campaigns (e.g.,
-  ABM on LinkedIn, Google Ads) to reach specific audiences, drive traffic to our
+  [ABM](/handbook/marketing/account-based-marketing/) on LinkedIn, Google Ads) to reach specific audiences, drive traffic to our
   key content, and generate MQLs (Marketing Qualified Leads). See [Lead
   Activation](/handbook/marketing/lead-activation/) for definitions of inbound
   vs. outbound lead sources.


### PR DESCRIPTION
## Summary
- Adds a new `Account-Based Marketing` handbook page under `marketing/account-based-marketing/index.md` that pulls together how FlowFuse does ABM today (paid ads, intent signals, AE/DevRel job descriptions)
- Links it from the marketing pillars list in `marketing/index.md` and the ABM mention in `marketing/programs.md`

## Test plan
- [ ] `npm run dev:nuxt` and confirm `/handbook/marketing/account-based-marketing/` renders and shows in the sidebar nav under Marketing
- [ ] Confirm links from `/handbook/marketing/` and `/handbook/marketing/programs/` resolve correctly