### PR TITLE
Add product marketing handbook page

### DIFF
--- a/nuxt/content/handbook/marketing/account-based-marketing/index.md
+++ b/nuxt/content/handbook/marketing/account-based-marketing/index.md
@@ -50,6 +50,7 @@ rather than a single dedicated program page:
 ## Related pages
 
 - [ABM target account list](https://app-eu1.hubspot.com/contacts/26586079/objectLists/2463/filters)
+- [Product Marketing](/handbook/marketing/product-marketing/)
 - [Marketing Programs](/handbook/marketing/programs/)
 - [Lead Activation](/handbook/marketing/lead-activation/)
 - [Messaging & ICP](/handbook/marketing/messaging/)

--- a/nuxt/content/handbook/marketing/index.md
+++ b/nuxt/content/handbook/marketing/index.md
@@ -10,6 +10,11 @@ We're the team that promotes our company and product of FlowFuse to the
 [core audience](/handbook/marketing/messaging/#ideal-customer-profile-icp)
 of FlowFuse.
 
+What we market is defined by our use cases, the customer-centric entry points
+into the FlowFuse platform. See
+[Product Marketing](/handbook/marketing/product-marketing/) for how these are
+developed into Showcases and brought to market.
+
 There's 3 pillars we're heavily invested in:
 1. Our [Content Strategy](./content-strategy/)
 2. [Account Based Marketing](./account-based-marketing/)

--- a/nuxt/content/handbook/marketing/product-marketing.md
+++ b/nuxt/content/handbook/marketing/product-marketing.md
@@ -35,6 +35,12 @@ the platform: what is built stays visible and understandable end to end in
 low code, so it can be trusted, audited, and operated in production. Every
 use case story ends at the same place, the platform.
 
+The platform and the use cases grow together. New feature functionality
+broadens the platform and unlocks new use cases, while deepening what already
+exists makes the current use cases better supported. For AI specifically, we
+look for use cases that are enabled by AI, next to using AI to better support
+the use cases that are not.
+
 ## Showcases
 
 A Showcase makes a use case visible as it can be developed on our platform,
@@ -65,18 +71,11 @@ it and has the time allocated to it.
 
 ## Prioritization
 
-Two lenses set the order in which use cases are developed into Showcases:
-
-- **[Account-based marketing](/handbook/marketing/account-based-marketing/)**:
-  each target account has specific problems, needs, and desires that map to
-  specific use cases. That mapping gives a priority order directly connected
-  to our pipeline.
-- **Breadth and depth**: platform improvements either deepen what already
-  exists or broaden into new use cases. Breadth aligns most directly with the
-  PMP because it creates new stories to tell; depth strengthens
-  differentiation and onboarding within existing stories. For AI specifically,
-  we look for use cases that are enabled by AI, next to using AI to improve
-  the onboarding of use cases that are not.
+[Account-based marketing](/handbook/marketing/account-based-marketing/) sets
+the order in which use cases are developed into Showcases: each target
+account has specific problems, needs, and desires that map to specific use
+cases. That mapping gives a priority order directly connected to our
+pipeline.
 
 ## Go-to-market plans
 

--- a/nuxt/content/handbook/marketing/product-marketing.md
+++ b/nuxt/content/handbook/marketing/product-marketing.md
@@ -80,8 +80,11 @@ pipeline.
 ## Go-to-market plans
 
 Each Showcase gets one story and one go-to-market plan, tracked in Asana with
-tickets across Marketing, Sales, Product, and Engineering. Work lands with
-marketing through the same mechanisms as all other marketing work: the
+tickets across Marketing, Sales, Product, and Engineering. Stories and their
+Asana tasks come together in the
+[Use Cases project](https://app.asana.com/1/1213818720452348/project/1215720226996029/note/1216389200058782),
+the holistic overview of the PMP. Work lands with marketing through the same
+mechanisms as all other marketing work: the
 [request forms](/handbook/marketing/content-strategy/#requesting-work-from-marketing)
 and the content calendar documented in
 [How we work](/handbook/marketing/how-we-work/).

--- a/nuxt/content/handbook/marketing/product-marketing.md
+++ b/nuxt/content/handbook/marketing/product-marketing.md
@@ -14,11 +14,7 @@ marketing team plans and executes content, see the
 
 ## The Product Marketable Product
 
-The FlowFuse platform is our strongest asset. It can entertain any scenario,
-and whatever is built on it the customer can fully inspect, adapt, and own.
-Power of that breadth needs concrete entry points to speak to an individual
-customer, because value is recognized fastest through one's own problem,
-need, or desire.
+The FlowFuse platform is our strongest asset. Customers can build almost anything on it, then fully inspect, adapt, and own what they build. That breadth needs concrete entry points. Customers recognize value fastest when they see their own problem being solved.
 
 Use cases are those entry points. A use case is the customer-centric
 abstraction of the platform: a real problem customers face and how it is

--- a/nuxt/content/handbook/marketing/product-marketing.md
+++ b/nuxt/content/handbook/marketing/product-marketing.md
@@ -100,7 +100,8 @@ coherent web of resources.
 ## Tracking success
 
 We track success on three levels, reviewed together in the weekly Product and
-Marketing sync:
+Marketing sync. As this practice matures, we can consider a review that also
+includes Sales.
 
 - **Lagging**: sales pipeline where a use case is the attributable entry
   point, and behind it, customers won that tie back to a specific story.

--- a/nuxt/content/handbook/marketing/product-marketing.md
+++ b/nuxt/content/handbook/marketing/product-marketing.md
@@ -38,7 +38,8 @@ across the funnel.
 
 ## Showcases
 
-A use case is completely developed when it becomes a Showcase, consisting of:
+A Showcase makes a use case visible as it can be developed on our platform,
+and includes everything around it, consisting of:
 
 1. **Use case definition**: the customer problem and outcome, written
    customer-centric.

--- a/nuxt/content/handbook/marketing/product-marketing.md
+++ b/nuxt/content/handbook/marketing/product-marketing.md
@@ -83,8 +83,11 @@ Each Showcase gets one story and one go-to-market plan, tracked in Asana with
 tickets across Marketing, Sales, Product, and Engineering. Stories and their
 Asana tasks come together in the
 [Use Cases project](https://app.asana.com/1/1213818720452348/project/1215720226996029/note/1216389200058782),
-the holistic overview of the PMP. Work lands with marketing through the same
-mechanisms as all other marketing work: the
+the holistic overview of the PMP. Tasks in it can be shared across Sales,
+Product, and Engineering.
+
+Work lands with marketing through the same mechanisms as all other marketing
+work: the
 [request forms](/handbook/marketing/content-strategy/#requesting-work-from-marketing)
 and the content calendar documented in
 [How we work](/handbook/marketing/how-we-work/).

--- a/nuxt/content/handbook/marketing/product-marketing.md
+++ b/nuxt/content/handbook/marketing/product-marketing.md
@@ -107,8 +107,7 @@ Marketing sync. As this practice matures, we can consider a review that also
 includes Sales.
 
 - **Lagging**: sales pipeline where a use case is the attributable entry
-  point and marketing MQL generation, with customers won that tie back to a
-  specific story behind both.
+  point and marketing MQL generation, with customers we win that tie back to a specific story.
 - **Leading**: behavior that predicts that pipeline; engagement on the use
   case pages, deployments of Showcase blueprints, hand-raises (contact sales
   submissions and trial signups attributable to use case content), and

--- a/nuxt/content/handbook/marketing/product-marketing.md
+++ b/nuxt/content/handbook/marketing/product-marketing.md
@@ -54,15 +54,13 @@ and includes everything around it, consisting of:
 ## Cross-functional ownership
 
 The PMP is a shared artifact between Sales, Marketing, Product, and
-Engineering. Each department is both contributor and stakeholder:
+Engineering. Each department is both contributor and stakeholder, and no
+single department owns a Showcase end to end.
 
-- **Sales** defines use cases from customer conversations and contributes
-  customer stories and proof-of-concept journeys.
-- **Marketing** produces and distributes the marketing artifacts and owns the
-  differentiation content, such as comparison pages.
-- **Product and Engineering** build the demos and blueprints, write
-  implementation journeys, and feed the use cases into the product roadmap
-  through product objectives.
+Ownership is assigned per Showcase: its go-to-market plan names an owner for
+each component (use case definition, differentiation, product application,
+onboarding journey, and marketing artifacts), based on who is best placed for
+it and has the time allocated to it.
 
 ## Prioritization
 

--- a/nuxt/content/handbook/marketing/product-marketing.md
+++ b/nuxt/content/handbook/marketing/product-marketing.md
@@ -8,6 +8,10 @@ description: |-
 
 # Product Marketing
 
+This page defines what we market and how it goes to market. For how the
+marketing team plans and executes content, see the
+[Content Strategy](/handbook/marketing/content-strategy/).
+
 ## The Product Marketable Product
 
 The FlowFuse platform is our strongest asset. It can entertain any scenario,
@@ -20,7 +24,9 @@ Use cases are those entry points. A use case is the customer-centric
 abstraction of the platform: a real problem customers face and how it is
 resolved with FlowFuse. Use cases are what customers recognize themselves in,
 and they are therefore what we lead with: our Product Marketable Product, or
-PMP.
+PMP. Use cases make our [company messaging](/handbook/marketing/messaging/)
+concrete: they express the product pillars as specific problems of our Ideal
+Customer Profile.
 
 A use case implementation is a starting point, not a boxed product. We show
 how the problem can be solved on FlowFuse, and customers adjust and fully own
@@ -49,7 +55,8 @@ and includes everything around it, consisting of:
 4. **Onboarding journey**: how we or the customer get the use case
    implemented, from first interest to production.
 5. **Marketing artifacts**: the show and tell; use case web pages, videos,
-   blog posts, social content, and customer stories.
+   blog posts, social content, and
+   [customer stories](/handbook/marketing/content-strategy/customer-stories/).
 
 ## Cross-functional ownership
 
@@ -66,9 +73,10 @@ it and has the time allocated to it.
 
 Two lenses set the order in which use cases are developed into Showcases:
 
-- **Account-based marketing**: each target account has specific problems,
-  needs, and desires that map to specific use cases. That mapping gives a
-  priority order directly connected to our pipeline.
+- **[Account-based marketing](/handbook/marketing/account-based-marketing/)**:
+  each target account has specific problems, needs, and desires that map to
+  specific use cases. That mapping gives a priority order directly connected
+  to our pipeline.
 - **Breadth and depth**: platform improvements either deepen what already
   exists or broaden into new use cases. Breadth aligns most directly with the
   PMP because it creates new stories to tell; depth strengthens
@@ -79,7 +87,11 @@ Two lenses set the order in which use cases are developed into Showcases:
 ## Go-to-market plans
 
 Each Showcase gets one story and one go-to-market plan, tracked in Asana with
-tickets across Marketing, Sales, Product, and Engineering.
+tickets across Marketing, Sales, Product, and Engineering. Work lands with
+marketing through the same mechanisms as all other marketing work: the
+[request forms](/handbook/marketing/content-strategy/#requesting-work-from-marketing)
+and the content calendar documented in
+[How we work](/handbook/marketing/how-we-work/).
 
 We run one storyline at a time and repeat it consistently across weeks and
 channels before moving to the next. A message must be repeated far more often

--- a/nuxt/content/handbook/marketing/product-marketing.md
+++ b/nuxt/content/handbook/marketing/product-marketing.md
@@ -46,7 +46,8 @@ and includes everything around it, consisting of:
 3. **Product application**: the use case implemented in FlowFuse, as a demo
    and, where possible, a blueprint anyone can deploy.
 4. **Onboarding journey**: how we or the customer get the use case
-   implemented, from first interest to production.
+   implemented, from first interest to production, supported by blueprints,
+   the FlowFuse Expert and our AI capabilities, and documentation.
 5. **Marketing artifacts**: the show and tell; use case web pages, videos,
    blog posts, social content, and
    [customer stories](/handbook/marketing/content-strategy/customer-stories/).

--- a/nuxt/content/handbook/marketing/product-marketing.md
+++ b/nuxt/content/handbook/marketing/product-marketing.md
@@ -94,6 +94,29 @@ All collateral ties back to its use case, so the use case page, blueprint,
 certified nodes, comparison pages, and customer stories interlink into one
 coherent web of resources.
 
+## Tracking success
+
+We track success on three levels, reviewed together in the weekly Product and
+Marketing sync:
+
+- **Lagging**: sales pipeline where a use case is the attributable entry
+  point, and behind it, customers won that tie back to a specific story.
+- **Leading**: behavior that predicts that pipeline; engagement on the use
+  case pages, deployments of Showcase blueprints, hand-raises (contact sales
+  submissions and trial signups attributable to use case content), and
+  engagement from the
+  [account-based marketing](/handbook/marketing/account-based-marketing/)
+  target accounts a use case maps to.
+- **Traction per story**: every story tracks the same base set for its
+  artifacts (reach, engagement, and deploys per artifact type), so stories
+  stay comparable and each go-to-market plan is judged on the same terms.
+
+These measures are not a separate scoreboard next to departmental goals: the
+lagging metrics are sales' own objectives, the leading indicators are the
+supporting metrics marketing already reports on, and blueprint deployments
+and onboarding success are product outcomes for Product and Engineering. A
+Showcase that works moves every department's existing objectives at once.
+
 ## Where to see it
 
 - Use cases on the [home page](https://flowfuse.com)

--- a/nuxt/content/handbook/marketing/product-marketing.md
+++ b/nuxt/content/handbook/marketing/product-marketing.md
@@ -104,7 +104,8 @@ Marketing sync. As this practice matures, we can consider a review that also
 includes Sales.
 
 - **Lagging**: sales pipeline where a use case is the attributable entry
-  point, and behind it, customers won that tie back to a specific story.
+  point and marketing MQL generation, with customers won that tie back to a
+  specific story behind both.
 - **Leading**: behavior that predicts that pipeline; engagement on the use
   case pages, deployments of Showcase blueprints, hand-raises (contact sales
   submissions and trial signups attributable to use case content), and
@@ -115,11 +116,16 @@ includes Sales.
   artifacts (reach, engagement, and deploys per artifact type), so stories
   stay comparable and each go-to-market plan is judged on the same terms.
 
-These measures are not a separate scoreboard next to departmental goals: the
-lagging metrics are sales' own objectives, the leading indicators are the
-supporting metrics marketing already reports on, and blueprint deployments
-and onboarding success are product outcomes for Product and Engineering. A
-Showcase that works moves every department's existing objectives at once.
+These measures are not a separate scoreboard next to departmental goals:
+
+- **Sales**: the pipeline lagging metric is sales' own objective.
+- **Marketing**: MQL generation is marketing's existing objective, fed by the
+  leading indicators.
+- **Product and Engineering**: a dedicated
+  [Product Objective](https://github.com/FlowFuse/product/issues/440) tracks
+  this behavior.
+
+A Showcase that works moves every department's existing objectives at once.
 
 ## Where to see it
 

--- a/nuxt/content/handbook/marketing/product-marketing.md
+++ b/nuxt/content/handbook/marketing/product-marketing.md
@@ -16,9 +16,7 @@ marketing team plans and executes content, see the
 
 The FlowFuse platform is our strongest asset. Customers can build almost anything on it, then fully inspect, adapt, and own what they build. That breadth needs concrete entry points. Customers recognize value fastest when they see their own problem being solved.
 
-Use cases are those entry points. A use case is the customer-centric
-abstraction of the platform: a real problem customers face and how it is
-resolved with FlowFuse. Use cases are what customers recognize themselves in,
+A use case is the customer's view of the platform: a real problem they face, and how FlowFuse solves it. Use cases are what customers recognize themselves in,
 and they are therefore what we lead with: our Product Marketable Product, or
 PMP. Use cases make our [company messaging](/handbook/marketing/messaging/)
 concrete: they express the product pillars as specific problems of our Ideal

--- a/nuxt/content/handbook/marketing/product-marketing.md
+++ b/nuxt/content/handbook/marketing/product-marketing.md
@@ -35,13 +35,6 @@ the platform: what is built stays visible and understandable end to end in
 low code, so it can be trusted, audited, and operated in production. Every
 use case story ends at the same place, the platform.
 
-This focus sharpened as [our strategy](/handbook/company/strategy/) shifted
-toward larger industrial accounts. Sales felt it first and began defining
-common use cases shared across customers, together with demos to show and
-tell how each is applied in FlowFuse. Marketing and Product follow the same
-use cases, so all departments pull in one direction and success compounds
-across the funnel.
-
 ## Showcases
 
 A Showcase makes a use case visible as it can be developed on our platform,

--- a/nuxt/content/handbook/marketing/product-marketing.md
+++ b/nuxt/content/handbook/marketing/product-marketing.md
@@ -45,7 +45,7 @@ and includes everything around it, consisting of:
 1. **Use case definition**: the customer problem and outcome, written
    customer-centric.
 2. **Differentiation**: why FlowFuse over the alternatives, the "why us".
-3. **Product application**: the use case implemented in FlowFuse, as a demo
+3. **Product application**: how we or the customer take the use case to production as a demo
    and, where possible, a blueprint anyone can deploy.
 4. **Onboarding journey**: how we or the customer get the use case
    implemented, from first interest to production, supported by blueprints,

--- a/nuxt/content/handbook/marketing/product-marketing.md
+++ b/nuxt/content/handbook/marketing/product-marketing.md
@@ -1,0 +1,97 @@
+---
+title: Product Marketing
+description: |-
+  How we market the FlowFuse platform through customer-centric use cases,
+  developed into complete Showcases through cross-functional go-to-market
+  plans shared by Sales, Marketing, Product, and Engineering.
+---
+
+# Product Marketing
+
+## The Product Marketable Product
+
+The FlowFuse platform is our strongest asset. It can entertain any scenario,
+and whatever is built on it the customer can fully inspect, adapt, and own.
+Power of that breadth needs concrete entry points to speak to an individual
+customer, because value is recognized fastest through one's own problem,
+need, or desire.
+
+Use cases are those entry points. A use case is the customer-centric
+abstraction of the platform: a real problem customers face and how it is
+resolved with FlowFuse. Use cases are what customers recognize themselves in,
+and they are therefore what we lead with: our Product Marketable Product, or
+PMP.
+
+A use case implementation is a starting point, not a boxed product. We show
+how the problem can be solved on FlowFuse, and customers adjust and fully own
+the implementation, tailored to their exact scenario. This is the strength of
+the platform: what is built stays visible and understandable end to end in
+low code, so it can be trusted, audited, and operated in production. Every
+use case story ends at the same place, the platform.
+
+This focus sharpened as [our strategy](/handbook/company/strategy/) shifted
+toward larger industrial accounts. Sales felt it first and began defining
+common use cases shared across customers, together with demos to show and
+tell how each is applied in FlowFuse. Marketing and Product follow the same
+use cases, so all departments pull in one direction and success compounds
+across the funnel.
+
+## Showcases
+
+A use case is completely developed when it becomes a Showcase, consisting of:
+
+1. **Use case definition**: the customer problem and outcome, written
+   customer-centric.
+2. **Differentiation**: why FlowFuse over the alternatives, the "why us".
+3. **Product application**: the use case implemented in FlowFuse, as a demo
+   and, where possible, a blueprint anyone can deploy.
+4. **Onboarding journey**: how we or the customer get the use case
+   implemented, from first interest to production.
+5. **Marketing artifacts**: the show and tell; use case web pages, videos,
+   blog posts, social content, and customer stories.
+
+## Cross-functional ownership
+
+The PMP is a shared artifact between Sales, Marketing, Product, and
+Engineering. Each department is both contributor and stakeholder:
+
+- **Sales** defines use cases from customer conversations and contributes
+  customer stories and proof-of-concept journeys.
+- **Marketing** produces and distributes the marketing artifacts and owns the
+  differentiation content, such as comparison pages.
+- **Product and Engineering** build the demos and blueprints, write
+  implementation journeys, and feed the use cases into the product roadmap
+  through product objectives.
+
+## Prioritization
+
+Two lenses set the order in which use cases are developed into Showcases:
+
+- **Account-based marketing**: each target account has specific problems,
+  needs, and desires that map to specific use cases. That mapping gives a
+  priority order directly connected to our pipeline.
+- **Breadth and depth**: platform improvements either deepen what already
+  exists or broaden into new use cases. Breadth aligns most directly with the
+  PMP because it creates new stories to tell; depth strengthens
+  differentiation and onboarding within existing stories. For AI specifically,
+  we look for use cases that are enabled by AI, next to using AI to improve
+  the onboarding of use cases that are not.
+
+## Go-to-market plans
+
+Each Showcase gets one story and one go-to-market plan, tracked in Asana with
+tickets across Marketing, Sales, Product, and Engineering.
+
+We run one storyline at a time and repeat it consistently across weeks and
+channels before moving to the next. A message must be repeated far more often
+than feels natural before most of the audience has seen it.
+
+All collateral ties back to its use case, so the use case page, blueprint,
+certified nodes, comparison pages, and customer stories interlink into one
+coherent web of resources.
+
+## Where to see it
+
+- Use cases on the [home page](https://flowfuse.com)
+- The first use case page:
+  [Production Monitoring](https://flowfuse.com/use-cases/production-monitoring/)


### PR DESCRIPTION
## Description

Following the Product and Marketing sync of July 8, this adds `/handbook/marketing/product-marketing/`. The handbook documents how marketing operates, but nowhere defines what we market. The agreed model: lead with customer-centric use cases rather than platform capabilities, with the platform's strength being that customers can fully own and adapt any use case implementation.

The page codifies:

- The shared vocabulary: use cases as the Product Marketable Product (PMP), Showcases as the complete definition of a use case, stories with go-to-market plans as the delivery mechanism, tracked in the Use Cases Asana project
- Ownership assigned per go-to-market plan, deliberately not fixed per department
- Success tracking on lagging, leading, and per-story traction levels, laddering into each department's existing objectives

It is wired into the marketing index, Account-Based Marketing, content strategy, messaging, and customer stories pages so it does not land as an orphan.

## Related Issue(s)

- https://docs.google.com/document/d/1AkqIPblYXKlG9G2WstYwULRh3JjSDzSf02DNY0RQZ2Y/edit?tab=t.0
- https://app.asana.com/1/1213818720452348/project/1215720226996029/note/1216389200058782

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))