### PR TITLE
Document Certified Nodes catalog update process

### DIFF
--- a/nuxt/content/handbook/engineering/ops/certified-nodes.md
+++ b/nuxt/content/handbook/engineering/ops/certified-nodes.md
@@ -42,4 +42,57 @@ _Screnshot of where to enter Certfied Nodes Token_
 6. Make changes to the `package.json` to update
     - The name and scope to be `@flowfuse-certified-nodes/<name>`, where name should be shortest sensible name 
     - The `homepage` link to FlowFuse documentation for the node
+    - The `publishConfig.registry` to point to the FlowFuse registry (`https://registry.flowfuse.com`)
     - Add .github/workflows/release-publish.yml` and the matching `CERTIFIED_NODES_PUBLISH_TOKEN` secret from 1Password.
+7. Publish the node to the FlowFuse registry.
+
+## Updating the Catalog
+
+Once a node is published, it must be registered in the `ff-certified-nodes` Node-RED instance before it appears in customer instances or on the [Integrations page](https://flowfuse.com/integrations). This instance lives in the `Internal Tools` Application on FlowFuse Cloud (`ff-certified-nodes.flowfuse.cloud`) and its editor has three flow tabs: **Authentication**, **catalog generator**, and **Usage**.
+
+Two things are generated from this instance and both must be updated when adding a node:
+
+- **Catalogs** — the `ff-it.json` / `ff-ot.json` files that are served to the end user's Node-RED instance.
+- **Authentication data** — sent to the backend plugin in the npm registry so packages can be mapped to the correct collection.
+
+Nodes are split by product, and the flow uses `IT`/`OT` to refer to them:
+
+- **Hub** = **IT** nodes
+- **Edge** = **OT** nodes
+
+### 1. Add the node to the build catalog
+
+1. Open the `ff-certified-nodes` editor and go to the **catalog generator** tab.
+2. Open the **Build catalogues** function node and select the **On Message** tab.
+3. Add the package name (e.g. `"@flowfuse-certified-nodes/<name>"`) to the correct const array:
+    - `ITNodes` for **Hub** nodes
+    - `OTNodes` for **Edge** nodes
+4. Deploy.
+
+These arrays feed `certNodesITCat` ("FlowFuse Hub Certified Nodes") and `certNodesOTCat` ("FlowFuse Edge Certified Nodes"), which build the catalog files delivered to customers' Node-RED instances.
+
+### 2. Add the node to the authentication collections
+
+1. In the same editor, go to the **Authentication** tab.
+2. Open the `template` node wired to the `/collections` endpoint (under the _Auth handler for certified nodes registry_ comment). It holds a JSON object with a `collections` array and a `lookup` map.
+3. Add the package to the correct group in the `collections` array (`it` for Hub, `ot` for Edge), and add a matching entry to the `lookup` object mapping the package to its group:
+
+    ```json
+    "collections": [
+      { "name": "ot", "packages": ["@flowfuse-certified-nodes/opcua", "@flowfuse-certified-nodes/rtsp"] },
+      { "name": "it", "packages": ["@flowfuse-certified-nodes/redis", "@flowfuse-certified-nodes/<name>"] },
+      { "name": "user", "packages": ["@flowfuse-nodes@nr-mcp-server-nodes"] }
+    ],
+    "lookup": {
+      "@flowfuse-certified-nodes/redis": ["it"],
+      "@flowfuse-certified-nodes/<name>": ["it"]
+    }
+    ```
+
+4. Deploy.
+
+The **Authentication** tab is also where customer instances/users (tokens) are managed — see [Generating Tokens for Access to Certified Nodes Registry](../contributing/certified-nodes.md#generating-tokens-for-access-to-certified-nodes-registry).
+
+### Result
+
+Once both tabs are updated and deployed, the node is included in the generated catalogs served to Node-RED instances and mapped in the registry. The website's [Integrations page](https://flowfuse.com/integrations) then picks it up automatically — it fetches `ff-it.json` and `ff-ot.json` from `ff-certified-nodes.flowfuse.cloud` directly.


### PR DESCRIPTION
## Description

Documents how to update the Certified Nodes catalog in the ops handbook. Adds the `ff-certified-nodes` flow steps (catalog generator + Authentication tabs) that pipe a published node through to the `/integrations` page.

## Related Issue(s)

N/A

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

