### PR TITLE
Footer variant B: drop only the first section border

### DIFF
--- a/nuxt/components/AppFooter.vue
+++ b/nuxt/components/AppFooter.vue
@@ -4,7 +4,7 @@
             <!-- Sections synced with the top nav: Platform / Solutions / Resources / Company -->
             <div class="grid grid-cols-1 lg:grid-cols-[2fr_3fr_1fr] gap-x-8 gap-y-12 text-sm">
                 <!-- Platform -->
-                <section class="border-t border-gray-300 pt-5">
+                <section class="pt-5">
                     <p class="text-lg font-medium text-gray-900 mb-6">Platform</p>
                     <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-2 gap-x-8 gap-y-8">
                         <div class="lg:col-start-1 lg:row-start-1">

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -369,7 +369,7 @@ eleventyComputed:
             <!-- Sections synced with the top nav: Platform / Solutions / Resources / Company -->
             <div class="grid grid-cols-1 lg:grid-cols-[2fr_3fr_1fr] gap-x-8 gap-y-12 text-sm">
                 <!-- Platform -->
-                <section class="border-t border-gray-300 pt-5">
+                <section class="pt-5">
                     <p class="text-lg font-medium text-gray-900 mb-6">Platform</p>
                     <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-2 gap-x-8 gap-y-8">
                         <div class="lg:col-start-1 lg:row-start-1">


### PR DESCRIPTION
## Description

**Variant B of 2.** Removes `border-t` from Platform only, leaving Solutions and Resources with theirs. Matches your mobile note exactly, where the sections stack and only the first sits directly under the background change.

On desktop the three sit side by side, so their borders read as one continuous rule across the grid. Removing only the first leaves that rule starting a third of the way in, which is the thing to judge on the preview.

Variant A (#5407) removes all three. Merge whichever you prefer, then close the other.

## Related Issue(s)

Review feedback on #5375.

## Checklist

 - [x] I have read the contribution guidelines
 - [x] I have considered the performance impact of these changes
