### PR TITLE
Put Pricing back in the top-level navigation

### DIFF
--- a/nuxt/components/AppHeader.vue
+++ b/nuxt/components/AppHeader.vue
@@ -317,6 +317,7 @@ onMounted(() => {
 
         <!-- Direct links -->
         <li class="nav-collapsible"><a class="flex items-center gap-2" href="/ai/"><span class="ff-nav-label">Industrial AI</span></a></li>
+        <li class="nav-collapsible"><a class="flex items-center gap-2" href="/pricing/"><span class="ff-nav-label">Pricing</span></a></li>
 
         <!-- More overflow (populated by JS) -->
         <li id="nav-more" class="ff-nav-dropdown relative hover:cursor-pointer" style="display:none">

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -326,6 +326,7 @@ eleventyComputed:
                             </ul>
                         {% endnavoption %}
                         {% navoption "Industrial AI", "/ai/", 0, false, false, "nav-collapsible" %}{% endnavoption %}
+                        {% navoption "Pricing", "/pricing/", 0, false, false, "nav-collapsible" %}{% endnavoption %}
                         <!-- More dropdown for overflow items -->
                         <li id="nav-more" class="ff-nav-dropdown relative hover:cursor-pointer" style="display:none">
                             <span class="flex items-center gap-1"><span class="ff-nav-label">More</span><span class="ff-nav-chevron">{% include "components/icons/chevron-down.svg" %}</span></span>


### PR DESCRIPTION
## Description

Pricing was reachable only from inside the Platform mega panel and the footer. It returns as a direct top-level link, placed after Industrial AI, on both front ends.

One thing to decide: it carries `nav-collapsible` to match Industrial AI, and the overflow script collapses the last collapsible item first, so Pricing is the first to fold into More at narrow desktop widths. Put it before Industrial AI, or drop the class, if it should always stay visible.

## Related Issue(s)

None.

## Checklist

 - [x] I have read the contribution guidelines
 - [x] I have considered the performance impact of these changes
