### PR TITLE
Pricing: Add popover to features table

### DIFF
--- a/nuxt/content.config.ts
+++ b/nuxt/content.config.ts
@@ -128,6 +128,7 @@ export default defineContentConfig({
                         id: z.string(),
                         title: z.string(),
                         note: z.string().optional(),
+                        description: z.string().optional(),
                         tiers: z.object({
                             edge: z.boolean(),
                             hub: z.boolean(),

--- a/nuxt/content/feature-catalog.yml
+++ b/nuxt/content/feature-catalog.yml
@@ -120,9 +120,11 @@ sections:
         tiers: { edge: true, hub: true }
       - id: certified-nodes-it
         title: Certified Nodes - IT
+        description: "IT certified node bundle includes: MQTT, Kafka, Redis, MSSQL, PostgreSQL, InfluxDB, TimescaleDB, HTTP Request, SQL/SQLite, AI nodes (Gemini, Claude, ChatGPT, Ollama)"
         tiers: { edge: false, hub: true }
       - id: certified-nodes-ot
         title: Certified Nodes - OT
+        description: "OT certified node bundle includes: OPC-UA, EtherNet/IP, Siemens S7, Modbus TCP & RTU, BACnet, DeltaV, Allen-Bradley / Rockwell, RTSP"
         tiers: { edge: true, hub: false }
       - id: baa-for-hipaa
         title: BAA for HIPAA

--- a/nuxt/pages/pricing/index.vue
+++ b/nuxt/pages/pricing/index.vue
@@ -14,6 +14,16 @@ const faqAccordionItems = computed(() => (faq.value?.items ?? []).map(item => ({
   content: item.answer,
 })))
 
+// UPricingTable's feature-title slot types `feature` without `description`,
+// even though the featureCatalog content schema does define it.
+interface CatalogFeature {
+  title: string
+  description?: string
+}
+function featureDescription (feature: CatalogFeature) {
+  return feature.description
+}
+
 useSchemaOrg([
   defineWebPage({ '@type': 'FAQPage' }),
   ...(faq.value?.items ?? []).map(item => defineQuestion({
@@ -44,8 +54,21 @@ useSchemaOrg([
             tierDescription: 'hidden',
             tierPriceWrapper: 'hidden',
         }"
-        />
-        
+        >
+        <template #feature-title="{ feature }">
+            <UPopover v-if="featureDescription(feature)" :content="{ side: 'top' }">
+                <button type="button" class="inline-flex items-center gap-1 text-left hover:text-indigo-600">
+                    <span>{{ feature.title }}</span>
+                    <UIcon name="i-lucide-info" class="size-3.5 shrink-0 text-gray-500" />
+                </button>
+                <template #content>
+                    <p class="max-w-xs p-3 text-sm text-gray-600">{{ featureDescription(feature) }}</p>
+                </template>
+            </UPopover>
+            <span v-else>{{ feature.title }}</span>
+        </template>
+        </UPricingTable>
+
         <div v-if="faq" class="mt-28 mx-auto">
         <h2 class="text-center mb-10" v-html="faq.title" />
         <UAccordion :items="faqAccordionItems">


### PR DESCRIPTION
## Description

Small iteration to enable pop over for features on the table and adds the description for the certified nodes.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

