### PR TITLE
Fix Fisher-Yates shuffle and clean up legacy dev-proxy middleware

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -103,7 +103,12 @@ module.exports = function(eleventyConfig) {
     });
 
       eleventyConfig.addFilter("shuffle", (array) => {
-        return array.sort(() => Math.random() - 0.5);
+        const shuffled = [...array];
+        for (let i = shuffled.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+        }
+        return shuffled;
     });
 
     // Add a global data variable for the current date

--- a/nuxt/server/api/home-logos.get.ts
+++ b/nuxt/server/api/home-logos.get.ts
@@ -19,11 +19,20 @@ function resolveRepoRoot (cwd = process.cwd()) {
     }
 }
 
+function shuffle (array) {
+    for (let i = array.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1))
+        ;[array[i], array[j]] = [array[j], array[i]]
+    }
+    return array
+}
+
 export default defineEventHandler(() => {
     const logosDir = join(resolveRepoRoot(), 'src/images/home-logos')
 
-    return readdirSync(logosDir)
+    const logos = readdirSync(logosDir)
         .filter(file => file.endsWith('.svg') || file.endsWith('.png'))
-        .sort(() => Math.random() - 0.5)
         .map(file => `/images/home-logos/${file}`)
+
+    return shuffle(logos)
 })

--- a/nuxt/server/middleware/legacy.ts
+++ b/nuxt/server/middleware/legacy.ts
@@ -21,7 +21,8 @@ export default defineEventHandler(async (event) => {
     if (path.startsWith('/_nuxt/') || path.startsWith('/api/') || path.startsWith('/__') || path.startsWith('/_studio') || path.startsWith('/_og/')) return
 
     // Let Nuxt handle migrated pages (strip trailing slash and query string before matching)
-    const pathWithoutQuery = path.split('?')[0] ?? '/'
+    const queryIndex = path.indexOf('?')
+    const pathWithoutQuery = queryIndex === -1 ? path : path.slice(0, queryIndex)
     const normalised = pathWithoutQuery.replace(/\/$/, '') || '/'
     if (NUXT_ROUTES.has(normalised)) return
     if (NUXT_ROUTE_PREFIXES.some(prefix => pathWithoutQuery.startsWith(prefix))) return


### PR DESCRIPTION
## Description

Follow-up from review comments on #5386 (Nuxt/pricing migration).

- Replace the `Math.random() - 0.5` comparator with a proper Fisher-Yates shuffle in both places: the Nuxt `home-logos` endpoint and the legacy 11ty `shuffle` filter.
- Clean up `nuxt/server/middleware/legacy.ts`: remove the `?? '/'` fallback that was only papering over a `noUncheckedIndexedAccess` TypeScript warning. Replaced the array-indexing (`split('?')[0]`) with `indexOf`/`slice`, which avoids the warning at its root instead of masking it.
## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

