### PR TITLE
PostHog analytics fix

### DIFF
--- a/nuxt/server/plugins/analytics.ts
+++ b/nuxt/server/plugins/analytics.ts
@@ -2,7 +2,7 @@ let headHtml: string | null = null
 let bodyHtml: string | null = null
 
 export default defineNitroPlugin((nitroApp) => {
-    if (import.meta.dev) return
+    if (import.meta.dev || process.env.CONTEXT !== 'production') return
 
     nitroApp.hooks.hook('render:html', async (html) => {
         if (html.bodyAppend.some(s => s.includes('cc.min.js'))) return

--- a/nuxt/server/plugins/analytics.ts
+++ b/nuxt/server/plugins/analytics.ts
@@ -2,7 +2,7 @@ let headHtml: string | null = null
 let bodyHtml: string | null = null
 
 export default defineNitroPlugin((nitroApp) => {
-    if (process.env.NODE_ENV !== 'production') return
+    if (import.meta.dev) return
 
     nitroApp.hooks.hook('render:html', async (html) => {
         if (html.bodyAppend.some(s => s.includes('cc.min.js'))) return


### PR DESCRIPTION
## Description
Gate analytics injection on import.meta.dev instead of process.env.NODE_ENV, which read as non-production in the server bundle and suppressed PostHog/GTM on all Nuxt pages. Changes `nuxt/server/plugins/analytics.ts`.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass

