### PR TITLE
Fix broken integration README anchors by aligning heading slugify with GitHub

### DIFF
--- a/nuxt/server/utils/integrations-enrich.ts
+++ b/nuxt/server/utils/integrations-enrich.ts
@@ -22,8 +22,23 @@ const GITHUB_HEADERS = {
     Accept: 'application/vnd.github+json'
 }
 
+// Mirrors GitHub's own heading slugger so anchors written against a README's
+// GitHub-rendered preview (e.g. `#egm-optional` for "## EGM (optional)") keep resolving here.
+function githubSlugify (heading: string): string {
+    return encodeURIComponent(
+        heading
+            .trim()
+            .toLowerCase()
+            .replace(/[^\w一-龥\- ]/g, '')
+            .replace(/\s+/g, '-')
+    )
+}
+
 const md = new MarkdownIt({ html: true })
-    .use(MarkdownItAnchor, { permalink: MarkdownItAnchor.permalink.headerLink() })
+    .use(MarkdownItAnchor, {
+        slugify: githubSlugify,
+        permalink: MarkdownItAnchor.permalink.headerLink()
+    })
     .use(MarkdownItFootnote)
     .use(MarkdownItAttrs)
 


### PR DESCRIPTION
## Description

- `nuxt-link-checker` was failing site-wide builds with "bad anchors" errors (e.g. `integrations/node-red-contrib-abb-gofa#egm-optional`), even on PRs unrelated to integrations.
- Root cause: integration pages render npm package READMEs at build time using `markdown-it-anchor`, whose default slugify doesn't strip punctuation (e.g. `## EGM (optional)` → `egm-(optional)`). GitHub's own slugger strips it (→ `egm-optional`), so internal README links written against GitHub's rendering broke under our pipeline.
- Added a custom `githubSlugify` function that mirrors GitHub's heading slug algorithm, so anchors generated by our renderer match the links authors wrote assuming GitHub-style rendering.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

