### PR TITLE
handbook: Document loading ABM target list into LinkedIn

### DIFF
--- a/nuxt/content/handbook/marketing/account-based-marketing/.navigation.yml
+++ b/nuxt/content/handbook/marketing/account-based-marketing/.navigation.yml
@@ -1,0 +1,3 @@
+title: "Account-Based Marketing"
+navigation:
+  icon: i-lucide-target

--- a/nuxt/content/handbook/marketing/account-based-marketing/index.md
+++ b/nuxt/content/handbook/marketing/account-based-marketing/index.md
@@ -37,7 +37,7 @@ rather than a single dedicated program page:
 ## How it fits together
 
 1. Sales and marketing agree on a
-   [target account list](https://app-eu1.hubspot.com/contacts/26586079/objectLists/2463/filters),
+   [target account list][hubspot-target-list],
    based on our
    [Ideal Customer Profile (ICP)](/handbook/marketing/messaging/#ideal-customer-profile-icp).
 2. Marketing runs targeted paid campaigns (LinkedIn, Google Ads) against that
@@ -47,10 +47,47 @@ rather than a single dedicated program page:
 4. Account Executives use ABM to prioritize and engage these key accounts
    directly, tracking outcomes in [HubSpot](/handbook/sales/hubspot/).
 
+## Loading the target account list into LinkedIn
+
+LinkedIn ABM campaigns target the same
+[target account list][hubspot-target-list]
+maintained in HubSpot, loaded into LinkedIn Campaign Manager as a Matched
+Audience. To (re)load the list:
+
+1. In HubSpot, open the
+   [target account list][hubspot-target-list]
+   and export it as a CSV, including the following columns: first name,
+   last name, email, job title, country, Google Advertising ID (googleaid),
+   and company (from the contact's company property, used as the company
+   name).
+1. Rename the exported columns to the headers LinkedIn expects:
+   `email`, `firstname`, `lastname`, `jobtitle`, `employeecompany`,
+   `country`, and `googleaid`.
+1. In [LinkedIn Campaign Manager][linkedin-campaign-manager], go to
+   **Plan > Audiences**.
+1. Select the existing ABM target account audience (or create one if it
+   doesn't exist yet) and choose to match on a company/contact source.
+1. Upload the renamed CSV to update the audience.
+1. Confirm the upload — LinkedIn will match contacts from the list against
+   its own member database and refresh the audience once matching
+   completes (this can take up to a day).
+1. Check that the active ABM campaigns are still targeting this audience
+   after the refresh.
+
+The target account list is **dynamic** — accounts are added and removed by
+sales and marketing as the ICP fit and pipeline priorities change. Because
+LinkedIn does not sync the list automatically, the operator running ABM
+campaigns must repeat these steps **weekly** to re-export the latest list
+from HubSpot and re-upload it, so LinkedIn targeting stays in sync with the
+current target accounts.
+
 ## Related pages
 
-- [ABM target account list](https://app-eu1.hubspot.com/contacts/26586079/objectLists/2463/filters)
+- [ABM target account list][hubspot-target-list]
 - [Marketing Programs](/handbook/marketing/programs/)
 - [Lead Activation](/handbook/marketing/lead-activation/)
 - [Messaging & ICP](/handbook/marketing/messaging/)
 - [Account Executive job description](/handbook/peopleops/job-descriptions/account-executive/)
+
+[hubspot-target-list]: https://app-eu1.hubspot.com/contacts/26586079/objectLists/2463/filters
+[linkedin-campaign-manager]: https://www.linkedin.com/campaignmanager/accounts/512972960/overview?businessId=personal

--- a/nuxt/content/handbook/marketing/account-based-marketing/index.md
+++ b/nuxt/content/handbook/marketing/account-based-marketing/index.md
@@ -37,7 +37,7 @@ rather than a single dedicated program page:
 ## How it fits together
 
 1. Sales and marketing agree on a
-   [target account list][hubspot-target-list],
+   [target account list][hubspot-target-account-list],
    based on our
    [Ideal Customer Profile (ICP)](/handbook/marketing/messaging/#ideal-customer-profile-icp).
 2. Marketing runs targeted paid campaigns (LinkedIn, Google Ads) against that
@@ -47,15 +47,20 @@ rather than a single dedicated program page:
 4. Account Executives use ABM to prioritize and engage these key accounts
    directly, tracking outcomes in [HubSpot](/handbook/sales/hubspot/).
 
-## Loading the target account list into LinkedIn
+## Loading the target lists into LinkedIn
 
-LinkedIn ABM campaigns target the same
-[target account list][hubspot-target-list]
-maintained in HubSpot, loaded into LinkedIn Campaign Manager as a Matched
-Audience. To (re)load the list:
+HubSpot maintains two related target lists for ABM:
+
+- The [target account list][hubspot-target-account-list] — the companies
+  sales and marketing have agreed to target.
+- The [target contact list][hubspot-target-contact-list] — the individual
+  contacts at those companies, used to build the LinkedIn Matched Audience.
+
+LinkedIn ABM campaigns target a Matched Audience built from the target
+contact list. To (re)load the list:
 
 1. In HubSpot, open the
-   [target account list][hubspot-target-list]
+   [target contact list][hubspot-target-contact-list]
    and export it as a CSV, including the following columns: first name,
    last name, email, job title, country, Google Advertising ID (googleaid),
    and company (from the contact's company property, used as the company
@@ -74,20 +79,23 @@ Audience. To (re)load the list:
 1. Check that the active ABM campaigns are still targeting this audience
    after the refresh.
 
-The target account list is **dynamic** — accounts are added and removed by
-sales and marketing as the ICP fit and pipeline priorities change. Because
-LinkedIn does not sync the list automatically, the operator running ABM
-campaigns must repeat these steps **weekly** to re-export the latest list
-from HubSpot and re-upload it, so LinkedIn targeting stays in sync with the
-current target accounts.
+Both the target account list and target contact list are **dynamic** —
+accounts and contacts are added and removed by sales and marketing as the
+ICP fit and pipeline priorities change. Because LinkedIn does not sync the
+list automatically, the operator running ABM campaigns must repeat these
+steps **weekly** to re-export the latest contact list from HubSpot and
+re-upload it, so LinkedIn targeting stays in sync with the current target
+accounts.
 
 ## Related pages
 
-- [ABM target account list][hubspot-target-list]
+- [ABM target account list][hubspot-target-account-list]
+- [ABM target contact list][hubspot-target-contact-list]
 - [Marketing Programs](/handbook/marketing/programs/)
 - [Lead Activation](/handbook/marketing/lead-activation/)
 - [Messaging & ICP](/handbook/marketing/messaging/)
 - [Account Executive job description](/handbook/peopleops/job-descriptions/account-executive/)
 
-[hubspot-target-list]: https://app-eu1.hubspot.com/contacts/26586079/objectLists/2463/filters
+[hubspot-target-account-list]: https://app-eu1.hubspot.com/contacts/26586079/objectLists/2463/filters
+[hubspot-target-contact-list]: https://app-eu1.hubspot.com/contacts/26586079/objectLists/2464/filters
 [linkedin-campaign-manager]: https://www.linkedin.com/campaignmanager/accounts/512972960/overview?businessId=personal


### PR DESCRIPTION
## Summary
- Adds a "Loading the target account list into LinkedIn" section to the ABM handbook page
- Documents exporting the HubSpot target account list, renaming columns to LinkedIn's expected headers (`email`, `firstname`, `lastname`, `jobtitle`, `employeecompany`, `country`, `googleaid`), and uploading it as a Matched Audience in LinkedIn Campaign Manager
- Notes the list is dynamic and must be re-exported/re-uploaded weekly
- Deduplicates the HubSpot list link via a reference-style Markdown link (`[hubspot-target-list]`)

## Test plan
- [ ] Docs-only change; not rendered locally — review Markdown for correctness