### PR TITLE
Remove deprecated Starter and Pro tiers from handbook

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -629,12 +629,8 @@ module.exports = function(eleventyConfig) {
 
     function deriveTierLabel(tierData) {
         if (!tierData) return null;
-        const starter = tierData.starter && tierData.starter.value;
-        const pro = tierData.pro && tierData.pro.value;
         const enterprise = tierData.enterprise && tierData.enterprise.value;
         const enterpriseDimmed = tierData.enterprise && tierData.enterprise.dimmed;
-        if (starter && pro && enterprise && !enterpriseDimmed) return "All tiers";
-        if (pro && enterprise && !enterpriseDimmed) return "Pro+";
         if (enterprise === 'contact' || (typeof enterprise === 'string' && enterprise.toLowerCase().includes('contact'))) return "Enterprise (contact us)";
         if (enterpriseDimmed) return "Enterprise (on request)";
         if (enterprise === 'time') return "Coming soon";
@@ -723,19 +719,13 @@ module.exports = function(eleventyConfig) {
                 // Inline tier specification (no feature ID)
                 const inlineFeature = {};
                 if (entry.tiers.cloud) {
-                    // Convert shorthand ("all", "pro+", "enterprise") to tier structure
-                    const t = entry.tiers.cloud;
+                    // Convert shorthand to tier structure
                     inlineFeature.cloud = {
-                        starter: { value: t === 'all' ? true : null },
-                        pro: { value: (t === 'all' || t === 'pro+') ? true : null },
                         enterprise: { value: true }
                     };
                 }
                 if (entry.tiers.selfHosted) {
-                    const t = entry.tiers.selfHosted;
                     inlineFeature.selfHosted = {
-                        starter: { value: t === 'all' ? true : null },
-                        pro: { value: (t === 'all' || t === 'pro+') ? true : null },
                         enterprise: { value: true }
                     };
                 }

--- a/nuxt/components/content/FeatureCatalog.vue
+++ b/nuxt/components/content/FeatureCatalog.vue
@@ -15,13 +15,13 @@
       <table class="border-collapse text-sm" style="width: max-content; min-width: 100%;">
         <colgroup>
           <col style="width: 220px;" />
-          <col v-for="n in 12" :key="n" :style="n <= 6 ? 'width: 110px;' : 'width: 100px;'" />
+          <col v-for="n in 8" :key="n" :style="n <= 2 ? 'width: 110px;' : 'width: 100px;'" />
         </colgroup>
         <thead>
           <tr>
             <th class="py-3 px-4 text-left align-bottom border-b-2 border-gray-200" rowspan="2">Feature</th>
-            <th colspan="3" class="py-3 px-4 text-center border border-gray-200 rounded-lg border-l-2 border-l-gray-300">FlowFuse Cloud</th>
-            <th colspan="3" class="py-3 px-4 text-center border border-gray-200 rounded-lg border-l-2 border-l-gray-300">Self Hosted</th>
+            <th colspan="1" class="py-3 px-4 text-center border border-gray-200 rounded-lg border-l-2 border-l-gray-300">FlowFuse Cloud</th>
+            <th colspan="1" class="py-3 px-4 text-center border border-gray-200 rounded-lg border-l-2 border-l-gray-300">Self Hosted</th>
             <th colspan="6" class="py-3 px-4 text-center border border-gray-200 rounded-lg border-l-2 border-l-gray-300">Solutions</th>
           </tr>
           <tr>
@@ -36,7 +36,7 @@
         <tbody>
           <template v-for="section in sections" :key="section.label">
             <tr>
-              <td colspan="13" class="py-2 px-4 bg-gray-100 font-semibold text-gray-600 text-xs uppercase tracking-wide">{{ section.label }}</td>
+              <td colspan="9" class="py-2 px-4 bg-gray-100 font-semibold text-gray-600 text-xs uppercase tracking-wide">{{ section.label }}</td>
             </tr>
             <tr v-for="feature in section.features" :key="feature.id" class="border-t border-gray-100 hover:bg-gray-50">
               <td class="py-3 px-4 align-top border-r border-gray-100" :class="{ 'pl-8': feature.subfeature }">
@@ -66,7 +66,7 @@
                     <template v-if="cellOf(feature, group, tier) && cellOf(feature, group, tier).note"><br v-if="cellOf(feature, group, tier).value" /><span class="text-gray-500 text-xs">{{ cellOf(feature, group, tier).note }}</span></template>
                   </td>
                 </template>
-                <td v-else colspan="3" class="py-3 px-4 text-center text-gray-300 border-r border-gray-100 border-l-2 border-l-gray-300">N/A</td>
+                <td v-else colspan="1" class="py-3 px-4 text-center text-gray-300 border-r border-gray-100 border-l-2 border-l-gray-300">N/A</td>
               </template>
 
               <td
@@ -92,17 +92,13 @@ import { ref, onMounted, onUnmounted } from 'vue'
 const featureCatalog = parseYaml(featureCatalogRaw) || {}
 const sections = featureCatalog.sections || []
 
-const tiers = ['starter', 'pro', 'enterprise']
+const tiers = ['enterprise']
 const groups = ['cloud', 'selfHosted']
 const solutions = ['mes', 'scada', 'uns', 'edge-connectivity', 'it-ot-middleware', 'data-integration']
 
 const tierHeaders = [
-  { key: 'c-starter', label: 'Starter', first: true },
-  { key: 'c-pro', label: 'Pro', first: false },
-  { key: 'c-enterprise', label: 'Enterprise', first: false },
-  { key: 'sh-starter', label: 'Starter', first: true },
-  { key: 'sh-pro', label: 'Pro', first: false },
-  { key: 'sh-enterprise', label: 'Enterprise', first: false },
+  { key: 'c-enterprise', label: 'Enterprise', first: true },
+  { key: 'sh-enterprise', label: 'Enterprise', first: true },
   { key: 'mes', label: 'MES', first: true },
   { key: 'scada', label: 'SCADA', first: false },
   { key: 'uns', label: 'UNS', first: false },

--- a/nuxt/content/handbook/engineering/product/pricing.md
+++ b/nuxt/content/handbook/engineering/product/pricing.md
@@ -12,7 +12,7 @@ FlowFuse is available as an unlicensed open-source edition (always self-managed)
 
 The [Buyer-Based Open Core (BBOC)](https://opencoreventures.com/blog/2023-01-open-core-standard-pricing-model/) principle is a fundamental guideline in our product
 development and monetization strategy. It's a framework we employ to discern which features should be open source and which should be proprietary. 
-BBOC aligns features into tiers based on their target users or 'buyers' — individual contributors, management, or executives.
+BBOC aligns features into tiers based on their target users or 'buyers': individual contributors, management, or executives.
 
 Features that are most beneficial to individual contributors, such as PLC engineers and line workers, sit lower in our packaging. Features that have broader organizational relevance, like Edge Connectivity or high availability, are offered in higher, licensed editions targeted towards IIoT managers and plant managers who need to manage multiple Node-RED instances.
 

--- a/nuxt/content/handbook/engineering/product/pricing.md
+++ b/nuxt/content/handbook/engineering/product/pricing.md
@@ -6,7 +6,7 @@ title: "Pricing Principles"
 
 This page sets out the concepts that we license and what units are measured across both FlowFuse Cloud  and Self-managed. Commercial decisions outside the scope of this document.
 
-We have three primary tiers: Starter (Open-Source when self-managed), Pro, and Enterprise. The value and features provided within each tier correspond to the specific [persona](./personas/), acknowledging that a higher placement in the organizational chart typically implies different requirements.
+FlowFuse is available as an unlicensed open-source edition (always self-managed), a FlowFuse Cloud trial, and a licensed Enterprise edition (self-managed or FlowFuse-managed). The value and features provided correspond to the specific [persona](./personas/), acknowledging that a higher placement in the organizational chart typically implies different requirements.
 
 ## Buyer-Based Open Core (BBOC) Principle
 
@@ -14,7 +14,7 @@ The [Buyer-Based Open Core (BBOC)](https://opencoreventures.com/blog/2023-01-ope
 development and monetization strategy. It's a framework we employ to discern which features should be open source and which should be proprietary. 
 BBOC aligns features into tiers based on their target users or 'buyers' — individual contributors, management, or executives.
 
-Features that are most beneficial to individual contributors, such as PLC engineers and line workers, fall within our Starter tier. On the other hand, features that have broader organizational relevance, like Edge Connectivity or high availability, are offered in our Pro tier or Enterprise tier, targeted towards IIoT managers and plant managers who need to manage multiple Node-RED instances.
+Features that are most beneficial to individual contributors, such as PLC engineers and line workers, sit lower in our packaging. Features that have broader organizational relevance, like Edge Connectivity or high availability, are offered in higher, licensed editions targeted towards IIoT managers and plant managers who need to manage multiple Node-RED instances.
 
 This buyer-based approach helps us focus our efforts on the value to the end-user, rather than technical specifications or development effort. It aligns our pricing strategy with the value each tier provides, ensuring that the cost is justified by the capabilities offered and the user persona it serves.
 
@@ -22,41 +22,9 @@ This buyer-based approach helps us focus our efforts on the value to the end-use
 
 | Tier | Objective | Problem it Solves | Persona |
 | ---- | --------- | ----------------- | ------- |
-| Starter | Enable professional Node-RED development for individuals and small teams | <ul><li>Moving beyond local development to cloud hosting</li><li>Secure connections</li><li>Version control and backup capabilities</li><li>Basic team collaboration</li></ul> | <ul><li>Individual contributor</li><li>PLC engineer</li><li>Line worker</li></ul> |
-| Pro | Build applications with Node-RED across distributed environments with more advanced management and full-stack features | <ul><li>Managing multiple instances across facilities</li><li>Edge device deployment and monitoring</li><li>Enhanced security and access controls</li><li>Team collaboration for larger organizations</li><li>Automated deployment workflows</li></ul> | <ul><li>IIoT manager</li><li>Plant manager</li></ul> |
 | Enterprise | Establish Node-RED as enterprise-wide standard with mission-critical capabilities | <ul><li>Enterprise-grade reliability and high availability</li><li>Compliance and comprehensive audit trails</li><li>Integration with corporate systems and SSO</li><li>Advanced monitoring and observability</li><li>Custom branding and dedicated support</li></ul> | <ul><li>Central IT departments</li><li>Plant manager</li></ul> |
 
 ## Tier Descriptions
-
-### Starter Tier
-
-The **Starter** tier is designed to introduce individuals to Node-RED development with FlowFuse. This tier provides the essential foundation for getting started with professional Node-RED hosting and development workflows.
-
-**Purpose**: Enable individual contributors and engineers to quickly deploy and manage Node-RED applications with professional-grade hosting and basic collaboration features.
-
-**Key Capabilities**:
-- Hosted Node-RED instance with reliable infrastructure and FlowFuse editor enhancements
-- Snapshot backups for version control and recovery
-- Basic team collaboration for up to 2 members
-
-This tier allows users to move beyond local Node-RED development to a cloud-hosted environment with backup and security features, making it ideal for proof-of-concepts, learning, and small-scale deployments.
-
-### Pro Tier
-
-The **Pro** tier is built for central IT, business teams, and SIs who need to build full-stack applications using Node-RED across multiple instances, manage edge devices effectively, and utilize more advanced Node-RED management features.
-
-**Purpose**: Enable organizations to build industrial applications and scale their Node-RED rollout with advanced device management, enhanced security, and team collaboration features for managing 5 or more instances across distributed environments.
-
-**Key Capabilities**:
-- Multiple hosted Node-RED instances (up to 5 included)
-- Edge Device Management with FlowFuse Device Agent
-- Advanced security features and access controls
-- Enhanced team collaboration for up to 20 members
-- DevOps pipelines for automated deployments
-- Persistent context and shared libraries
-- Priority support with faster response times
-
-This tier empowers organizations to implement Node-RED as a scalable solution across plants and facilities, with the tools needed to manage distributed deployments, ensure security compliance, and maintain operational efficiency.
 
 ### Enterprise Tier
 
@@ -112,7 +80,7 @@ Devices are part of the licensed instances.
 
 ## Licenses
 
-From the perspective of licensing the there's an unlicensed edition: open-source. This version is always self-managed. There's also a licensed version of FlowFuse, this can be self-managed or FlowFuse Managed. For FlowFuse managed properties there's 3 tiers; Starter, Pro, and Enterprise.
+From the perspective of licensing the there's an unlicensed edition: open-source. This version is always self-managed. There's also a licensed version of FlowFuse, this can be self-managed or FlowFuse Managed.
 The open source edition doesn't require a license key to be uploaded. Without a valid license a basic set of features and
 quantity of instances(5), users(5), teams(5), and devices(5) are available.
 When a license is purchased it provides all of the functionality of the higher

--- a/nuxt/content/handbook/marketing/education.md
+++ b/nuxt/content/handbook/marketing/education.md
@@ -4,7 +4,7 @@ title: "FlowFuse for Education"
 
 # FlowFuse for Education
 
-The purpose of FlowFuse for Education is to support non-profit education by allowing educators to use FlowFuse Starter for free.
+The purpose of FlowFuse for Education is to support non-profit education by allowing educators to use FlowFuse for free.
 
 ## Approval Process
 

--- a/nuxt/content/handbook/sales/customer-success.md
+++ b/nuxt/content/handbook/sales/customer-success.md
@@ -53,8 +53,6 @@ as follows:
 | Cohort     | Key Traits                                                     |
 | ---------- | -------------------------------------------------------------- |
 | Trial      | Not paying for services                                        |
-| Starter    | Low number of Node-RED instances                               |
-| Pro        | Smaller applications, collaboration on applications            |
 | Enterprise | Large scale applications, extensive use of FlowFuse's features |
 
 You can view our current customer-base and their cohorts in
@@ -71,7 +69,7 @@ however important to consider that some customers would not benefit from our
 broadest offerings of services. Appropriate resources should be put into
 customers who have found lasting value further up the cohorts table.
 
-To ensure a smooth onboarding experience and long-term success for our customers, we follow a structured [Customer Success Playbook](https://docs.google.com/document/d/1LqttB5AWueJfahdCciqloS4MSRhDZQRVHjla5xR4toU/edit?tab=t.0#heading=h.rwalcx5xuqez) for our Pro and Enterprise customers. This playbook outlines key activities, engagement points, and best practices that guide our Customer Success team in supporting each customer’s goals throughout their journey with FlowFuse.
+To ensure a smooth onboarding experience and long-term success for our customers, we follow a structured [Customer Success Playbook](https://docs.google.com/document/d/1LqttB5AWueJfahdCciqloS4MSRhDZQRVHjla5xR4toU/edit?tab=t.0#heading=h.rwalcx5xuqez) for our Enterprise customers. This playbook outlines key activities, engagement points, and best practices that guide our Customer Success team in supporting each customer’s goals throughout their journey with FlowFuse.
 
 ## Playbooks
 
@@ -228,7 +226,7 @@ customer direct to a repo for a 3rd party node question.
 
 Support availability and response times are defined by the customer’s subscription level:
 
-- Pro (Standard Support) 
+- Standard Support
   - Support available 24 × 5 (Monday to Friday, UTC-2 timezone)
   - First Response SLA: Next business day (within 24 hours)  
   - Support tickets can be submitted at [our Support Form](https://flowfuse.com/support/)

--- a/nuxt/content/handbook/sales/meetings/poc.md
+++ b/nuxt/content/handbook/sales/meetings/poc.md
@@ -6,7 +6,7 @@ title: "Proof of Concept"
 
 ### Cloud trial
 
-If the prospect would like to trial FlowFuse Cloud, they are able to self-service at https://app.flowfuse.com/account/create. This will give them a 30-day trial of the Pro tier. If they would like to test with Enterprise features, you can apply a coupon code to their Stripe account and elevate their Tier, after they create their trial account.
+If the prospect would like to trial FlowFuse Cloud, they are able to self-service at https://app.flowfuse.com/account/create. This will give them a 30-day trial of FlowFuse Cloud. If they would like to test with Enterprise features, you can apply a coupon code to their Stripe account and elevate their Tier, after they create their trial account.
 
 #### Extending a trial
 

--- a/src/_data/featureCatalog.yaml
+++ b/src/_data/featureCatalog.yaml
@@ -14,17 +14,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: "Contact Support to enable"
 
@@ -40,17 +32,9 @@ sections:
         showOnPricing: false
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: 'contact'
             note: "On request; requires assistant tokens and the Expert MQTT bridge"
@@ -67,17 +51,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
             dimmed: true
@@ -93,23 +69,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-            tag: "Beta"
-            tagPrefix: "While in"
-            note: "Available during beta"
-          pro:
-            value: null
-            tag: "Beta"
-            tagPrefix: "While in"
-            note: "Available during beta"
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
             dimmed: true
@@ -124,29 +86,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-            tag: "Beta"
-            tagPrefix: "During Insights Mode"
-            note: "Available during beta of Insights Mode"
-          pro:
-            value: null
-            tag: "Beta"
-            tagPrefix: "During Insights Mode"
-            note: "Available during beta of Insights Mode"
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-            tag: "Beta"
-            tagPrefix: "During Insights Mode"
-            note: "Available during beta of Insights Mode"
-          pro:
-            value: null
-            tag: "Beta"
-            tagPrefix: "During Insights Mode"
-            note: "Available during beta of Insights Mode"
           enterprise:
             value: true
 
@@ -162,17 +104,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
 
@@ -185,22 +119,10 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: true
-            note: "Starts with 2 hosted instances, 2 remote instances. Upgrades available up to 3 hosted / 3 remote instances."
-          pro:
-            value: true
-            note: "Starts with 5, shared with edge device count"
           enterprise:
             value: true
             note: "Starts with 20, shared with edge device count"
         selfHosted:
-          starter:
-            value: "5"
-            note: "Includes 5 hosted instances, shared with edge device count"
-          pro:
-            value: true
-            note: "Includes 5 hosted instances, shared with edge device count"
           enterprise:
             value: true
             note: "Starts with 20, shared with edge device count"
@@ -214,17 +136,9 @@ sections:
         subfeature: false
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
 
@@ -239,22 +153,10 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: true
-            note: "Includes 5 edge devices"
-          pro:
-            value: true
-            note: "Starts with 5, shared with hosted instance count"
           enterprise:
             value: true
             note: "Starts with 20, shared with hosted instance count"
         selfHosted:
-          starter:
-            value: "5"
-            note: "Includes 5 edge devices, shared with hosted instance count"
-          pro:
-            value: true
-            note: "Shared with hosted instance count"
           enterprise:
             value: true
             note: "Starts with 20, shared with hosted instance count"
@@ -269,17 +171,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
 
@@ -293,17 +187,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: true
           enterprise:
             value: true
 
@@ -317,17 +203,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: true
           enterprise:
             value: true
 
@@ -340,17 +218,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: true
           enterprise:
             value: true
 
@@ -363,17 +233,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: true
           enterprise:
             value: true
 
@@ -386,17 +248,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
 
@@ -409,17 +263,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
 
@@ -432,17 +278,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
 
@@ -455,10 +293,6 @@ sections:
         showOnPricing: true
         tags: [cloud]
         cloud:
-          starter:
-            value: "1 GB"
-          pro:
-            value: "10 GB"
           enterprise:
             value: "100 GB"
 
@@ -471,10 +305,6 @@ sections:
         showOnPricing: true
         tags: [cloud]
         cloud:
-          starter:
-            value: "10 MB"
-          pro:
-            value: "100 MB"
           enterprise:
             value: "1 GB"
 
@@ -487,17 +317,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: "Unlimited"
-          pro:
-            value: "Unlimited"
           enterprise:
             value: "Unlimited"
         selfHosted:
-          starter:
-            value: "Unlimited"
-          pro:
-            value: "Unlimited"
           enterprise:
             value: "Unlimited"
 
@@ -513,19 +335,10 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: true
-            note: "Includes 5 clients. Additional clients can be purchased."
           enterprise:
             value: true
             note: "Includes 20 clients. Additional clients can be purchased."
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
             note: "Includes 20 clients. Additional clients can be purchased."
@@ -539,17 +352,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
 
@@ -562,17 +367,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: true
           enterprise:
             value: true
 
@@ -585,17 +382,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
 
@@ -610,17 +399,9 @@ sections:
         showOnPricing: false
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
 
@@ -635,17 +416,9 @@ sections:
         showOnPricing: false
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
 
@@ -658,17 +431,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
 
@@ -683,17 +448,9 @@ sections:
         showOnPricing: false
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
 
@@ -706,17 +463,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: true
           enterprise:
             value: true
 
@@ -729,17 +478,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
 
@@ -752,17 +493,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
 
@@ -775,17 +508,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
 
@@ -799,17 +524,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
 
@@ -825,17 +542,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
 
@@ -848,17 +557,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
 
@@ -871,17 +572,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
 
@@ -894,17 +587,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
 
@@ -920,17 +605,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
 
@@ -944,17 +621,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
 
@@ -968,17 +637,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
 
@@ -991,22 +652,10 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: list
-            options: ["None", "HTTP Basic Auth"]
-          pro:
-            value: list
-            options: ["None", "HTTP Basic Auth", "FlowFuse Authentication"]
           enterprise:
             value: list
             options: ["None", "HTTP Basic Auth", "FlowFuse Authentication"]
         selfHosted:
-          starter:
-            value: list
-            options: ["None", "HTTP Basic Auth"]
-          pro:
-            value: list
-            options: ["None", "HTTP Basic Auth"]
           enterprise:
             value: list
             options: ["None", "HTTP Basic Auth", "FlowFuse Authentication"]
@@ -1020,17 +669,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
 
@@ -1043,17 +684,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: 'time'
             note: "Available from 2.32"
@@ -1067,17 +700,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: true
           enterprise:
             value: true
 
@@ -1090,17 +715,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
 
@@ -1113,17 +730,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
 
@@ -1139,10 +748,6 @@ sections:
         showOnPricing: false
         tags: [self-hosted]
         selfHosted:
-          starter:
-            value: "5"
-          pro:
-            value: "Unlimited"
           enterprise:
             value: "Unlimited"
 
@@ -1155,17 +760,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: "2"
-          pro:
-            value: "20"
           enterprise:
             value: "Unlimited"
         selfHosted:
-          starter:
-            value: "5"
-          pro:
-            value: "20"
           enterprise:
             value: "Unlimited"
 
@@ -1178,17 +775,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
 
@@ -1201,17 +790,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: true
-          pro:
-            value: true
           enterprise:
             value: true
 
@@ -1224,17 +805,9 @@ sections:
         showOnPricing: true
         tags: [cloud, self-hosted]
         cloud:
-          starter:
-            value: null
-          pro:
-            value: true
           enterprise:
             value: true
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: null
           enterprise:
             value: true
 
@@ -1247,10 +820,6 @@ sections:
         showOnPricing: true
         tags: [self-hosted]
         selfHosted:
-          starter:
-            value: null
-          pro:
-            value: true
           enterprise:
             value: true
 

--- a/src/_includes/feature_lists/features-table-base.njk
+++ b/src/_includes/feature_lists/features-table-base.njk
@@ -5,10 +5,6 @@
             <ul class="{{ hosting }} ff-feature-table-section">
                 <li class="ff-feature--column-header">
                     <span class="sticky left-0 h-full bg-white"></span>
-                    <label>
-                        <div>Starter</div>
-                    </label>
-                    <label>Pro</label>
                     <label>Enterprise</label>
                 </li>
             </ul>
@@ -20,14 +16,12 @@
 <div class="overflow-x-auto sm:overflow-x-visible" data-table-body>
     <div class="ff-feature-table ff-feature-table--body m-auto">
         {% set hostingKey = 'selfHosted' if hosting == 'self-hosted' else 'cloud' %}
-        {% set tiers = ['starter', 'pro', 'enterprise'] %}
+        {% set tiers = ['enterprise'] %}
 
         {% asyncAll section in featureCatalog.sections %}
         <ul class="{{ hosting }} ff-feature-table-section">
             <li class="ff-feature--header sm:sticky sm:top-[208px] md:top-[160px]">
                 <span class="sticky left-0 h-full">{{ section.label }}</span>
-                <span></span>
-                <span></span>
                 <span></span>
             </li>
             {% asyncAll row in section.features %}
@@ -93,7 +87,7 @@
 
 <div id="feature-dialogs">
     {% set hostingKey = 'selfHosted' if hosting == 'self-hosted' else 'cloud' %}
-    {% set tiers = ['starter', 'pro', 'enterprise'] %}
+    {% set tiers = ['enterprise'] %}
     {% asyncAll section in featureCatalog.sections %}
     {% asyncAll row in section.features %}
     {% if row.showOnPricing and row.description %}

--- a/src/css/style.page.css
+++ b/src/css/style.page.css
@@ -149,8 +149,17 @@
     margin-right: auto;
 }
 
+.pricing-tiles--single {
+    grid-template-columns: minmax(0, 24rem);
+    justify-content: center;
+}
+
 .contentSelfHosted .pricing-tiles {
     grid-template-columns: 1fr 1fr 1fr;
+}
+
+.contentSelfHosted .pricing-tiles--single {
+    grid-template-columns: minmax(0, 24rem);
 }
 
 .pricing-tile {

--- a/src/pricing/index.njk
+++ b/src/pricing/index.njk
@@ -5,12 +5,12 @@ sitemapPriority: 0.90
 faqTitle: "Frequently Asked <span class='text-indigo-600'>Questions</span>"
 faqSubtitle: "If you have any questions not addressed here, don't hesitate to contact us through our <a href='/contact-us'>Contact Us</a> page"
 meta:
-    description: Discover the pricing options for FlowFuse, featuring Starter, Pro, and Enterprise plans. Benefit from volume discounts on Pro and Enterprise plans. Get started with a 30-day trial period for the Pro plan.
+    description: Discover the pricing options for FlowFuse. Volume discounts are available for large-scale deployments, and you can get started with a 30-day trial of FlowFuse Cloud.
     keywords: FlowFuse pricing, Cost, Plans, Features, Cloud, Self-hosted
     faq:
         - question: "Does FlowFuse offer annual discounts for FlowFuse Cloud?"
           answer: >
-            Yes, both Starter and Pro customers receive a free month when paying for a year of FlowFuse in advance. Simply choose yearly billing upon signup, or select it from the Billing area in the app.
+            Yes, customers receive a free month when paying for a year of FlowFuse in advance. Simply choose yearly billing upon signup, or select it from the Billing area in the app.
         - question: "Are flat-fee or site-wide licenses available?"
           answer: >
             It is not possible at this time to purchase an unlimited-use license, but contact us to discuss pricing for your unique use case.
@@ -52,129 +52,9 @@ hubspot:
         </div>
         <div class="px-6 pricing-tiles flex flex-col lg:max-w-screen-2xl md:mt-8">
             <!-- Plans -->
-            {% macro starter(cloud=true) %}
-            <div class="pricing-tile-background pb-6">
-                <div class="flex flex-col items-center text-left md:flex-row md:px-0 md:block">
-                    <div class="flex flex-row justify-between mt-4 w-full gap-x-2">
-                        <h2 class="text-2xl font-medium" style="display:inline-block;">Starter</h2>
-                    </div>
-                    {% if cloud %}
-                    <p class="mt-7"><span class="inline font-normal">Cloud-hosted Node-RED</span> with FlowFuse development enhancements. The fastest way to <span class="inline font-normal">get started building </span>with Node-RED.</p>
-                    {% else %}
-                    <p class="mt-7">Download and self-host the <span class="inline font-normal">open-source edition</span> of FlowFuse. Ideal for evaluation and small deployments.</p>
-                    {% endif %}
-                </div>
-                <div class="flex flex-col content-start features mt-6 md:mt-3 w-full">
-                    {% if cloud %}
-                    <ul class="ff-checklist font-light leading-7 mt-2">
-                        <li>FlowFuse Expert for AI-assisted Node&#8209;RED development</li>
-                        <li>2 team members</li>
-                        <li>Blueprints</li>
-                        <li>Option to upgrade up to 3 hosted/3 remote instances</li>
-                    </ul>
-                    {% else %}
-                    <ul class="ff-checklist font-light leading-7 mt-2">
-                        <li>Open-source FlowFuse platform</li>
-                        <li>Self-hosted deployment</li>
-                        <li>Core instance & device management</li>
-                        <li>5 team members</li>
-                        <li>Community edition</li>
-                    </ul>
-                    {% endif %}
-                </div>
-                <note class="font-semibold mt-4">{% if cloud %}Includes 1 hosted instance. Additional instances are $20/month.{% else %}Includes up to 5 hosted instances or remote instances.{% endif %}
-                </note>
-                <div data-nosnippet class="flex">
-                    {% if cloud %}
-                    <div class="mt-9 md:mt-6 md:text-left items-left w-full mb-11 md:mb-5 flex flex-row md:self-end">
-                        <div class="text-left flex flex-row md:self-end">
-                            <div class="mr-1">
-                                <note class="note text-sm">Starting at</note>
-                                <h2 class="self-end pb-1">
-                                    $20
-                                </h2>
-                            </div>
-                            <note class="pl-2 text-sm leading-4 text-left self-end pb-2">
-                                /month
-                                <br>
-                                <span class="text-xs text-gray-500">after free trial of Pro</span>
-                            </note>
-                        </div>
-                    </div>
-                    {% else %}
-                    <div class="mt-9 md:mt-6 md:text-left items-left w-full mb-11 md:mb-5 flex flex-row md:self-end">
-                        <h2 class="self-end pb-1">Free</h2>
-                    </div>
-                    {% endif %}
-                </div>
-                <a class="md:self-end ff-btn ff-btn--primary-outlined uppercase align-baseline w-full"
-                    href='{% if cloud %}{% include "sign-up-url.njk" %}{% else %}https://flowfuse.com/docs/install/introduction/{% endif %}'
-                    {% if cloud %}onclick="capture('cta-join', {'position': 'primary'}, {'plan': 'cloud-starter'})"{% else %}onclick="capture('cta-install', {'position': 'primary'}, {'plan': 'sh-starter'})"{% endif %}>
-                    {% if cloud %}TRY FOR FREE{% else %}INSTALL NOW{% endif %}
-                </a>
-            </div>
-            {% endmacro %}
             <!-- Cloud -->
             <div class="contentCloud m-auto transition duration-1000 md:min-h-[502px]">
-                <div class="pricing-tiles flex flex-col md:grid md:max-lg lg:max-w-screen-xl mt-4 md:mt-0">
-                    <!-- Starter -->
-                    <div class="pricing-tile md:h-full">
-                        {{ starter() }}
-                    </div>
-                    <!-- Pro -->
-                    <div class="pricing-tile md:h-full">
-                        {% macro team(cloud=true) %}
-                        <div class="pricing-tile-background pb-6">
-                            <div class="flex flex-col items-center text-left md:flex-row md:px-0 md:block">
-                                <div class="flex flex-row justify-between mt-4 w-full gap-x-2">
-                                    <h2 class="text-2xl font-medium" style="display:inline-block;">Pro</h2>
-                                </div>
-                                <p class="mt-7"><span class="inline font-normal">Build bespoke applications collaboratively</span>, manage your Node-RED applications with improved security and control.</p>
-                            </div>
-                            <div class="flex flex-col content-start features mt-6 md:mt-3 w-full">
-                                <ul class="ff-checklist font-light leading-7 mt-2">
-                                    <li>Everything in Starter</li>
-                                    <li>20 Team members</li>
-                                    <li>Team collaboration</li>
-                                    {% if cloud %}
-                                    <li>MQTT Broker (8 clients to start)</li>
-                                    <li>Standard Support + SLA: 99.5&#37;</li>
-                                    {% else %}
-                                    <li>Installation support</li>
-                                    <li>Dedicated Success Management</li>
-                                    {% endif %}
-                                </ul>
-                            </div>
-                            <note class="font-semibold mt-4">Includes {% if cloud %}5{% else %}5{% endif %} hosted instances or remote instances. Additional instances start at $35/month.
-                            </note>
-                            <div data-nosnippet class="flex">
-                                <div class="mt-9 md:mt-6 md:text-left items-left w-full mb-11 md:mb-5 flex flex-row md:self-end">
-                                    <div class="text-left flex flex-row md:self-end">
-                                        <div class="mr-1">
-                                            <note class="note text-sm">Starting at</note>
-                                            <h2 class="self-end pb-1">
-                                                $425
-                                            </h2>
-                                        </div>
-                                        <note class="pl-2 text-sm leading-4 text-left self-end pb-2">
-                                            /month
-                                            {% if not cloud %}
-                                            <br>
-                                            <span class="text-xs text-gray-500">Billed annually</span>
-                                            {% endif %}
-                                        </note>
-                                    </div>
-                                </div>
-                            </div>
-                            <a class="md:self-end ff-btn ff-btn--primary-outlined uppercase align-baseline w-full"
-                                href="{% if cloud %}{% include "sign-up-url.njk" %}{% else %}/contact-us{% endif %}"
-                                {% if cloud %}onclick="capture('cta-join', {'position': 'primary'}, {'plan': 'cloud-team'})"{% else %}onclick="capture('cta-contact-us', {'position': 'primary'}, {'plan': 'sh-team'})"{% endif %}>
-                                {% if cloud %}TRY FOR FREE{% else %}CONTACT US{% endif %}
-                            </a>
-                        </div>
-                        {% endmacro %}
-                        {{ team() }}
-                    </div>
+                <div class="pricing-tiles pricing-tiles--single flex flex-col md:grid md:max-lg lg:max-w-screen-xl mt-4 md:mt-0">
                     <!-- Enterprise -->
                     {% macro enterprise(show_sla=true, cloud=true) %}
                     <div class="pricing-tile pricing-tile--enterprise md:h-full">
@@ -187,7 +67,6 @@ hubspot:
                             </div>
                             <div class="flex flex-col content-start features mt-6 md:mt-3 w-full">
                                 <ul class="ff-checklist font-light leading-7 mt-2">
-                                    <li>Everything in Pro</li>
                                     {% if cloud %}
                                     <li>Includes Insights Mode</li>
                                     {% else %}
@@ -226,15 +105,7 @@ hubspot:
             </div>
             <!-- Self-Hosted -->
             <div class="contentSelfHosted hide m-auto transition duration-1000 md:min-h-[502px]">
-                <div class="pricing-tiles flex flex-col md:grid md:max-lg lg:max-w-screen-xl mt-4 md:mt-0">
-                    <!-- Starter -->
-                    <div class="pricing-tile md:h-full">
-                        {{ starter(false) }}
-                    </div>
-                    <!-- Team -->
-                    <div class="pricing-tile md:h-full">
-                        {{ team(false) }}
-                    </div>
+                <div class="pricing-tiles pricing-tiles--single flex flex-col md:grid md:max-lg lg:max-w-screen-xl mt-4 md:mt-0">
                     <!-- Enterprise -->
                     <div class="pricing-tile md:h-full">
                         {{ enterprise(false, false) }}


### PR DESCRIPTION
## Description

Removes the deprecated Starter and Pro tiers from the handbook, as part of the Product Repackaging effort (Phase 2, Deprecate Starter). Enterprise is kept. No new packaging (Edge/Hub/Fleet) is introduced here.

- `engineering/product/pricing.md`: removed the Starter and Pro tier sections and their Value Layers rows; neutralized the opening tier enumeration and the BBOC examples; simplified the Licenses paragraph. Also fixed one pre-existing em dash.
- `sales/customer-success.md`: removed the Starter and Pro cohort rows; "Pro and Enterprise customers" to "Enterprise customers"; SLA "Pro (Standard Support)" to "Standard Support".
- `marketing/education.md`: "FlowFuse Starter for free" to "FlowFuse for free".
- `sales/meetings/poc.md`: "30-day trial of the Pro tier" to "30-day trial of FlowFuse Cloud".

Please do not merge yet: this should land with the Product Repackaging launch, alongside the new-model content.

A few intentional non-changes / open items:
- `engineering/product/metrics.md` WCI formula still references the deprecated tiers and needs re-basing under the new packaging in a follow-up.
- `engineering/support/troubleshooting.md` "2025 Pricing & Tier Changes" is left as a historical record; happy to adjust if preferred.
- The standard-support tier naming still needs a decision under the new packaging.
- `sales/subscription-agreement-1.5.md` references "Team and Enterprise tier customers" and lists a Team support row. Left unchanged here as it is contractual language; it needs legal review under the new packaging rather than a silent edit.

## Related Issue(s)

Product Repackaging Initiative, Phase 2 (Deprecate Starter).

## Checklist

 - [x] Documentation has been updated
