### PR TITLE
Homepage: Add title, description and CTA to customer stories

### DIFF
--- a/src/_includes/testimonials.njk
+++ b/src/_includes/testimonials.njk
@@ -9,7 +9,9 @@
           {% image imageSrc, imageDescription, [360] %}
         </div>
         <div class="items-end justify-between sm:pl-12 flex-1 flex flex-col h-full w-full justify-items-end">
+          {% if not hideReadMore %}
           <span class="text-right pb-5 flex gap-1 hover:underline">Read the full story {% include "components/icons/arrow-long-right.svg" %}</span>
+          {% endif %}
           <p class="font-normal italic text-2xl">
             "{{ t.quote }}"
           </p>
@@ -27,12 +29,20 @@
   </a>
   {%- endfor -%}
 </div>
-<div class="flex flex-wrap flex-row gap-3 justify-center my-6">
-  {%- for t in testimonials -%}
-  <button class="testimonial-button align-baseline max-md:p-2" aria-label="Show testimonial from {{ t.author }}, {{ t.company }}">
-    <span></span>
-  </button>
-  {%- endfor -%}
+<div class="flex {% if browseAllUrl %}flex-col sm:flex-row{% else %}flex-row flex-wrap{% endif %} items-center justify-center {% if browseAllUrl %}sm:justify-between{% endif %} gap-3 my-6">
+  <div class="flex flex-wrap flex-row justify-center gap-3">
+    {%- for t in testimonials -%}
+    <button class="testimonial-button align-baseline max-md:p-2" aria-label="Show testimonial from {{ t.author }}, {{ t.company }}">
+      <span></span>
+    </button>
+    {%- endfor -%}
+  </div>
+  {% if browseAllUrl %}
+  <a href="{{ browseAllUrl }}" class="flex items-center gap-1.5 text-blue-600 hover:underline">
+    {{ browseAllText | default("Browse all customer stories") }}
+    {% include "components/icons/arrow-long-right.svg" %}
+  </a>
+  {% endif %}
 </div>
 
 <script>

--- a/src/index.njk
+++ b/src/index.njk
@@ -337,6 +337,11 @@ hubspot:
     <!-- Testimonials -->
     <div class="w-full mt-16 md:px-0">
         <div class="max-w-screen-lg mx-auto">
+            <h2 class="md:text-5xl">Real results from <span class="text-indigo-600">industrial teams</span></h2>
+            <p class="mb-8">See how manufacturers and industrial operators are using FlowFuse to standardize, scale, and govern their operations.</p>
+            {% set hideReadMore = true %}
+            {% set browseAllUrl = "/customer-stories/" %}
+            {% set browseAllText = "Browse all customer stories" %}
             {% include "testimonials.njk" %}
         </div>
     </div>
@@ -358,7 +363,7 @@ hubspot:
                     </div>
                     <p class="text-gray-700 font-light m-0">FlowFuse Expert, our industrial-tuned AI assistant, lets your team describe what they need in plain language — and generates flows, data transformations, and dashboard logic. No waiting on scarce developers.</p>
                 </div>
-                <a href="/ai/" class="flex items-center justify-end gap-1.5 text-indigo-600 hover:underline mt-6">
+                <a href="/ai/" class="flex items-center justify-end gap-1.5 text-blue-600 hover:underline mt-6">
                     Learn more about FlowFuse AI
                     {% include "components/icons/arrow-long-right.svg" %}
                 </a>
@@ -373,7 +378,7 @@ hubspot:
                     </div>
                     <p class="text-gray-700 font-light m-0">Speed without governance creates new debt. FlowFuse provides the production layer where AI-assisted work becomes visible, versioned, secure, and reusable — across the enterprise.</p>
                 </div>
-                <a href="/book-demo/" class="flex items-center justify-end gap-1.5 text-indigo-600 hover:underline mt-6" onclick="capture('cta-book-demo', {'position': 'ai'})">
+                <a href="/book-demo/" class="flex items-center justify-end gap-1.5 text-blue-600 hover:underline mt-6" onclick="capture('cta-book-demo', {'position': 'ai'})">
                     Book a demo
                     {% include "components/icons/arrow-long-right.svg" %}
                 </a>


### PR DESCRIPTION
## Description

Adds a title, description, and index CTA to the customer stories section on the homepage.

## Related Issue(s)

https://app.asana.com/1/1213818720452348/project/1213916046431331/task/1213993878866928?focus=true

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

