### PR TITLE
handbook: require pre-approval for education and conference expenses

### DIFF
--- a/nuxt/content/handbook/peopleops/expenses.md
+++ b/nuxt/content/handbook/peopleops/expenses.md
@@ -210,6 +210,11 @@ particular material you would like to study, or an event you would like to
 attend. FlowFuse will help cover reasonable costs associated with the activity -
 such as travel and ticket fees.
 
+Get pre-approval from your manager before you book or pay for anything. Share
+the activity, the dates and the expected total cost (ticket, travel and
+accommodation) so the full amount can be approved up front. Without
+pre-approval there is no guarantee the expense will be reimbursed.
+
 ## Software Licenses
 
 Licenses and software assets can be purchased for third-party software will be


### PR DESCRIPTION
## Description

Adds explicit pre-approval language to the Education & Conferences section of the expenses handbook page: get manager approval before booking or paying, and share dates and expected total cost (ticket, travel, accommodation) so the full amount is approved up front.

## Related Issue(s)

None.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))