### PR TITLE
Pricing: Refine Edge & Hub pricing card messaging

### DIFF
--- a/nuxt/assets/css/theme.css
+++ b/nuxt/assets/css/theme.css
@@ -23,31 +23,36 @@
 
 /* Same base heading sizes as src/css/style.css (11ty). Declared here, not just
    there, because Tailwind v4's Preflight (imported above) loads after that
-   legacy stylesheet in <head> and wins equal-specificity ties on h1-h5. */
-h1 {
-    font-size: 2.75rem;
-    line-height: 3.1rem;
-}
+   legacy stylesheet in <head> and wins equal-specificity ties on h1-h5.
+   Wrapped in @layer base so inline inline classes (which
+   Tailwind puts in @layer utilities) can still override these: unlayered
+   CSS always beats every @layer regardless of specificity. */
+@layer base {
+    h1 {
+        font-size: 2.75rem;
+        line-height: 3.1rem;
+    }
 
-h2 {
-    font-size: 2.25rem;
-    line-height: 2.65rem;
-}
+    h2 {
+        font-size: 2.25rem;
+        line-height: 2.65rem;
+    }
 
-h3 {
-    font-size: 1.85rem;
-    line-height: 2.3rem;
-}
+    h3 {
+        font-size: 1.85rem;
+        line-height: 2.3rem;
+    }
 
-h4 {
-    font-size: 1.4rem;
-    line-height: 1.9rem;
-}
+    h4 {
+        font-size: 1.4rem;
+        line-height: 1.9rem;
+    }
 
-h5 {
-    font-size: 1.1rem;
-    line-height: 1.85rem;
-    font-weight: 600;
+    h5 {
+        font-size: 1.1rem;
+        line-height: 1.85rem;
+        font-weight: 600;
+    }
 }
 
 .handbook-content :is(h1, h2, h3, h4, h5, h6) {

--- a/nuxt/content/plans/edge.yml
+++ b/nuxt/content/plans/edge.yml
@@ -1,17 +1,15 @@
 title: Edge
 tierId: edge
 order: 1
-description: Connect PLCs and machines across every plant, standardize automation on the shop floor, and give OT teams the governance to scale beyond a single site.
-badge: "Cloud or Self-Hosted"
+description: Deploy, manage and scale industrial applications across production sites with centralized governance and certified industrial connectivity.
+badge: For OT teams
 features:
-  - FlowFuse Expert (AI) & Node-RED MCP Servers
-  - Certified Nodes – OT (OPC-UA, EtherNet/IP, Siemens S7, Modbus TCP & RTU, BACnet, DeltaV, Allen-Bradley/Rockwell, RTSP)
+  - Industrial applications
+  - PLC & machine connectivity
+  - OT-certified nodes
   - MQTT Broker
   - DevOps Pipelines
   - Device Group Management
-  - Application-Level RBAC & Endpoint Security
-  - Blueprints (OT Apps)
-  - Team Library
 button:
   label: Contact us
   to: /contact-us/

--- a/nuxt/content/plans/hub.yml
+++ b/nuxt/content/plans/hub.yml
@@ -1,18 +1,15 @@
 title: Hub
 tierId: hub
 order: 2
-description: Move data between the ERPs, databases, and APIs your business runs on, with the governance IT teams need to integrate and orchestrate systems at scale.
-badge: "Cloud or Self-Hosted"
-badge: "Cloud or Self-Hosted"
+description: Integrate and orchestrate data across enterprise systems, APIs and databases with centralized governance.
+badge: For IT teams
 features:
-  - FlowFuse Expert (AI) & Node-RED MCP Servers
-  - "Certified Nodes – IT (MQTT, Kafka, Redis, MSSQL, PostgreSQL, InfluxDB, TimescaleDB, HTTP Request, SQL/SQLite, AI nodes)"
-  - Git Integration & High Availability
-  - DevOps Pipelines & Private NPM Registry
-  - Application-Level RBAC & Endpoint Security
-  - BAA for HIPAA
-  - Blueprints (IT Apps)
-  - Team Library & Protected Instances
+  - Business system integration
+  - Data orchestration
+  - IT-certified nodes
+  - Git Integration
+  - High Availability
+  - DevOps Pipelines
 button:
   label: Contact us
   to: /contact-us/

--- a/nuxt/pages/pricing/index.vue
+++ b/nuxt/pages/pricing/index.vue
@@ -37,8 +37,8 @@ useSchemaOrg([
   <div class="w-full px-6">
     <div class="max-w-5xl mx-auto py-16 px-4">
         <h1 class="text-center"><span class="text-indigo-600">FlowFuse</span> Pricing</h1>
-        <h2 class="text-center text-gray-500 text-2xl -mt-3 mb-10">Explore our package options</h2>
-        <p class="text-center text-lg max-w-2xl mx-auto mb-16">Machines on the shop floor, scaling to more plants? Or business systems and data sources to bring under governance? FlowFuse runs both.</p>
+        <h2 class="text-center text-gray-500 text-2xl -mt-3 mb-10">Choose the package that fits your team</h2>
+        <p class="text-center text-lg max-w-2xl mx-auto mb-16">Machines on the shop floor, scaling to more plants? Or business systems and data sources to bring under governance? There’s a FlowFuse package for both.</p>
         <UPricingPlans>
         <UPricingPlan v-for="plan in plans" :key="plan.id" v-bind="plan" :ui="{ button: 'text-base font-bold', featureTitle: 'whitespace-normal overflow-visible text-clip', titleWrapper: 'mb-4' }" />
         </UPricingPlans>

--- a/nuxt/pages/pricing/index.vue
+++ b/nuxt/pages/pricing/index.vue
@@ -36,7 +36,8 @@ useSchemaOrg([
 <template>
   <div class="w-full px-6">
     <div class="max-w-5xl mx-auto py-16 px-4">
-        <h1 class="text-center mb-16"><span class="text-indigo-600">FlowFuse</span> Pricing</h1>
+        <h1 class="text-center mb-10"><span class="text-indigo-600">FlowFuse</span> Pricing</h1>
+        <p class="text-center text-lg max-w-2xl mx-auto mb-16">Machines on the shop floor, scaling to more plants? Or business systems and data sources to bring under governance? FlowFuse runs both.</p>
         <UPricingPlans>
         <UPricingPlan v-for="plan in plans" :key="plan.id" v-bind="plan" :ui="{ button: 'text-base font-bold', featureTitle: 'whitespace-normal overflow-visible text-clip', titleWrapper: 'mb-4' }" />
         </UPricingPlans>

--- a/nuxt/pages/pricing/index.vue
+++ b/nuxt/pages/pricing/index.vue
@@ -38,7 +38,7 @@ useSchemaOrg([
     <div class="max-w-5xl mx-auto py-16 px-4">
         <h1 class="text-center mb-16"><span class="text-indigo-600">FlowFuse</span> Pricing</h1>
         <UPricingPlans>
-        <UPricingPlan v-for="plan in plans" :key="plan.id" v-bind="plan" :ui="{ button: 'text-base font-bold', featureTitle: 'whitespace-normal overflow-visible text-clip' }" />
+        <UPricingPlan v-for="plan in plans" :key="plan.id" v-bind="plan" :ui="{ button: 'text-base font-bold', featureTitle: 'whitespace-normal overflow-visible text-clip', titleWrapper: 'mb-4' }" />
         </UPricingPlans>
         <SocialProof class="mt-16" />
 

--- a/nuxt/pages/pricing/index.vue
+++ b/nuxt/pages/pricing/index.vue
@@ -36,7 +36,8 @@ useSchemaOrg([
 <template>
   <div class="w-full px-6">
     <div class="max-w-5xl mx-auto py-16 px-4">
-        <h1 class="text-center mb-10"><span class="text-indigo-600">FlowFuse</span> Pricing</h1>
+        <h1 class="text-center"><span class="text-indigo-600">FlowFuse</span> Pricing</h1>
+        <h2 class="text-center text-gray-500 text-2xl -mt-3 mb-10">Explore our package options</h2>
         <p class="text-center text-lg max-w-2xl mx-auto mb-16">Machines on the shop floor, scaling to more plants? Or business systems and data sources to bring under governance? FlowFuse runs both.</p>
         <UPricingPlans>
         <UPricingPlan v-for="plan in plans" :key="plan.id" v-bind="plan" :ui="{ button: 'text-base font-bold', featureTitle: 'whitespace-normal overflow-visible text-clip', titleWrapper: 'mb-4' }" />


### PR DESCRIPTION
## Description

Updates the hero section to better communicate each product’s positioning and target audience.

Changes include:

- Add an introductory message above the pricing cards to help visitors choose between Edge and Hub
- Replace “Cloud or Self-Hosted” badges with audience-focused badges (“For OT teams” / “For IT teams”)
- Rewrite product descriptions to better reflect the new product positioning
- Simplify feature lists to emphasize key capabilities instead of duplicating the comparison table

## Related Issue(s)

Follow up on https://github.com/FlowFuse/website/pull/5386

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

