### PR TITLE
fix: correctly gate Nuxt analytics/cookie banner injection to production

### DIFF
--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -41,6 +41,13 @@ export default defineNuxtConfig({
     devtools: { enabled: true },
     modules: ['@nuxt/ui', '@nuxt/content', '@nuxtjs/seo', 'nuxt-studio', '@nuxt/image', './modules/docs-source'],
 
+    // Captured at build time (Netlify sets CONTEXT during the build, not necessarily
+    // in the deployed Function's runtime), then baked into the server bundle via
+    // runtimeConfig so analytics.ts doesn't depend on a process.env read at request time.
+    runtimeConfig: {
+        isProductionContext: process.env.CONTEXT === 'production'
+    },
+
     css: ['~/assets/css/theme.css'],
 
     // Dark mode isn't implemented across the site yet — force light mode so
@@ -133,7 +140,9 @@ export default defineNuxtConfig({
         serverAssets: [
             {
                 baseName: 'analytics',
-                dir: '../src/_includes/analytics'
+                // Nitro resolves this dir against nitro.srcDir (Nuxt's serverDir, i.e. nuxt/server),
+                // not against the nuxt/ root — so this needs one more level up than it looks like.
+                dir: '../../src/_includes/analytics'
             },
             {
                 baseName: 'team',

--- a/nuxt/server/plugins/analytics.ts
+++ b/nuxt/server/plugins/analytics.ts
@@ -2,7 +2,7 @@ let headHtml: string | null = null
 let bodyHtml: string | null = null
 
 export default defineNitroPlugin((nitroApp) => {
-    if (import.meta.dev || process.env.CONTEXT !== 'production') return
+    if (import.meta.dev || !useRuntimeConfig().isProductionContext) return
 
     nitroApp.hooks.hook('render:html', async (html) => {
         if (html.bodyAppend.some(s => s.includes('cc.min.js'))) return


### PR DESCRIPTION
## Description

## Summary
Follow-up to #5425 (initial PostHog fix). That PR fixed the guard using `import.meta.dev`, but that alone would inject analytics on every build, which isn't what we want; it should only fire in real production.

1. `process.env.CONTEXT` isn't reliable at request time in Netlify's Function runtime, so the guard could still misfire. Now captured at build time via `runtimeConfig`.
2. The `serverAssets` path for analytics HTML was wrong. Before #5128 it worked fine as `'../src/_includes/analytics'`, resolved relative to `process.cwd()`. #5128 switched to Nitro's `serverAssets`, which resolves that same path against `nuxt/server` instead — one level short of the real folder. Fixed to `'../../src/_includes/analytics'`.

Both were needed: analytics/cookie banner never actually loaded on Nuxt pages (handbook, docs, changelog, pricing) because of this second bug, even after #5425.
## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

