### PR TITLE
Add pricing decks handbook page (Edge, Hub, Fleet)

### DIFF
--- a/src/handbook/sales/engagements.md
+++ b/src/handbook/sales/engagements.md
@@ -7,7 +7,8 @@ navTitle: Engagements & Pricing
 Pricing is publicly available at [our pricing page](/pricing/). When discussing
 pricing with enterprise customers, make a copy of
 [our internal pricing template deck](https://docs.google.com/presentation/d/1kaW6aZxpnCaVuQVdVsi0RTulhRMbeqglhZHkzSP-2kM/)
-to discuss.
+to discuss. For per-product commercial conversations, use the relevant
+[Pricing Decks](./pricing-decks.md) (Edge, Hub, and Fleet).
 
 ## Creating a Deal
 

--- a/src/handbook/sales/index.md
+++ b/src/handbook/sales/index.md
@@ -39,6 +39,7 @@ Questions can be asked in the [#dept-sales](https://flowfuse.slack.com/archives/
  - [Forecast Review](./forecast-review.md)
  - [Demo](./meetings/demo.md)
  - [Sales Deck](./sales-deck.md)
+ - [Pricing Decks](./pricing-decks.md)
  - [Engagements & Pricing](./engagements.md)
  - [Deal Board](https://app-eu1.hubspot.com/contacts/26586079/objects/0-3/views/all/board)
  - [Sales playbook (internal)](https://docs.google.com/document/d/1Jrt5sNg46wngQ5UAii8sbN94PTlIAscOWrFcOhSVNPE/edit){rel="nofollow"}

--- a/src/handbook/sales/pricing-decks.md
+++ b/src/handbook/sales/pricing-decks.md
@@ -1,0 +1,38 @@
+---
+navTitle: Pricing Decks
+---
+
+# Pricing Decks
+
+The pricing decks present FlowFuse commercial packaging to prospects, broken out by product line. Each deck frames the value, tiers, and pricing model for its product so the conversation stays focused on what the customer is actually evaluating.
+
+There are three decks, one per product:
+
+| Deck | Product | Link |
+|------|---------|------|
+| Edge | FlowFuse Edge (edge connectivity) | [Edge pricing deck](https://docs.google.com/presentation/d/1TwVdFyyuxUPNGNR-6i8PWdxYC9sCQpRgzU1oZAgjn-M/) |
+| Hub | FlowFuse Hub (central management) | [Hub pricing deck](https://docs.google.com/presentation/d/1aUKy_9bfO8UI25LoUVCFnUZ_Ekng1a7SWnNNwacbR2c/) |
+| Fleet | FlowFuse Fleet (device fleet management) | [Fleet pricing deck](https://docs.google.com/presentation/d/19rLgt3AK6moh2BhKHrezgvqvYFVo8KGrxdUCMxVPeCs/) |
+
+## When to Use It
+
+Use the pricing decks **later in the cycle**, once the product fit is understood and the conversation turns to commercials — typically during proposal, pricing, and procurement review meetings. Lead with the deck that matches the product the prospect is evaluating; use more than one only when the deal spans multiple product lines.
+
+They are not intro material. Establish the problem and value with the [Sales Deck](./sales-deck.md) first, then move to pricing once there is a business case to price against.
+
+## How to Use It
+
+- **Make a copy before customizing.** Never edit the master deck.
+- Present the deck that matches the product in play — don't walk a prospect through all three by default.
+- Anchor pricing to the value and scope established earlier in the engagement.
+- For non-standard pricing, discounts, or terms, follow the [Deal Desk process](./engagements.md) before committing anything.
+- Close every meeting with a defined next step.
+
+## Stakeholders
+
+| Role | Responsibility |
+|------|----------------|
+| VP of Sales (Michael Davis) | Owns the decks; approves changes to pricing, packaging, or structure. |
+| Account Executives | Primary users. Responsible for customizing per engagement. |
+| Marketing | Contributes positioning and competitive messaging. Loop them in before making narrative changes. |
+| CEO | Consulted on major pricing or packaging shifts and executive/investor-level use. |

--- a/src/handbook/sales/sales-deck.md
+++ b/src/handbook/sales/sales-deck.md
@@ -10,6 +10,8 @@ The [FlowFuse Sales Deck](https://docs.google.com/presentation/d/1xygs4VS6A7sHY8
 
 Use it in **intro and discovery calls** — the first or second meeting with a new prospect. It's also appropriate for executive briefings or re-engagement conversations where a high-level overview is more useful than a deep technical walkthrough.
 
+Once the conversation turns to commercials, move to the per-product [Pricing Decks](./pricing-decks.md) (Edge, Hub, and Fleet).
+
 ## How to Use It
 
 - **Make a copy before customizing.** Never edit the master deck.


### PR DESCRIPTION
## Summary

Adds a dedicated **Pricing Decks** handbook page and three inbound links, mirroring the existing Sales Deck page.

- **New page** `src/handbook/sales/pricing-decks.md` → `/handbook/sales/pricing-decks/`, covering the Edge, Hub, and Fleet pricing decks with When to Use It / How to Use It / Stakeholders sections.
- **Inbound links:**
  - `sales/index.md` — added to the *How we work* list under Sales Deck
  - `engagements.md` — pointer to the per-product decks in the pricing intro
  - `sales-deck.md` — cross-link to move from intro to commercial conversation

Note: this branch also includes the earlier Sales Deck page commit (`ed2f13a`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)