### PR TITLE
Add SDR handbook page with bonus structure

### DIFF
--- a/nuxt/content/handbook/marketing/sdr.md
+++ b/nuxt/content/handbook/marketing/sdr.md
@@ -1,0 +1,40 @@
+---
+title: "Sales Development Representative (SDR)"
+---
+
+# Sales Development Representative (SDR)
+
+The SDR works leads — inbound and outbound — toward a booked meeting. The role
+sits organizationally within the Marketing department, reflecting how closely
+SDR output (booked meetings) depends on marketing's lead generation and
+activation work. See the
+[SDR job description](/handbook/peopleops/job-descriptions/sales-development-representative/)
+for the full role definition.
+
+## Bonus Structure
+
+The SDR is compensated under a quarterly bonus plan tied to a single goal:
+booking `First Meetings`. Note that specific targets are subject to review at
+the start of each fiscal year or quarter.
+
+- First Meetings Booked: Measured against a quarterly goal.
+**_Note: overachieving the goal comes with a proportional upside bonus._**
+
+### First Meetings Bonus Formula
+
+The bonus is calculated on a linear scale between the baseline and goal:
+
+Variables
+- $X$: Achievement (Actual First Meetings booked)
+- $Y$: Baseline (The minimum First Meetings threshold before any payout)
+- $G$: Goal (The target First Meetings for a standard 100% bonus payout)
+- $B_{\text{target}}$: Target Bonus (The dollar amount paid if the SDR exactly hits goal $G$)
+
+**Formula**
+
+$$
+\text{Bonus} = \max \left( 0, B_{\text{target}} \times \frac{X - Y}{G - Y} \right)
+$$
+
+For payout timelines and submission requirements, see
+[Processing non-commission Bonuses](/handbook/operations/commission-payment/#processing-non-commission-bonuses).


### PR DESCRIPTION
## Summary
- Adds a new handbook page for the SDR role, filed under `nuxt/content/handbook/marketing/` since the SDR reports into Marketing.
- Explains the SDR's quarterly bonus structure, tied to booking `First Meetings`.
- Reuses the linear-scale bonus formula from the CSM commission structure (`nuxt/content/handbook/sales/customer-success.md`), rendered via KaTeX.
- Links to the existing SDR job description and to the "Processing non-commission Bonuses" section of the commission-payment page.

## Test plan
- [x] Verified the page renders at `/handbook/marketing/sdr/` with the formula correctly typeset (6 KaTeX spans, matching the CSM page)
- [x] Verified linked pages (job description, commission-payment anchor) resolve