### PR TITLE
Add verification steps for commission deal handoff

### DIFF
--- a/nuxt/content/handbook/operations/commission-payment.md
+++ b/nuxt/content/handbook/operations/commission-payment.md
@@ -20,6 +20,21 @@ invoice. FlowFuse might withhold commission payments or claw back payments if
 payments aren't made within 60 days after the
 [deal was closed](/handbook/sales/engagements/#closing-a-deal).
 
+### Verifying Deals Before Handoff
+ 
+Before passing the commission workbook to the sales rep for confirmation, verify
+each deal in the workbook against HubSpot. Complete the following checks:
+ 
+1. **Account name** - Confirm the account name matches between the workbook and HubSpot.
+2. **Close date** — Confirm the deal's qualifying date falls within the quarter being evaluated.
+Deals are counted by signing date only; a deal signed outside the evaluation quarter must not be included,
+even if other activity falls within it.
+3. **Amount** — Confirm the deal amount matches between the workbook and HubSpot.
+4. **Deal type** — Keep renewals separate from expansion deals. These are classified and paid
+differently and must not be combined in a single line.
+Flag any figure that isn't shown in HubSpot (e.g., highlight the cell) and confirm
+it with the relevant sales team member before finalizing sheet.
+
 ### Calculating Team Commissions
 
 In the first week after the month has passed, commission payments are

--- a/nuxt/content/handbook/operations/commission-payment.md
+++ b/nuxt/content/handbook/operations/commission-payment.md
@@ -20,21 +20,6 @@ invoice. FlowFuse might withhold commission payments or claw back payments if
 payments aren't made within 60 days after the
 [deal was closed](/handbook/sales/engagements/#closing-a-deal).
 
-### Verifying Deals Before Handoff
- 
-Before passing the commission workbook to the sales rep for confirmation, verify
-each deal in the workbook against HubSpot. Complete the following checks:
- 
-1. **Account name** - Confirm the account name matches between the workbook and HubSpot.
-2. **Close date** — Confirm the deal's qualifying date falls within the quarter being evaluated.
-Deals are counted by signing date only; a deal signed outside the evaluation quarter must not be included,
-even if other activity falls within it.
-3. **Amount** — Confirm the deal amount matches between the workbook and HubSpot.
-4. **Deal type** — Keep renewals separate from expansion deals. These are classified and paid
-differently and must not be combined in a single line.
-Flag any figure that isn't shown in HubSpot (e.g., highlight the cell) and confirm
-it with the relevant sales team member before finalizing sheet.
-
 ### Calculating Team Commissions
 
 In the first week after the month has passed, commission payments are
@@ -156,6 +141,21 @@ The bonus payment will be included in the next payroll after the goal completion
 ## Processing CSM Commission
 
 Following the end of each quarter, the Operations team processes CSM commissions based on the performance metrics outlined in the [CS Handbook](https://flowfuse.com/handbook/sales/customer-success/).
+
+### Verifying Deals Before Handoff
+ 
+Before passing the commission workbook to the sales rep for confirmation, verify
+each deal in the workbook against HubSpot. Complete the following checks:
+ 
+1. **Account name** - Confirm the account name matches between the workbook and HubSpot.
+2. **Close date** — Confirm the deal's qualifying date falls within the quarter being evaluated.
+Deals are counted by signing date only; a deal signed outside the evaluation quarter must not be included,
+even if other activity falls within it.
+3. **Amount** — Confirm the deal amount matches between the workbook and HubSpot.
+4. **Deal type** — Keep renewals separate from expansion deals. These are classified and paid
+differently and must not be combined in a single line.
+Flag any figure that isn't shown in HubSpot (e.g., highlight the cell) and confirm
+it with the relevant sales team member before finalizing sheet.
 
 ### Payout Timeline & Submission
 


### PR DESCRIPTION
Added verification steps for deals before handing off the commission workbook to sales reps, including checks for account name, close date, amount, and deal type.

## Description

<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

