### PR TITLE
Fill the nav highlight card with the image again

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2595,14 +2595,15 @@ lite-youtube::before {
         border: 1px solid #e5e7eb;
         background: #fff;
     }
-    /* `contain`, not `cover`: highlight images come from each linked page's own
-       front matter and are not all 16/9, so cover was cropping the taller ones
-       (the Platform panel's AI image most visibly). */
+    /* `cover`, so the card fills its 16/9 frame. Highlight images come from each
+       linked page's own front matter and are not all 16/9, so any that are the
+       wrong ratio get cropped rather than letterboxed. The fix for those is to
+       crop the source image to 16/9, not to letterbox every card. */
     .ff-website header .ff-nav-dropdown > ul.mega li.mega-highlight a.mega-highlight-card img {
         display: block;
         width: 100%;
         height: 100%;
-        object-fit: contain;
+        object-fit: cover;
         transition: transform 0.3s ease;
     }
     .ff-website header .ff-nav-dropdown > ul.mega li.mega-highlight a.mega-highlight-card:hover img {


### PR DESCRIPTION
## Description

Back to `object-fit: cover` on the mega panel highlight cards, so they fill the frame instead of letterboxing. Images with the wrong ratio get re-cropped to 16/9 at source.

## Related Issue(s)

Review feedback on #5375.

## Checklist

 - [x] I have read the contribution guidelines
 - [x] I have considered the performance impact of these changes
