### PR TITLE
Update headline with IT OT IIOT

### DIFF
--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -7,6 +7,7 @@
     },
     "messaging": {
         "tagLine": "The Edge-Native Platform for Industrial Applications",
+        "heroTagLine": "The Edge-Native Platform for Industrial Applications for IT, OT, and IIOT",
         "subtitle": "Build, deploy, and govern operational applications across every plant and production line, distributed to the edge and accelerated by AI.",
         "title": "Build workflows and integrations that optimize your industrial operations",
         "keywords": "Node-RED, Application Development, IoT, IIoT, Low-Code, open source, Integration, Workflow, Automation, Data Processing, Data Integration, Data Transformation, Data Visualization, Industrial Automation, Industrial IoT, Industry 4.0"

--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -7,7 +7,7 @@
     },
     "messaging": {
         "tagLine": "The Edge-Native Platform for Industrial Applications",
-        "heroTagLine": "The Edge-Native Platform for Industrial Applications for IT, OT, and IIOT",
+        "heroTagLine": "The Edge-Native Platform for Industrial IT, OT, and IIOT Applications",
         "subtitle": "Build, deploy, and govern operational applications across every plant and production line, distributed to the edge and accelerated by AI.",
         "title": "Build workflows and integrations that optimize your industrial operations",
         "keywords": "Node-RED, Application Development, IoT, IIoT, Low-Code, open source, Integration, Workflow, Automation, Data Processing, Data Integration, Data Transformation, Data Visualization, Industrial Automation, Industrial IoT, Industry 4.0"

--- a/src/index.njk
+++ b/src/index.njk
@@ -131,7 +131,10 @@ hubspot:
             <div class="container m-auto text-left max-w-screen-lg">
                 <div class="mx-auto">
                     <h1 class="font-medium m-auto text-5xl md:text-7xl text-center text-white max-w-4xl">
-                        {{ site.messaging.tagLine | safe }}
+                        {# heroTagLine, not tagLine: tagLine also renders into every page's
+                           <title> via base.njk and into llms.txt, where the persona clause
+                           would push the title past the search-result truncation length. #}
+                        {{ site.messaging.heroTagLine | safe }}
                     </h1>
                     <p class="mt-12 text-center text-gray-200 md:text-xl m-auto max-w-4xl">
                         {{ site.messaging.subtitle | replace("-", "&#8209;") | safe }}


### PR DESCRIPTION
## Description

The hero H1 was missing the persona clause that was agreed in the marketing thread. The subtitle already matched.

> The Edge-Native Platform for Industrial Applications **for IT, OT, and IIOT**

Uses a new `heroTagLine` key rather than editing `tagLine`, which also feeds every Eleventy page's `<title>` and `llms.txt`, where the clause would push the title from 63 to 84 characters, past search truncation.

## Related Issue(s)

None.

## Checklist

 - [x] I have read the contribution guidelines
 - [x] I have considered the performance impact of these changes
