### PR TITLE
Restructure /node-red page into a single narrative

### DIFF
--- a/src/node-red/index.njk
+++ b/src/node-red/index.njk
@@ -94,7 +94,7 @@ sitemapPriority: 0.8
                     {
                         "svgPath": "components/icons/puzzle-piece.svg",
                         "title": "Digital Services Integration",
-                        "description": "Node-RED facilitates seamless integration with a wide array of digital services, including protocols (OPC-UA, Modbus, Siemens S7), databases, APIs, and devices."
+                        "description": 'Node-RED facilitates seamless integration with a wide array of digital services, including protocols (OPC-UA, Modbus, Siemens S7), databases, APIs, and devices. <a href="/integrations/">Browse the full integrations catalog</a>.'
                     },
                     {
                         "svgPath": "components/icons/document-chart-bar.svg",
@@ -130,40 +130,94 @@ sitemapPriority: 0.8
     </div>
 </div>    
 
-<!--Learning Resources-->
-<div class="w-full bg-gray-50 pb-20 pt-16">
-    <div class="max-w-screen-lg m-auto px-6">
-    <h2 class="max-md:text-center">
-        Node-RED <span class="text-indigo-600">Learning Resources</span>
-    </h2>
-<div class="max-sm:text-center max-w-md sm:max-w-none mx-auto sm:grid justify-center items-center mt-10" style="grid-template-columns: 45% auto;">
-    <div class="max-h-[400px] md:max-h-[350px] ff-image-cover scale ff-image-rounded w-full h-full mb-4 sm:mb-0">
-        {% image "../images/learning_nr.png", "Node-RED pseudo UI", [406] %}
-    </div>
-        <div class="content-center justify-center sm:pl-8 flex-1">
-            <p class="md:mt-0">
-                Jumpstart your Node-RED journey with FlowFuse’s comprehensive learning resources, including tutorials, case studies, and community forums. Whether you’re new to Node-RED or looking to refine your skills, our resources are designed to accelerate your learning curve.
-            </p>
-            <p class="text-blue-700 mb-10 mt-7">
-                <a href="https://node-red-academy.learnworlds.com/">Node-RED Academy</a>
-                <span class="px-3">|</span>
-                <a href="/node-red/core-nodes/">Core Nodes</a>
-                <span class="px-3">|</span>
-                <a href="/blog/2024/05/understanding-node-flow-global-environment-variables-in-node-red/">Variables</a>
-                <span class="px-3">|</span>
-                <a href="/blog/2023/04/3-quick-node-red-tips-6/">Quick Tips</a>
-            </p>
-            <a class="ff-btn ff-btn--primary min-h-[40px] md:inline mb-2 md:mb-0 md:mr-2" href="/node-red/learn/">SEE MORE</a>
-            <a class="ff-btn ff-btn--primary-outlined min-h-[40px] md:inline" href="/professional-services/">GET IMPLEMENTATION SUPPORT</a>
+<div class="max-w-screen-lg mx-auto text-center pt-20 pb-6 px-6 text-lg flex-col flex-row items-center justify-center gap-1 hover:no-underline flex-wrap">
+    <!--Customer Stories Banner-->
+    <h2 class="md:text-left max-w-3xl">Explore <span class="text-indigo-600">Real-World Node-RED Applications</span> from FlowFuse Customers</h2>
+    <ul class="mt-10 grid grid-cols-1 md:grid md:grid-cols-3 gap-y-4 pb-4 m-auto gap-6">
+        {%- for item in collections.stories | sort(attribute='item.date') | reverse | limit(3) -%}
+        <li class="w-full max-w-md m-auto my-2">
+            <a href="{{ item.url }}" class="w-full flex flex-col group hover:no-underline">
+                <div>
+                    <div>
+                        <div class="relative">
+                            <div class="w-full h-40 ff-image-cover scale mb-4 ff-image-rounded object-contain overflow-hidden">
+                                {% if item.data.image %}
+                                    {% set imageSrc = ["./", item.data.image ] | join %}
+                                    {% set imageDescription = ["Image representing ", item.data.title] | join %}
+                                    {% if item.data.logo %}
+                                        <div class="w-1/2 h-full absolute left-0 top-0 bg-white flex items-center justify-center">
+                                            {% set logoSrc = ["./", item.data.logo ] | join %}
+                                            {% set logoDescription = ["Image representing ", item.data.story.brand, " logo"] | join %}
+                                            {% image logoSrc, logoDescription, [285] %}
+                                        </div>
+                                    {% endif %}
+                                {% else %}
+                                    {% set imageSrc = "./images/og-blog.jpg" %}
+                                    {% set imageDescription = "Image with logo and the slogan: Elevate Node-RED with Flowfuse" %}
+                                {% endif %}
+                                {% image imageSrc, imageDescription, [285] %}
+                            </div>
+                        </div>
+                    </div>
+                    <h5 class="mt-1 mb-0 group-hover:underline font-light text-lg text-left text-gray-600">{{ item.data.title }}</h5>
+                </div>
+            </a>
+        </li>
+        {% endfor %}
+    </ul>
+    <a href="/customer-stories/" class="w-full font-light text-center md:text-left hover:underline pt-3 flex flex-row items-center gap-1 cursor-pointer flex-wrap max-md:max-w-md mx-auto mb-20">
+        See more customer stories {% include "components/icons/chevron-right-sm.svg" %}
+    </a>
+</div>
+
+<!--Why FlowFuse-->
+<div class="max-w-screen-lg mx-auto text-center pb-6 px-6 text-lg">
+    <div class="ff-blue-card">
+        <h2 class="font-bold m-auto w-full text-center sm:text-left mb-5">Why Choose <span class="text-red-600">FlowFuse</span> for Node-RED </h2>
+        <div class="w-full sm:grid sm:grid-cols-2 gap-6 sm:gap-8">
+            {% set sections = [
+                {
+                    "iconPath": "components/icons/shield-check.svg",
+                    "title": "Enhanced Security",
+                    "description": "Security and compliance guardrails ensure adherence to security protocols."
+                },
+                {
+                    "iconPath": "components/icons/user-group.svg",
+                    "title": "Seamless Collaboration",
+                    "description": "Cloud-based solutions and dev-ops pipelines streamline development with user-friendly interfaces and safeguard against errors."
+                },
+                {
+                    "iconPath": "components/icons/arrows-pointing-out.svg",
+                    "title": "Scalable Architecture ",
+                    "description": "Start small and scale to thousands of self–built and self–maintained applications. Reduce reliance on point solutions and vendor lock-in."
+                },
+                {
+                    "iconPath": "components/icons/academic-cap.svg",
+                    "title": "Expert Support",
+                    "description": "Get access to our dedicated support team who are creators and experts in Node-RED, ready to assist you at every step."
+                }
+            ] %}
+
+            {% for section in sections %}
+                <div class="w-full mt-4 md:mt-0 flex flex-col justify-between">
+                    <div>
+                        <div class="flex max-sm:w-full justify-center sm:justify-start mt-3 mb-2 w-8 h-8">
+                            {% include section.iconPath %}
+                        </div>
+                        <h4 class="flex justify-center sm:justify-start font-semibold">{{ section.title }}</h4>
+                        <p class="font-light mt-6">{{ section.description }}</p>
+                    </div>
+                </div>
+            {% endfor %}
         </div>
     </div>
-</div>
 </div>
 
 <!--Certified Nodes-->
 {# Driven by the live catalogues via src/_data/certifiedNodes.js, so newly
    certified nodes appear here without editing this page. The section is
-   skipped entirely if neither catalogue could be fetched at build time. #}
+   skipped entirely if neither catalogue could be fetched at build time.
+   Positioned beside the "Why FlowFuse" block: both make the production/trust case. #}
 {% if certifiedNodes.all.length %}
 <div class="w-full pb-20 pt-16">
     <div class="max-w-screen-lg m-auto px-6">
@@ -207,86 +261,38 @@ sitemapPriority: 0.8
 </div>
 {% endif %}
 
-<div class="max-w-screen-lg mx-auto text-center pt-20 pb-6 px-6 text-lg flex-col flex-row items-center justify-center gap-1 hover:no-underline flex-wrap">
-    <!--Customer Stories Banner-->
-    <h2 class="md:text-left max-w-3xl">Explore <span class="text-indigo-600">Real-World Node-RED Applications</span> from FlowFuse Customers</h2>
-    <ul class="mt-10 grid grid-cols-1 md:grid md:grid-cols-3 gap-y-4 pb-4 m-auto gap-6">
-        {%- for item in collections.stories | sort(attribute='item.date') | reverse | limit(3) -%}
-        <li class="w-full max-w-md m-auto my-2">
-            <a href="{{ item.url }}" class="w-full flex flex-col group hover:no-underline">
-                <div>
-                    <div>
-                        <div class="relative">
-                            <div class="w-full h-40 ff-image-cover scale mb-4 ff-image-rounded object-contain overflow-hidden">
-                                {% if item.data.image %}
-                                    {% set imageSrc = ["./", item.data.image ] | join %}
-                                    {% set imageDescription = ["Image representing ", item.data.title] | join %}
-                                    {% if item.data.logo %}
-                                        <div class="w-1/2 h-full absolute left-0 top-0 bg-white flex items-center justify-center">
-                                            {% set logoSrc = ["./", item.data.logo ] | join %}
-                                            {% set logoDescription = ["Image representing ", item.data.story.brand, " logo"] | join %}
-                                            {% image logoSrc, logoDescription, [285] %}
-                                        </div>
-                                    {% endif %}
-                                {% else %}
-                                    {% set imageSrc = "./images/og-blog.jpg" %}
-                                    {% set imageDescription = "Image with logo and the slogan: Elevate Node-RED with Flowfuse" %}
-                                {% endif %}
-                                {% image imageSrc, imageDescription, [285] %}
-                            </div>
-                        </div>
-                    </div>
-                    <h5 class="mt-1 mb-0 group-hover:underline font-light text-lg text-left text-gray-600">{{ item.data.title }}</h5>
-                </div>
-            </a>
-        </li>
-        {% endfor %}
-    </ul>
-    <a href="/customer-stories/" class="w-full font-light text-center md:text-left hover:underline pt-3 flex flex-row items-center gap-1 cursor-pointer flex-wrap max-md:max-w-md mx-auto mb-20">
-        See more customer stories {% include "components/icons/chevron-right-sm.svg" %}
-    </a>
-
-    <!--Why FlowFuse-->
-    <div class="ff-blue-card">
-        <h2 class="font-bold m-auto w-full text-center sm:text-left mb-5">Why Choose <span class="text-red-600">FlowFuse</span> for Node-RED </h2>
-        <div class="w-full sm:grid sm:grid-cols-2 gap-6 sm:gap-8">
-            {% set sections = [
-                {
-                    "iconPath": "components/icons/shield-check.svg",
-                    "title": "Enhanced Security",
-                    "description": "Security and compliance guardrails ensure adherence to security protocols."
-                },
-                {
-                    "iconPath": "components/icons/user-group.svg",
-                    "title": "Seamless Collaboration",
-                    "description": "Cloud-based solutions and dev-ops pipelines streamline development with user-friendly interfaces and safeguard against errors."
-                },
-                {
-                    "iconPath": "components/icons/arrows-pointing-out.svg",
-                    "title": "Scalable Architecture ",
-                    "description": "Start small and scale to thousands of self–built and self–maintained applications. Reduce reliance on point solutions and vendor lock-in."
-                },
-                {
-                    "iconPath": "components/icons/academic-cap.svg",
-                    "title": "Expert Support",
-                    "description": "Get access to our dedicated support team who are creators and experts in Node-RED, ready to assist you at every step."
-                }
-            ] %}
-
-            {% for section in sections %}
-                <div class="w-full mt-4 md:mt-0 flex flex-col justify-between">
-                    <div>
-                        <div class="flex max-sm:w-full justify-center sm:justify-start mt-3 mb-2 w-8 h-8">
-                            {% include section.iconPath %}
-                        </div>
-                        <h4 class="flex justify-center sm:justify-start font-semibold">{{ section.title }}</h4>
-                        <p class="font-light mt-6">{{ section.description }}</p>
-                    </div>
-                </div>
-            {% endfor %}
+<!--Learning Resources (on-ramp, positioned near the closing CTAs)-->
+<div class="w-full bg-gray-50 pb-20 pt-16">
+    <div class="max-w-screen-lg m-auto px-6">
+    <h2 class="max-md:text-center">
+        Node-RED <span class="text-indigo-600">Learning Resources</span>
+    </h2>
+<div class="max-sm:text-center max-w-md sm:max-w-none mx-auto sm:grid justify-center items-center mt-10" style="grid-template-columns: 45% auto;">
+    <div class="max-h-[400px] md:max-h-[350px] ff-image-cover scale ff-image-rounded w-full h-full mb-4 sm:mb-0">
+        {% image "../images/learning_nr.png", "Node-RED pseudo UI", [406] %}
+    </div>
+        <div class="content-center justify-center sm:pl-8 flex-1">
+            <p class="md:mt-0">
+                Jumpstart your Node-RED journey with FlowFuse’s comprehensive learning resources, including tutorials, case studies, and community forums. Whether you’re new to Node-RED or looking to refine your skills, our resources are designed to accelerate your learning curve.
+            </p>
+            <p class="text-blue-700 mb-10 mt-7">
+                <a href="https://node-red-academy.learnworlds.com/">Node-RED Academy</a>
+                <span class="px-3">|</span>
+                <a href="/node-red/core-nodes/">Core Nodes</a>
+                <span class="px-3">|</span>
+                <a href="/blog/2024/05/understanding-node-flow-global-environment-variables-in-node-red/">Variables</a>
+                <span class="px-3">|</span>
+                <a href="/blog/2023/04/3-quick-node-red-tips-6/">Quick Tips</a>
+            </p>
+            <a class="ff-btn ff-btn--primary min-h-[40px] md:inline mb-2 md:mb-0 md:mr-2" href="/node-red/learn/">SEE MORE</a>
+            <a class="ff-btn ff-btn--primary-outlined min-h-[40px] md:inline" href="/professional-services/">GET IMPLEMENTATION SUPPORT</a>
         </div>
     </div>
+</div>
+</div>
 
+<!--Flexible Deployment + FAQ-->
+<div class="max-w-screen-lg mx-auto text-center pb-6 px-6 text-lg">
     <!--Flexible Deployment with FlowFuse-->
     <div class="text-center text-teal-50 mt-12 pt-12 text-lg flex-col flex-row items-center justify-center gap-1 hover:no-underline flex-wrap">
         <div class="text-center mt-6 md:mt-4 mb-14">
@@ -327,7 +333,7 @@ sitemapPriority: 0.8
             </div>
         </div>
     </div>
-    <!-- Frequently Asked Questions --> 
+    <!-- Frequently Asked Questions -->
     <div class="md:text-left max-md:max-w-md mx-auto pt-24 md:pt-16 text-left">
         <h2 class="max-md:text-center -mb-12">
             Frequently Asked <span class="text-indigo-600">Questions</span>


### PR DESCRIPTION
## What & why

Reorders the `/node-red` (`src/node-red/index.njk`) sections so the page reads as one narrative — **what it is → what it does → proof → why us → how to start** — and fixes a dead-end integrations link.

### Section order

| # | Section | Change |
|---|---------|--------|
| 1 | Hero — "What is Node-RED?" | unchanged |
| 2 | Harness the Power of Low-Code Integration | unchanged |
| 3 | Explore Real-World Node-RED Applications | **moved up** (was #5) — proof earlier |
| 4 | Why Choose FlowFuse for Node-RED | grouped with ↓ |
| 5 | Nodes certified for production | **moved down** (was #4) to sit beside Why-FlowFuse — the why-us case in one place |
| 6 | Node-RED Learning Resources | **moved down** toward the closing CTAs as the on-ramp |
| 7 | Flexible Deployment with FlowFuse | kept with FAQ as the on-ramp tail |
| 8 | Frequently Asked Questions | last |

### Integrations linking

- Added a link from the **Digital Services Integration** pillar to the full `/integrations/` catalog (it previously listed connectors — OPC-UA, Modbus, Siemens S7, databases, APIs — but linked nowhere). The pillar description was switched to a single-quoted string so the anchor is valid, matching the existing Data Visualization pillar.
- Resolved the pillar/certified-nodes redundancy **by role**: pillar → full catalog; certified-nodes → production/trust. The certified copy was already framed on trust (named owner, vetted, patched), so it was **repositioned, not rewritten**.

## Reviewer notes

- The shared wrapper that nested Customer Stories / Why-FlowFuse / Deployment / FAQ had to be split so Certified Nodes and Learning Resources could sit between them. Each relocated **text** section got its own `max-w-screen-lg mx-auto … px-6` wrapper (identical to the page's existing pattern); Certified and Learning stay `w-full` so their backgrounds remain full-bleed.
- Verified locally (11ty, with compiled CSS): rendered section order matches the table; the three moved text sections render centered at 1024px while Certified/Learning stay full-bleed; the pillar link resolves to `/integrations/`; all sections populated; no console errors; div tags balanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)