### PR TITLE
Docs: copy button on code blocks

### DIFF
--- a/nuxt/components/prose/ProsePre.vue
+++ b/nuxt/components/prose/ProsePre.vue
@@ -9,7 +9,10 @@ const props = defineProps({
 })
 
 const mermaidRef = ref(null)
+const preRef = ref(null)
+const copied = ref(false)
 let renderCount = 0
+let copiedTimer = null
 
 onMounted(async () => {
     if (props.language !== 'mermaid' || !props.code || !mermaidRef.value) return
@@ -26,11 +29,60 @@ onMounted(async () => {
         if (mermaidRef.value) mermaidRef.value.textContent = props.code
     }
 })
+
+onBeforeUnmount(() => {
+    if (copiedTimer) clearTimeout(copiedTimer)
+})
+
+async function copyCode () {
+    // props.code is the raw source; the rendered <pre> is the fallback for the
+    // rare block that reaches this component without it.
+    const text = props.code || preRef.value?.textContent || ''
+    if (!text) return
+
+    try {
+        if (navigator.clipboard) {
+            await navigator.clipboard.writeText(text)
+        } else {
+            // navigator.clipboard is unavailable outside secure contexts
+            const field = document.createElement('textarea')
+            field.value = text
+            field.setAttribute('readonly', '')
+            field.style.position = 'absolute'
+            field.style.left = '-9999px'
+            document.body.appendChild(field)
+            field.select()
+            document.execCommand('copy')
+            document.body.removeChild(field)
+        }
+    } catch {
+        return
+    }
+
+    copied.value = true
+    if (copiedTimer) clearTimeout(copiedTimer)
+    copiedTimer = setTimeout(() => { copied.value = false }, 2000)
+}
 </script>
 
 <template>
   <div v-if="language === 'mermaid'" ref="mermaidRef" class="mermaid-diagram overflow-x-auto py-4" />
-  <pre v-else :class="$props.class"><slot /></pre>
+  <div v-else class="code-block group relative">
+    <!--
+      Nuxt UI's own ProsePre ships a copy button, but this component shadows it to
+      render mermaid blocks, so the button is reproduced here rather than adopting
+      Nuxt UI's Pre and restyling every code block in docs and handbook.
+    -->
+    <button
+      type="button"
+      class="absolute right-2 top-2 z-10 rounded border border-slate-500 bg-slate-800 px-2 py-0.5 text-xs font-medium text-slate-200 transition hover:border-slate-300 hover:text-white opacity-100 [@media(hover:hover)]:opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+      :aria-label="copied ? 'Code copied' : 'Copy code'"
+      @click="copyCode"
+    >
+      {{ copied ? 'Copied' : 'Copy' }}
+    </button>
+    <pre ref="preRef" :class="$props.class"><slot /></pre>
+  </div>
 </template>
 
 <style>
@@ -41,5 +93,10 @@ pre code .line { display: block }
 pre {
     overflow-x: auto;
     max-width: 100%;
+}
+
+/* Keep code clear of the copy button in the top right corner. */
+.code-block pre {
+    padding-right: 4.5rem;
 }
 </style>


### PR DESCRIPTION
## Description

Code blocks across docs and handbook had no way to copy their contents. Nuxt UI ships a `ProsePre` with a copy button, but `nuxt/components/prose/ProsePre.vue` shadows it in order to render mermaid diagrams, so the button was missing everywhere. Rather than adopt Nuxt UI's `Pre` and restyle every code block, the button is added to the local component.

It reveals on hover on pointer devices and stays visible on touch, is styled to match the dark code blocks, and falls back to `execCommand` where the clipboard API is unavailable. Mermaid blocks are untouched and still render.

Verified in the Nuxt dev container: buttons present on every block of a docs page and a handbook page, copy confirmed by clicking in the browser, and a mermaid page still renders its diagram.

## Related Issue(s)

None.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))