### PR TITLE
Footer variant A: drop all three section borders

### DIFF
--- a/nuxt/components/AppFooter.vue
+++ b/nuxt/components/AppFooter.vue
@@ -4,7 +4,7 @@
             <!-- Sections synced with the top nav: Platform / Solutions / Resources / Company -->
             <div class="grid grid-cols-1 lg:grid-cols-[2fr_3fr_1fr] gap-x-8 gap-y-12 text-sm">
                 <!-- Platform -->
-                <section class="border-t border-gray-300 pt-5">
+                <section class="pt-5">
                     <p class="text-lg font-medium text-gray-900 mb-6">Platform</p>
                     <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-2 gap-x-8 gap-y-8">
                         <div class="lg:col-start-1 lg:row-start-1">
@@ -41,7 +41,7 @@
                     </div>
                 </section>
                 <!-- Solutions -->
-                <section class="border-t border-gray-300 pt-5">
+                <section class="pt-5">
                     <p class="text-lg font-medium text-gray-900 mb-6">Solutions</p>
                     <div class="grid grid-cols-2 sm:grid-cols-3 gap-x-8 gap-y-8">
                         <div>
@@ -83,7 +83,7 @@
                     </div>
                 </section>
                 <!-- Resources -->
-                <section class="border-t border-gray-300 pt-5">
+                <section class="pt-5">
                     <p class="text-lg font-medium text-gray-900 mb-6">Resources</p>
                     <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-1 gap-x-8 gap-y-8">
                         <div>

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -369,7 +369,7 @@ eleventyComputed:
             <!-- Sections synced with the top nav: Platform / Solutions / Resources / Company -->
             <div class="grid grid-cols-1 lg:grid-cols-[2fr_3fr_1fr] gap-x-8 gap-y-12 text-sm">
                 <!-- Platform -->
-                <section class="border-t border-gray-300 pt-5">
+                <section class="pt-5">
                     <p class="text-lg font-medium text-gray-900 mb-6">Platform</p>
                     <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-2 gap-x-8 gap-y-8">
                         <div class="lg:col-start-1 lg:row-start-1">
@@ -406,7 +406,7 @@ eleventyComputed:
                     </div>
                 </section>
                 <!-- Solutions -->
-                <section class="border-t border-gray-300 pt-5">
+                <section class="pt-5">
                     <p class="text-lg font-medium text-gray-900 mb-6">Solutions</p>
                     <div class="grid grid-cols-2 sm:grid-cols-3 gap-x-8 gap-y-8">
                         <div>
@@ -448,7 +448,7 @@ eleventyComputed:
                     </div>
                 </section>
                 <!-- Resources -->
-                <section class="border-t border-gray-300 pt-5">
+                <section class="pt-5">
                     <p class="text-lg font-medium text-gray-900 mb-6">Resources</p>
                     <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-1 gap-x-8 gap-y-8">
                         <div>


### PR DESCRIPTION
## Description

**Variant A of 2.** Removes `border-t` from Platform, Solutions and Resources. The Company section keeps its border, since it separates the link columns from the logo and legal row rather than sitting between equal siblings. Spacing is unchanged.

Variant B (#5408) removes only the first border. Compare the two previews and merge whichever you prefer, then close the other.

## Related Issue(s)

Review feedback on #5375.

## Checklist

 - [x] I have read the contribution guidelines
 - [x] I have considered the performance impact of these changes
