### PR TITLE
Fix dark mode still showing for returning visitors

### DIFF
--- a/nuxt/plugins/force-light-mode.client.ts
+++ b/nuxt/plugins/force-light-mode.client.ts
@@ -1,0 +1,8 @@
+// @nuxtjs/color-mode persists whatever preference a visitor had (often "system")
+// to localStorage, which overrides nuxt.config.ts's colorMode default on repeat
+// visits. Dark mode isn't supported across the site yet, so force + persist
+// "light" here to self-heal anyone who has an old stored preference.
+export default defineNuxtPlugin(() => {
+    const colorMode = useColorMode()
+    colorMode.preference = 'light'
+})


### PR DESCRIPTION
## Description

- Nuxt UI components (pricing cards, comparison table, etc.) kept rendering in dark mode for visitors who'd loaded the site before our earlier dark-mode-disable fix, even after that fix shipped.
- Root cause: `@nuxtjs/color-mode` persists the resolved preference (often `"system"`) to `localStorage` on load, and that stored value always takes priority over `nuxt.config.ts`'s `colorMode` default on future visits. The config change only protected new visitors going forward, it couldn't repair anyone who already had a stale value stored.
- Adds `nuxt/plugins/force-light-mode.client.ts`, which explicitly sets `colorMode.preference = 'light'` on every load, overwriting any stale stored preference. Self-healing for every visitor, old or new, until the site has real dark mode support across the board.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

