### PR TITLE
Nuxt: Disable dark mode

### DIFF
--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -24,6 +24,13 @@ export default defineNuxtConfig({
 
     css: ['~/assets/css/theme.css'],
 
+    // Dark mode isn't implemented across the site yet — force light mode so
+    // Nuxt UI components don't switch to dark when the visitor's OS prefers it.
+    colorMode: {
+        preference: 'light',
+        fallback: 'light',
+    },
+
     // Heebo is already loaded via the Google Fonts <link> in app.head.
     // @nuxt/fonts is a transitive dep of @nuxt/ui; disable all provider downloads
     // so it never fetches font files at build time (which exhausts Netlify's memory).


### PR DESCRIPTION
## Description

Nuxt UI components default to switching to dark mode when the visitor's OS has it enabled. Since we don't have dark mode support across the rest of the site yet, this PR forces light mode via colorMode config until we do.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

