### PR TITLE
fix: explicit border-gray-200 on Nuxt page elements

### DIFF
--- a/nuxt/components/HandbookSearch.vue
+++ b/nuxt/components/HandbookSearch.vue
@@ -116,5 +116,5 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div ref="searchContainer" id="algolia-search" class="border rounded"></div>
+  <div ref="searchContainer" id="algolia-search" class="border border-gray-200 rounded"></div>
 </template>

--- a/nuxt/pages/resources/publications.vue
+++ b/nuxt/pages/resources/publications.vue
@@ -43,11 +43,11 @@ useHead({
         <li
           v-for="item in publications"
           :key="item.url"
-          class="customer-story-tile w-full my-2 border px-0 rounded-lg hover:drop-shadow-lg hover:border-blue-600 transition ease-in-out duration-300 bg-white"
+          class="customer-story-tile w-full my-2 border border-gray-200 px-0 rounded-lg hover:drop-shadow-lg hover:border-blue-600 transition ease-in-out duration-300 bg-white"
         >
           <NuxtLink :to="item.url" class="w-full flex flex-col group hover:no-underline h-full m-0">
             <div>
-              <div class="relative border-b">
+              <div class="relative border-b border-gray-200">
                 <div class="w-full h-52 ff-image-cover ff-image-top-rounded">
                   <img :src="item.thumbnail" :alt="`Image representing ${item.title}`" class="w-full h-full object-cover">
                 </div>


### PR DESCRIPTION
## Description

On Nuxt-served pages, `theme.css` loads after `style.css` and its Tailwind v4 preflight (border: 0 solid) resets the default border color to currentColor, overriding the border-color: var(--color-gray-200) that `style.css` sets in `@layer base`. This caused border and border-b elements on Nuxt pages to render with the inherited text color instead of the expected light gray.

Fix: add explicit `border-gray-200` to the two affected elements in Nuxt pages.
## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

