### PR TITLE
Fix blueprint page horizontal overflow on desktop

### DIFF
--- a/src/_includes/layouts/blueprint.njk
+++ b/src/_includes/layouts/blueprint.njk
@@ -13,7 +13,7 @@ layout: layouts/base.njk
     </div>
     <div class="blog nohero w-full pb-12">
         <div class="container flex flex-col md:flex-row m-auto text-left max-lg:px-6 md:max-w-screen-lg gap-8 items-stretch">
-            <div class="ff-prose">
+            <div class="ff-prose min-w-0">
                 <a class="inline-flex align-center gap-1 mb-4" href="/blueprints">
                     {% include "components/icons/chevron-left.svg" %}
                     Back to Blueprints Library


### PR DESCRIPTION
## Description

Blueprint pages with a code block containing a long unbroken line (e.g. the worldmap prompt example on /blueprints/ai/llm-chat-agent/) overflow horizontally on desktop. The prose column is a flex item with the default `min-width: auto`, so it cannot shrink below the code block's longest line width. That pushes the sidebar (Deploy button, author tile) off screen and adds page-wide horizontal scrolling.

Adding `min-w-0` to the column lets it shrink to the container width again, and the code block scrolls internally via its existing `overflow-x: auto`. Mobile was unaffected (the container stacks as a column below `md`).

Verified headless at a 1440px viewport: document scroll width returns to 1440, the sidebar is visible, and the long prompt line scrolls inside its code block.

## Related Issue(s)

https://flowfuse.com/blueprints/ai/llm-chat-agent/ showed the problem

<img width="2812" height="2084" alt="CleanShot 2026-07-14 at 18 01 31@2x" src="https://github.com/user-attachments/assets/3c16e192-c698-41bb-a757-ef2f351bdf57" />


## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))
