### PR TITLE
fix: restore Tailwind v3 prose behavior — reorder CSS layers and reset prose max-width

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,5 +1,6 @@
-@layer vendor, theme, base, components, utilities, overrides;
+@layer vendor, theme, base, components, overrides, utilities;
 
+@config "../../tailwind.config.js";
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
@@ -83,7 +84,6 @@
 
 @layer overrides {
     .prose {
-        max-width: none;
         --tw-prose-body: var(--color-gray-700);
         --tw-prose-headings: var(--color-gray-600);
         --tw-prose-links: var(--color-blue-600);
@@ -2303,7 +2303,7 @@ lite-youtube::before {
     }
 }
 
-@layer overrides {
+@layer utilities {
     .prose h1 { font-weight: 500; }
     .prose h2, .prose h3, .prose h4, .prose h5, .prose h6 { font-weight: 400; }
     .prose picture { margin-top: 0; margin-bottom: 0; margin-left: auto; margin-right: auto; }
@@ -2325,4 +2325,4 @@ lite-youtube::before {
     .prose .ff-blue-card > h5:first-of-type,
     .prose .ff-blue-card > h6:first-of-type { margin-top: 0; }
     .prose .ff-blue-card > p:last-of-type { margin-bottom: 0; }
-}
+} /* end @layer utilities */

--- a/src/css/style.handbook.css
+++ b/src/css/style.handbook.css
@@ -238,6 +238,6 @@
 
 } /* end @layer components */
 
-@layer overrides {
+@layer utilities {
     .handbook .prose { max-width: 100%; }
 }

--- a/src/css/style.nohero.css
+++ b/src/css/style.nohero.css
@@ -46,7 +46,7 @@
 
 } /* end @layer components */
 
-@layer overrides {
+@layer utilities {
 
 .prose code::after {
     content: '' !important;
@@ -109,4 +109,4 @@
     margin-bottom: 2em;
 }
 
-} /* end @layer overrides */
+} /* end @layer utilities */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  theme: {
+    extend: {
+      typography: {
+        DEFAULT: {
+          css: {
+            maxWidth: '80ch',
+          },
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Description

The Tailwind v4 migration left prose styles broken: inline utilities couldn't override plugin defaults because the CSS layer order was wrong. `@layer overrides` was a temporary workaround — this PR replaces it with the correct fix.

- Reorder CSS layers so `@layer utilities` is last, making inline utility classes always override predefined styles (matching v3 behavior)
- Add minimal `tailwind.config.js` with `@config` to restore `max-width: 80ch` on `.prose`, which was previously set via the v3 typography plugin config
- Remove `@layer overrides` workaround introduced post-migration; prose style overrides now live in `@layer utilities` where they correctly beat the typography plugin

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

