### PR TITLE
Update quote step 6 to reference Edge, Hub, and Fleet templates

### DIFF
--- a/nuxt/content/handbook/sales/engagements.md
+++ b/nuxt/content/handbook/sales/engagements.md
@@ -72,10 +72,16 @@ Follow these steps to create a quote.
 5. Set Signature and Payment settings as needed. Ensure a countersignature is
    required from either the CEO or Head of GTM.
 6. In the Template and Details section, choose the appropriate Quote Template
-   from the dropdown menu. Choosing the correct Quote Template is important
-   because it will pre-fill the correct plan features onto the quote. You can
-   include additional Comments to Buyer or Purchase Terms here. They will not
-   overwrite the Terms and Comments included with the Quote Template.
+   from the dropdown menu. Always use one of the three product templates that
+   correspond to our pricing packages:
+   - **Edge**
+   - **Hub**
+   - **Fleet**
+
+   Choosing the correct Quote Template is important because it will pre-fill the
+   correct plan features onto the quote. You can include additional Comments to
+   Buyer or Purchase Terms here. They will not overwrite the Terms and Comments
+   included with the Quote Template.
 7. Review your Quote, and when everything is correct, click Create to create the
    quote attached to the relevant Deal.
 


### PR DESCRIPTION
## Summary

Updates step 6 of the **Creating a Quote** section in the sales engagements handbook page to reference the three product templates that correspond to our new pricing packages: **Edge**, **Hub**, and **Fleet**.

This clarifies that one of these three product templates should always be selected when choosing a Quote Template in HubSpot.

Page: [/handbook/sales/engagements/#generating-a-quote](https://flowfuse.com/handbook/sales/engagements/#generating-a-quote)

🤖 Generated with [Claude Code](https://claude.com/claude-code)