### PR TITLE
Disable nuxt colorMode and revert previous "fixes"

### DIFF
--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -50,13 +50,6 @@ export default defineNuxtConfig({
 
     css: ['~/assets/css/theme.css'],
 
-    // Dark mode isn't implemented across the site yet — force light mode so
-    // Nuxt UI components don't switch to dark when the visitor's OS prefers it.
-    colorMode: {
-        preference: 'light',
-        fallback: 'light',
-    },
-
     // Heebo is already loaded via the Google Fonts <link> in app.head.
     // @nuxt/fonts is a transitive dep of @nuxt/ui; disable all provider downloads
     // so it never fetches font files at build time (which exhausts Netlify's memory).
@@ -233,10 +226,15 @@ export default defineNuxtConfig({
     },
     
     ui: {
-    theme: {
-      colors: ['primary', 'secondary', 'success', 'info', 'warning', 'error', 'highlight']
-    }
-  },
+        // Dark mode isn't implemented across the site yet. Disabling the color-mode
+        // module here (rather than just setting a light `colorMode` preference) is
+        // what actually stops Nuxt UI from switching to dark for visitors whose OS
+        // prefers it — see https://ui.nuxt.com/docs/getting-started/integrations/color-mode/nuxt#configuration
+        colorMode: false,
+        theme: {
+            colors: ['primary', 'secondary', 'success', 'info', 'warning', 'error', 'highlight']
+        }
+    },
     // Dev proxying to 11ty is handled by server/middleware/legacy.ts
     // to allow per-route exclusions as pages are migrated.
 })

--- a/nuxt/plugins/force-light-mode.client.ts
+++ b/nuxt/plugins/force-light-mode.client.ts
@@ -1,8 +1,0 @@
-// @nuxtjs/color-mode persists whatever preference a visitor had (often "system")
-// to localStorage, which overrides nuxt.config.ts's colorMode default on repeat
-// visits. Dark mode isn't supported across the site yet, so force + persist
-// "light" here to self-heal anyone who has an old stored preference.
-export default defineNuxtPlugin(() => {
-    const colorMode = useColorMode()
-    colorMode.preference = 'light'
-})


### PR DESCRIPTION
## Description

According to [Nuxt's documentation](https://ui.nuxt.com/docs/getting-started/integrations/color-mode/nuxt#configuration), this is the right way of disabling the dark mode.

This PR also reverts past failed attempts to fix it.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

