### PR TITLE
Drop the redundant chevron wrapper on the back links

### DIFF
--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -51,7 +51,7 @@
         <div class="container flex flex-col md:flex-row m-auto text-left max-lg:px-6 md:max-w-screen-lg gap-8 items-stretch">
             <div class="ff-prose min-w-0">
                 <a class="group hover:no-underline inline-flex items-center gap-1 mb-4" href="/blog">
-                    <span class="w-5 h-5 shrink-0 flex items-center [&>svg]:w-full [&>svg]:h-full">{% include "components/icons/chevron-left.svg" %}</span>
+                    {% include "components/icons/chevron-left.svg" %}
                     <span class="group-hover:underline">Back to Blog Posts</span>
                 </a>
                 <div class="prose w-full flex-grow">

--- a/src/_includes/layouts/story.njk
+++ b/src/_includes/layouts/story.njk
@@ -19,7 +19,7 @@ layout: layouts/base.njk
     <div class="blog nohero w-full pt-6 pb-24 bg-gray-50">
         <div class="container flex flex-col m-auto text-left max-lg:px-6 md:max-w-screen-lg items-stretch">
             <a class="group hover:no-underline inline-flex items-center gap-1 mb-5 md:mb-4" href="/customer-stories">
-                <span class="w-5 h-5 shrink-0 flex items-center [&>svg]:w-full [&>svg]:h-full">{% include "components/icons/chevron-left.svg" %}</span>
+                {% include "components/icons/chevron-left.svg" %}
                 <span class="group-hover:underline">Back to Customer Stories</span>
             </a>
             <div class="ff-prose flex flex-col-reverse md:flex-row md:gap-8 mb-6 border-b">


### PR DESCRIPTION
## Description

`chevron-left.svg` already sizes itself with `w-5 h-5` on its root, so the wrapper span forcing the same size was redundant. Same cleanup as the `arrow-right.svg` wrapper reverted during the industry review. No visual change.

## Related Issue(s)

Scope feedback on #5381.

## Checklist

 - [x] I have read the contribution guidelines
 - [x] I have considered the performance impact of these changes
