### PR TITLE
blog: say Edge, not Hub, for the certified Modbus node

### DIFF
--- a/src/blog/2026/07/flowfuse-release-2-33.md
+++ b/src/blog/2026/07/flowfuse-release-2-33.md
@@ -39,7 +39,7 @@ More of the from-scratch onboarding experience lands in upcoming releases.
 
 ## Modbus Certified Node
 
-FlowFuse Hub customers can now install a FlowFuse-certified Modbus node straight from the palette manager in their editor. It covers Modbus TCP and Serial — including RTU and ASCII — in a single package.
+FlowFuse Edge customers can now install a FlowFuse-certified Modbus node straight from the palette manager in their editor. It covers Modbus TCP and Serial — including RTU and ASCII — in a single package.
 
 Modbus is one of the most common protocols on the factory floor, but the community package most teams rely on depends on volunteer maintainers. The FlowFuse-certified node is backed by our own testing, SLA-backed security patching, and a long-term maintenance commitment.
 


### PR DESCRIPTION
## Description

The Modbus section contradicts itself: the opening line says "FlowFuse **Hub** customers can now install...", while the availability note one paragraph below says "available exclusively to FlowFuse **Edge** customers".

Edge is correct. The now-merged Modbus docs page in #5384 says the package "is part of the FlowFuse Edge Certified Nodes catalogue, which is part of the **FlowFuse Edge** offering", matching `opcua.md`, `rtsp.md`, `cip-suite.md` and the section `index.md` word for word. This changes the one outlier so the post agrees with itself and with the docs.

The other `Hub and Edge` availability lines cover different features and are left alone.

Targets the release blog branch rather than `main`, so it can go in before the post publishes.

## Related Issue(s)

Against #5365. Tier wording established by #5384.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))