### PR TITLE
Remove dead buttons block from featureCatalog.yaml

### DIFF
--- a/src/_data/featureCatalog.yaml
+++ b/src/_data/featureCatalog.yaml
@@ -857,13 +857,3 @@ sections:
         selfHosted:
           enterprise:
             value: true
-
-buttons:
-  cloud:
-    - cta: Request a Quote
-      url: /pricing/request-quote/
-      onclick: "capture('cta-request-quote', {'position': 'secondary'}, {'plan': 'cloud-enterprise'})"
-  selfHosted:
-    - cta: Request a Quote
-      url: /pricing/request-quote/
-      onclick: "capture('cta-request-quote', {'position': 'secondary'}, {'plan': 'sh-enterprise'})"


### PR DESCRIPTION
## Summary
- `src/_data/featureCatalog.yaml` had a top-level `buttons:` block (cloud/self-hosted "Request a Quote" CTA data) that neither the old 11ty pricing template nor `nuxt/composables/useFeatureCatalog.ts` ever reads — confirmed no references anywhere in `src/` or `nuxt/`.
- Removed it as unused dead data.

## Test plan
- [ ] Confirm `/pricing` renders unchanged (this data was never wired to anything, so no visible change expected)