### PR TITLE
Fix invisible headings when a stale color-mode preference is stored

### DIFF
--- a/nuxt/assets/css/theme.css
+++ b/nuxt/assets/css/theme.css
@@ -21,6 +21,39 @@
     --ui-text-highlighted: var(--color-gray-700);
 }
 
+/* Single-theme safety net. colorMode is pinned to light in nuxt.config.ts, but
+   the class that drives Nuxt UI's dark palette is applied by an inline script
+   from client state, so a stale or hand-set value can still put `.dark` on
+   <html>. The page background comes from the 11ty stylesheet and has no dark
+   variant, so when that happened, headings resolved to near-white on white and
+   became invisible. Re-point Nuxt UI's dark tokens at its own light values so
+   the class cannot change what anything looks like. Keep this in sync with
+   Nuxt UI's `:root` block if a version bump adds tokens. */
+.dark {
+    --ui-text-dimmed: var(--ui-color-neutral-400);
+    --ui-text-muted: var(--ui-color-neutral-500);
+    --ui-text-toned: var(--ui-color-neutral-600);
+    --ui-text: var(--ui-color-neutral-700);
+    --ui-text-highlighted: var(--ui-color-neutral-900);
+    --ui-text-inverted: #fff;
+    --ui-bg: #fff;
+    --ui-bg-muted: var(--ui-color-neutral-50);
+    --ui-bg-elevated: var(--ui-color-neutral-100);
+    --ui-bg-accented: var(--ui-color-neutral-200);
+    --ui-bg-inverted: var(--ui-color-neutral-900);
+    --ui-border: var(--ui-color-neutral-200);
+    --ui-border-muted: var(--ui-color-neutral-200);
+    --ui-border-accented: var(--ui-color-neutral-300);
+    --ui-border-inverted: var(--ui-color-neutral-900);
+}
+
+/* Nuxt UI sets `color-scheme: dark` alongside those tokens, which would darken
+   native scrollbars and form controls on our light pages. */
+.dark,
+.dark * {
+    color-scheme: light;
+}
+
 /* Same base heading sizes as src/css/style.css (11ty). Declared here, not just
    there, because Tailwind v4's Preflight (imported above) loads after that
    legacy stylesheet in <head> and wins equal-specificity ties on h1-h5.

--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -50,11 +50,20 @@ export default defineNuxtConfig({
 
     css: ['~/assets/css/theme.css'],
 
-    // Dark mode isn't implemented across the site yet — force light mode so
-    // Nuxt UI components don't switch to dark when the visitor's OS prefers it.
+    // The site ships a single (light) theme, so pin @nuxtjs/color-mode (installed
+    // by @nuxt/ui) to light.
+    //
+    // `preference` alone only covers first-time visitors. The module's inline head
+    // script trusts a stored preference over this config, and its `app:mounted`
+    // hook then copies that stored value back into the reactive state, so anyone
+    // who visited while the default was still "system" keeps getting `.dark` on
+    // <html> on every load. `storageKey` is part of that script's lookup, so
+    // renaming it retires every stale value in one go; from then on the only value
+    // ever written is "light", because the site has no theme switcher.
     colorMode: {
         preference: 'light',
         fallback: 'light',
+        storageKey: 'flowfuse-color-mode',
     },
 
     // Heebo is already loaded via the Google Fonts <link> in app.head.

--- a/nuxt/plugins/force-light-mode.client.ts
+++ b/nuxt/plugins/force-light-mode.client.ts
@@ -1,8 +1,0 @@
-// @nuxtjs/color-mode persists whatever preference a visitor had (often "system")
-// to localStorage, which overrides nuxt.config.ts's colorMode default on repeat
-// visits. Dark mode isn't supported across the site yet, so force + persist
-// "light" here to self-heal anyone who has an old stored preference.
-export default defineNuxtPlugin(() => {
-    const colorMode = useColorMode()
-    colorMode.preference = 'light'
-})


### PR DESCRIPTION
## Description

Headings rendered near-white on the white page background (contrast ratio 1.00) for any visitor whose stored `nuxt-color-mode` was not `light`. `colorMode.preference` only covers first-time visitors: @nuxtjs/color-mode's inline head script reads the stored value ahead of the config and puts `.dark` on `<html>` before first paint, and its own `app:mounted` hook then copies that stored value back into the reactive state and re-persists it, so the state never settles on light and the class is never removed.

Renaming `storageKey` retires every stale value, because that key is exactly what the inline script looks up. Nuxt UI's dark tokens are additionally re-pointed at its own light values, so the class cannot change how anything renders even if it ever does appear.

This also removes `force-light-mode.client.ts`, which was verified in the browser to be a no-op: it assigned `preference` a value the hydrated state already held, so no watcher fired, and the module's `app:mounted` hook overwrote it afterwards regardless. Happy to keep it if you would rather.

Verified with Playwright against production and against this branch's config: with no stored value (the state every visitor lands in after this change) `.dark` is absent and `light` is persisted under both light and dark OS preferences; and with `.dark` forced on, the token override reproduces the light rendering identically across all 603 coloured elements on the page.

## Related Issue(s)

Follow-up to #5406 and #5422.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))