### PR TITLE
Marker variant A: align markers to the first line of text

### DIFF
--- a/src/_includes/layouts/industry.njk
+++ b/src/_includes/layouts/industry.njk
@@ -82,7 +82,7 @@ layout: default
                     <h2 class="max-md:text-center">{% if problemTitle %}{{ problemTitle | safe }}{% else %}<span class="text-red-600">The Problem</span> Today{% endif %}</h2>
                     <ul class="mt-6 flex flex-col gap-6 list-none p-0 m-0">
                         {% for problem in problems %}
-                        <li class="flex items-start gap-3 items-center">
+                        <li class="flex items-start gap-3">
                             <span class="flex-shrink-0 w-12 h-12 bg-red-300 rounded-full flex items-center justify-center text-white">
                                 <span class="w-6 h-6">{% include "components/icons/x-mark.svg" %}</span>
                             </span>
@@ -108,7 +108,7 @@ layout: default
                     <h2 class="text-white max-md:text-center">{{ solution.title }}</h2>
                     <ul class="mt-8 flex flex-col gap-6 list-none p-0 m-0">
                         {% for benefit in solution.benefits %}
-                        <li class="flex items-start gap-6 items-center">
+                        <li class="flex items-start gap-6">
                             <span class="flex-shrink-0 w-12 h-12 bg-indigo-50 rounded-full flex items-center justify-center text-indigo-600">
                                 <span class="w-6 h-6">{% include benefit.svgPath %}</span>
                             </span>


### PR DESCRIPTION
## Description

**Variant A of 2.** The `li` carried both `items-start` and `items-center`, so which one won was decided by the order Tailwind emits them in the stylesheet, not by the attribute. It resolved to `flex-start`. This keeps that but makes it explicit, so it no longer depends on build order.

Visually identical to what is on the site today. The paragraph keeps its `pt-2`, the nudge that lines the marker up with the first line rather than the top of the text box.

Variant B centres the marker on the whole paragraph. Merge whichever you prefer, then close the other.

## Related Issue(s)

Review feedback on #5378.

## Checklist

 - [x] I have read the contribution guidelines
 - [x] I have considered the performance impact of these changes
