### PR TITLE
Show the FlowFuse AI and MCP nodes on /integrations

### DIFF
--- a/nuxt/types/integrations.ts
+++ b/nuxt/types/integrations.ts
@@ -109,3 +109,11 @@ export const INTEGRATION_CATEGORIES: Record<string, string> = {
 export const INTEGRATIONS_API = 'https://ff-integrations.flowfuse.cloud/api/nodes'
 export const CERTIFIED_HUB_API = 'https://ff-certified-nodes.flowfuse.cloud/ff-it.json'
 export const CERTIFIED_EDGE_API = 'https://ff-certified-nodes.flowfuse.cloud/ff-ot.json'
+
+/*
+    The FlowFuse-published node packages, which are a different set from the Hub
+    and Edge certified catalogues above. Packages published only to the private
+    registry (the AI and MCP server nodes) appear here and nowhere else, so
+    without this feed the page cannot list them at all.
+*/
+export const FLOWFUSE_NODES_API = 'https://ff-certified-nodes.flowfuse.cloud/ff-catalogue.json'

--- a/nuxt/utils/integrations.ts
+++ b/nuxt/utils/integrations.ts
@@ -3,9 +3,15 @@ import type {
     CertifiedCatalogueModule,
     CertifiedCatalogueResponse,
     CertifiedCollection,
-    IntegrationCatalogEntry
+    IntegrationCatalogEntry,
+    IntegrationTier
 } from '../types/integrations'
-import { CERTIFIED_EDGE_API, CERTIFIED_HUB_API, INTEGRATIONS_API } from '../types/integrations'
+import {
+    CERTIFIED_EDGE_API,
+    CERTIFIED_HUB_API,
+    FLOWFUSE_NODES_API,
+    INTEGRATIONS_API
+} from '../types/integrations'
 
 interface CatalogApiResponse { catalogue: IntegrationCatalogEntry[] }
 
@@ -28,14 +34,18 @@ const DOCS_URL_OVERRIDES: Record<string, string> = {
     '@flowfuse-certified-nodes/opcua': '/node-red/flowfuse/edge/opcua/'
 }
 
-function normalizeCertifiedModule (m: CertifiedCatalogueModule, collection: CertifiedCollection): IntegrationCatalogEntry {
+function normalizeCatalogueModule (
+    m: CertifiedCatalogueModule,
+    tier: IntegrationTier,
+    collection?: CertifiedCollection
+): IntegrationCatalogEntry {
     return {
         _id: m.id,
         name: m.name ?? m.id.split('/').pop() ?? m.id,
         description: m.description,
         categories: m.categories ?? [],
         npmScope: scopeFromId(m.id),
-        tier: 'certified',
+        tier,
         collection,
         version: m.version,
         downloads: { week: 0 },
@@ -44,20 +54,30 @@ function normalizeCertifiedModule (m: CertifiedCatalogueModule, collection: Cert
     }
 }
 
-async function fetchCertified (url: string, collection: CertifiedCollection): Promise<IntegrationCatalogEntry[]> {
+/*
+    A catalogue feed is unreachable often enough (private registry, transient
+    network) that a failure must degrade to an empty list rather than take the
+    whole page down with it.
+*/
+async function fetchCatalogueFeed (
+    url: string,
+    tier: IntegrationTier,
+    collection?: CertifiedCollection
+): Promise<IntegrationCatalogEntry[]> {
     try {
         const data = await ofetch<CertifiedCatalogueResponse>(url)
-        return (data.modules ?? []).map(m => normalizeCertifiedModule(m, collection))
+        return (data.modules ?? []).map(m => normalizeCatalogueModule(m, tier, collection))
     } catch {
         return []
     }
 }
 
 export async function fetchCatalogue (): Promise<IntegrationCatalogEntry[]> {
-    const [api, hub, edge] = await Promise.all([
+    const [api, hub, edge, flowfuseNodes] = await Promise.all([
         ofetch<CatalogApiResponse>(INTEGRATIONS_API).catch(() => ({ catalogue: [] as IntegrationCatalogEntry[] })),
-        fetchCertified(CERTIFIED_HUB_API, 'hub'),
-        fetchCertified(CERTIFIED_EDGE_API, 'edge')
+        fetchCatalogueFeed(CERTIFIED_HUB_API, 'certified', 'hub'),
+        fetchCatalogueFeed(CERTIFIED_EDGE_API, 'certified', 'edge'),
+        fetchCatalogueFeed(FLOWFUSE_NODES_API, 'recommended')
     ])
 
     const recommended = (api.catalogue ?? []).map(n => ({
@@ -67,5 +87,23 @@ export async function fetchCatalogue (): Promise<IntegrationCatalogEntry[]> {
 
     const certified = [...hub, ...edge]
     const certifiedIds = new Set(certified.map(n => n._id))
-    return [...certified, ...recommended.filter(n => !certifiedIds.has(n._id))]
+    const apiIds = new Set(recommended.map(n => n._id))
+
+    /*
+        The FlowFuse Nodes feed overlaps the other two sources: most of its
+        modules are @flowfuse packages the library API already returns, with
+        download counts and author data this feed does not carry. Those richer
+        entries win, so only modules missing from both other sources are taken
+        from here. Today that is the AI and MCP server node packages, which are
+        published to the private registry and so never reach the public library.
+    */
+    const flowfuseOnly = flowfuseNodes.filter(
+        n => !certifiedIds.has(n._id) && !apiIds.has(n._id)
+    )
+
+    return [
+        ...certified,
+        ...flowfuseOnly,
+        ...recommended.filter(n => !certifiedIds.has(n._id))
+    ]
 }


### PR DESCRIPTION
## Description

The `/integrations` page reads three feeds: the Node-RED library mirror at `ff-integrations.flowfuse.cloud/api/nodes`, plus the Hub and Edge certified catalogues. The FlowFuse AI nodes and the MCP server nodes are in none of them, because both packages are published only to the private registry and so never reach the public library.

A fourth catalogue does list them, `ff-certified-nodes.flowfuse.cloud/ff-catalogue.json` ("FlowFuse Nodes", 13 modules). This adds it as a source and filters it down: eleven of its modules are `@flowfuse` packages the library API already returns with download counts and author data, so those richer entries win and only modules missing from both other sources are taken from the new feed. Today that is `@flowfuse-nodes/nr-ai-nodes` and `@flowfuse-nodes/nr-mcp-server-nodes`.

They are classified as `recommended`, which sorts them into the block directly after the certified entries and gives them a generated detail page. Both carry a `flowfuse.com` docs URL in the catalogue, so the existing docs-path handling links them to `/node-red/flowfuse/ai/` and `/node-red/flowfuse/mcp/` without an override.

The two shared helpers were generalised to take the tier and an optional collection, since the fetch and normalise logic is identical across all three catalogue feeds. A feed that fails still degrades to an empty list rather than taking the page down.

## Related Issue(s)

Closes FlowFuse/engineering#212

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))
