### PR TITLE
Fix duplicate quote and regex index drift in rewriteHandbookLinks

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -459,12 +459,9 @@ module.exports = function(eleventyConfig) {
     eleventyConfig.addFilter("rewriteHandbookLinks", (str, page) => {
         const isIndexPage = /(README.md|index.md)$/i.test(page.inputPath)
 
-        const matcher = /((href|src)="([^"]*))"/g
-        let match
-        while ((match = matcher.exec(str)) !== null) {
-            let url = match[3]
+        return str.replace(/(href|src)="([^"]*)"/g, (full, attr, url) => {
             if (/^(http|#|mailto:)/.test(url)) {
-                continue
+                return full
             }
             url = url.replace(/.md(#.*)?$/, '$1')
             url = url.replace(/README(#.*)?$/, '$1')
@@ -472,9 +469,8 @@ module.exports = function(eleventyConfig) {
                 url = '../'+url
             }
 
-            str = str.substring(0, match.index) + `${match[2]}="${url}"` + str.substring(match.index+match[1].length)
-        }
-        return str;
+            return `${attr}="${url}"`
+        })
     })
 
     eleventyConfig.addFilter("handbookEditLink", (page) => {


### PR DESCRIPTION
## Description

Internal links in the handbook, docs and `/node-red` pages publish with a stray extra quote, `href="/blog/example/""`, on 984 links across 146 pages. Browsers ignore it, so nothing ever looked broken, but the published HTML is invalid for anything that parses strictly.

The link-rewriting build step spliced strings by hand and never removed the original closing quote. Switching it to a replace callback fixes that and removes a second latent bug where the scan could skip a link after a shortening rewrite. Rewriting rules are unchanged, so the URLs come out identical.

## Related Issue(s)

None.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))
