### PR TITLE
Fix link in prerequisites for RTSP camera tutorial

### DIFF
--- a/src/blog/2026/06/process-rtsp-camera-feeds-at-the-edge.md
+++ b/src/blog/2026/06/process-rtsp-camera-feeds-at-the-edge.md
@@ -61,7 +61,7 @@ In this tutorial, you'll connect to an RTSP camera and display the live feed on 
 
 ## Prerequisites
 
-Before you begin, ensure the FlowFuse Device Agent is installed and running on an edge device that can access the camera. This device will be managed through FlowFuse and serves as the environment where you'll install the required nodes and build the flow. If you haven't configured a device yet, complete the [Device Agent Quickstart](/docs/device-agent/quickstart/#setup-installation) before continuing.
+Before you begin, ensure the FlowFuse Device Agent is installed and running on an edge device that can access the camera. This device will be managed through FlowFuse and serves as the environment where you'll install the required nodes and build the flow. If you haven't configured a device yet, complete the [Device Agent Quickstart](/docs/device-agent/quickstart/) before continuing.
 
 The RTSP Video Feed node is part of the **FlowFuse Edge Certified Nodes**, which are part of the **FlowFuse Edge** offering and aren't enabled by default. This applies to FlowFuse Cloud customers too, so the catalogue won't appear in your Palette Manager until it's switched on for your team. [Talk to our sales team](/contact-us/) to get access before you start.
 


### PR DESCRIPTION
Updated the link in the prerequisites section to point to the correct Device Agent Quickstart page.

## Description

<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

