### PR TITLE
Handbook/social-media: Add HubSpot note

### DIFF
--- a/nuxt/content/handbook/marketing/social-media.md
+++ b/nuxt/content/handbook/marketing/social-media.md
@@ -75,8 +75,10 @@ Social posts are planned as part of the broader [content strategy](/handbook/mar
     - Each assignee will get reminders to post in the `#social-post-reminders` Slack channel starting two days before the scheduled date and continuing until one day after if it hasn’t been scheduled.
     - Make sure to mark the Asana task as done once the post is scheduled. Otherwise, you’ll keep getting reminders, or it will show up as a missed deadline.
 - **Posting hours:** Aligned with USA Eastern Time before work hours and during lunch, aiming to coincide with Germany's lunch and after work hours.
-    - USA before work (6:00 am EDT - 12 pm CEST).
-    - USA lunch hours (11:30 am EDT -  5:30 pm CEST).
+    - Time slot 1 — USA before work (6:00 am EDT / 12:00 pm CEST).
+    - Time slot 2 — USA lunch hours (11:30 am EDT / 5:30 pm CEST).
+
+    > **Note:** Always set the scheduled time manually to match one of the two time slots above. HubSpot's default suggested posting time is not reliable and often does not align with our defined posting hours — don't rely on it.
 - While we have a planned schedule, it's crucial to remain flexible. If more impactful or relevant content emerges, we'll adapt our plan accordingly to ensure the best possible engagement.
 - If the post is part of a campaign, add it as a campaign asset in HubSpot. If the campaign doesn't exist yet, create it with a descriptive name for easy identification.
 


### PR DESCRIPTION
## Description

Labels the two posting time slots as "Time slot 1" and "Time slot 2" while keeping the original context (USA before work / USA lunch hours).
Adds a note warning that HubSpot's default suggested posting time should not be trusted, since it doesn't always match the handbook's defined hours, the time must be set manually to one of the two slots.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

