### PR TITLE
Nuxt: Move white background to template

### DIFF
--- a/nuxt/layouts/default.vue
+++ b/nuxt/layouts/default.vue
@@ -8,7 +8,7 @@
     <AppHeader />
     <div class="flex-grow base">
       <div class="w-full">
-        <main id="main-content" class="flex flex-col mx-auto items-center justify-center gradient-bg">
+        <main id="main-content" class="flex flex-col mx-auto items-center justify-center bg-white gradient-bg">
           <slot />
         </main>
       </div>

--- a/nuxt/pages/docs/[...slug].vue
+++ b/nuxt/pages/docs/[...slug].vue
@@ -45,7 +45,7 @@ const breadcrumbs = computed(() => {
 </script>
 
 <template>
-  <div class="w-full pl-6 bg-white/50">
+  <div class="w-full pl-6">
     <div class="handbook ff-prose text-left pb-24 m-auto">
 
       <!-- Left navigation -->

--- a/nuxt/pages/handbook/[...slug].vue
+++ b/nuxt/pages/handbook/[...slug].vue
@@ -63,7 +63,7 @@ defineOgImage('Default', {
 </script>
 
 <template>
-  <div class="light w-full pl-6 bg-white">
+  <div class="light w-full pl-6">
     <div class="handbook ff-prose text-left pb-24 m-auto">
 
       <!-- Left navigation -->


### PR DESCRIPTION
## Description

There were white backgrounds in some pages that covered the parent's gradient background. This PR moves that class to the main template to make sure no pages have transparent background while keeping the gradient on top.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

