### PR TITLE
Document Expert broker config for Docker self-hosted installs

### DIFF
--- a/nuxt/content/handbook/engineering/ops/self-hosted-assistant.md
+++ b/nuxt/content/handbook/engineering/ops/self-hosted-assistant.md
@@ -49,6 +49,32 @@ docker compose stop forge
 docker compose up -d forge
 ```
 
+#### Broker configuration
+
+Expert chat is delivered over the platform's Team Broker, which bridges chat requests to the central Expert broker on FlowFuse Cloud. The latest Docker Compose template configures this for you. If you maintain a customized `flowforge.yml`, ensure both the `broker` and `expert` sections are present:
+
+```yaml
+broker:
+  teamBroker:
+    enabled: true
+    api:
+      url: http://broker:18083/api/v5   # your EMQX admin API endpoint
+      key: <emqx-api-key>
+      secret: <emqx-api-secret>
+expert:
+  enabled: true
+  service:
+    token: ${EXPERT_TOKEN}
+    # url is optional and defaults to https://expert.flowfuse.com/v4/expert
+  centralBroker:
+    server: expert-broker.flowfuse.com:8883   # host and port in a single string
+    ssl: true
+```
+
+- Use `expert.centralBroker.server` (a single `host:port` string). Do not use `expert.broker.address` / `expert.broker.port` here: those key names apply only to the Helm chart, which translates them internally. In a raw `flowforge.yml` they are ignored and the chat bridge is never provisioned.
+- The port must be part of the `server` value. With `ssl: true` and no port, EMQX falls back to plain `1883` and the TLS handshake is dropped.
+- The bridge is provisioned through the EMQX admin API, so the Team Broker must be enabled with valid `api` credentials. Without them the bridge cannot be created and chat receives no response.
+
 ### Kubernetes
 
 The feature is enabled by adding the tokens to the values passed to the Helm chart.

--- a/nuxt/content/handbook/engineering/ops/self-hosted-assistant.md
+++ b/nuxt/content/handbook/engineering/ops/self-hosted-assistant.md
@@ -74,8 +74,7 @@ The feature is enabled by adding the tokens to the values passed to the Helm cha
 - `forge.expert.enabled` should be set to `true`
 - `forge.expert.service.url` should be set to `https://expert.flowfuse.com/v4/expert`
 - `forge.expert.service.token` should be set to the provided Expert Token
-- `forge.expert.broker.address` should be set to `expert-broker.flowfuse.com`
-- `forge.expert.broker.port` should be set to `8883`
+- `forge.broker.teamBroker.enabled` should be set to `true` (required for Expert chat; the Team Broker requires the EMQX operator to be installed)
 
 Example:
 
@@ -91,9 +90,11 @@ forge:
      service:
        url: https://expert.flowfuse.com/v4/expert
        token: Provided-Expert-Token
-     broker:
-       address: expert-broker.flowfuse.com
-       port: 8883
+   broker:
+     teamBroker:
+       enabled: true
 ```
+
+NOTE: The Expert central broker address is configured by default, so `forge.expert.broker.address` and `forge.expert.broker.port` no longer need to be set.
 
 NOTE: For FlowFuse v2.29.0 and onward the urls (`forge.assistant.service.url` & `forge.expert.service.url`) can be omitted from the configuration as they have preset defaults

--- a/nuxt/content/handbook/engineering/ops/self-hosted-assistant.md
+++ b/nuxt/content/handbook/engineering/ops/self-hosted-assistant.md
@@ -97,6 +97,6 @@ forge:
        enabled: true
 ```
 
-NOTE: For FlowFuse Helm chart vX.Y.Z and onward the Expert central broker address is configured by default, so `forge.expert.broker.address` and `forge.expert.broker.port` no longer need to be set.
+NOTE: For FlowFuse Helm chart v2.84.0 and onward the Expert central broker address is configured by default, so `forge.expert.broker.address` and `forge.expert.broker.port` no longer need to be set.
 
 NOTE: For FlowFuse v2.29.0 and onward the urls (`forge.assistant.service.url` & `forge.expert.service.url`) can be omitted from the configuration as they have preset defaults

--- a/nuxt/content/handbook/engineering/ops/self-hosted-assistant.md
+++ b/nuxt/content/handbook/engineering/ops/self-hosted-assistant.md
@@ -71,8 +71,7 @@ expert:
     ssl: true
 ```
 
-- Use `expert.centralBroker.server` (a single `host:port` string). Do not use `expert.broker.address` / `expert.broker.port` here: those key names apply only to the Helm chart, which translates them internally. 
-- The bridge is provisioned through the EMQX admin API, so the Team Broker must be enabled with valid `api` credentials. Without them the bridge cannot be created and chat receives no response.
+- Use `expert.centralBroker.server` (a single `host:port` string). Do not use `expert.broker.address` / `expert.broker.port` here: those key names apply only to the Helm chart, which translates them internally.
 
 ### Kubernetes
 

--- a/nuxt/content/handbook/engineering/ops/self-hosted-assistant.md
+++ b/nuxt/content/handbook/engineering/ops/self-hosted-assistant.md
@@ -74,7 +74,8 @@ The feature is enabled by adding the tokens to the values passed to the Helm cha
 - `forge.expert.enabled` should be set to `true`
 - `forge.expert.service.url` should be set to `https://expert.flowfuse.com/v4/expert`
 - `forge.expert.service.token` should be set to the provided Expert Token
-- `forge.broker.teamBroker.enabled` should be set to `true` (required for Expert chat; the Team Broker requires the EMQX operator to be installed)
+- `forge.broker.enabled` should be set to `true` (the Team Broker requires the EMQX operator to be installed)
+- `forge.broker.teamBroker.enabled` should be set to `true` (required for Expert chat)
 
 Example:
 
@@ -91,10 +92,11 @@ forge:
        url: https://expert.flowfuse.com/v4/expert
        token: Provided-Expert-Token
    broker:
+     enabled: true
      teamBroker:
        enabled: true
 ```
 
-NOTE: The Expert central broker address is configured by default, so `forge.expert.broker.address` and `forge.expert.broker.port` no longer need to be set.
+NOTE: For FlowFuse Helm chart vX.Y.Z and onward the Expert central broker address is configured by default, so `forge.expert.broker.address` and `forge.expert.broker.port` no longer need to be set.
 
 NOTE: For FlowFuse v2.29.0 and onward the urls (`forge.assistant.service.url` & `forge.expert.service.url`) can be omitted from the configuration as they have preset defaults

--- a/nuxt/content/handbook/engineering/ops/self-hosted-assistant.md
+++ b/nuxt/content/handbook/engineering/ops/self-hosted-assistant.md
@@ -73,6 +73,7 @@ expert:
 
 - Use `expert.centralBroker.server` (a single `host:port` string). Do not use `expert.broker.address` / `expert.broker.port` here: those key names apply only to the Helm chart, which translates them internally.
 
+None of these changes should be made without updating to the latest release of the `docker-compose.yml` file first
 ### Kubernetes
 
 The feature is enabled by adding the tokens to the values passed to the Helm chart.

--- a/nuxt/content/handbook/engineering/ops/self-hosted-assistant.md
+++ b/nuxt/content/handbook/engineering/ops/self-hosted-assistant.md
@@ -51,29 +51,19 @@ docker compose up -d forge
 
 #### Broker configuration
 
-Expert chat is delivered over the platform's Team Broker, which bridges chat requests to the central Expert broker on FlowFuse Cloud. The latest Docker Compose template configures this for you. If you maintain a customized `flowforge.yml` inside the `docker-compose.yml` file, ensure both the `broker` and `expert` sections are present:
+Expert chat is delivered over the platform's Team Broker, which bridges chat requests to the central Expert broker on FlowFuse Cloud. The latest Docker Compose template already enables the Team Broker and pre-configures this bridge, so no changes to the compose file are needed. A valid `EXPERT_TOKEN` in `.env` is all that is required.
 
-```yaml
-broker:
-  teamBroker:
-    enabled: true
-    api:
-      url: http://broker:18083/api/v5   # your EMQX admin API endpoint
-      key: <emqx-api-key>
-      secret: <emqx-api-secret>
-expert:
-  enabled: true
-  service:
-    token: ${EXPERT_TOKEN}
-    # url is optional and defaults to https://expert.flowfuse.com/v4/expert
-  centralBroker:
-    server: expert-broker.flowfuse.com:8883   # host and port in a single string
-    ssl: true
-```
+Do not edit the broker or expert configuration inside the compose file directly. Those values are managed by the template and any manual changes are overwritten on the next upgrade.
 
-- Use `expert.centralBroker.server` (a single `host:port` string). Do not use `expert.broker.address` / `expert.broker.port` here: those key names apply only to the Helm chart, which translates them internally.
+If you need to override a default, use these `.env` variables. Leave them unset to keep the template defaults:
 
-None of these changes should be made without updating to the latest release of the `docker-compose.yml` file first
+| Variable | Purpose |
+| --- | --- |
+| `EXPERT_BROKER_SERVER` | Central Expert broker host (defaults to `expert-broker.flowfuse.com`) |
+| `BROKER_API_KEY` / `BROKER_API_SECRET` | Local EMQX admin API credentials used to provision the bridge |
+
+None of these changes should be made without updating to the latest release of the `docker-compose.yml` file first.
+
 ### Kubernetes
 
 The feature is enabled by adding the tokens to the values passed to the Helm chart.

--- a/nuxt/content/handbook/engineering/ops/self-hosted-assistant.md
+++ b/nuxt/content/handbook/engineering/ops/self-hosted-assistant.md
@@ -51,7 +51,7 @@ docker compose up -d forge
 
 #### Broker configuration
 
-Expert chat is delivered over the platform's Team Broker, which bridges chat requests to the central Expert broker on FlowFuse Cloud. The latest Docker Compose template configures this for you. If you maintain a customized `flowforge.yml`, ensure both the `broker` and `expert` sections are present:
+Expert chat is delivered over the platform's Team Broker, which bridges chat requests to the central Expert broker on FlowFuse Cloud. The latest Docker Compose template configures this for you. If you maintain a customized `flowforge.yml` inside the `docker-compose.yml` file, ensure both the `broker` and `expert` sections are present:
 
 ```yaml
 broker:
@@ -71,8 +71,7 @@ expert:
     ssl: true
 ```
 
-- Use `expert.centralBroker.server` (a single `host:port` string). Do not use `expert.broker.address` / `expert.broker.port` here: those key names apply only to the Helm chart, which translates them internally. In a raw `flowforge.yml` they are ignored and the chat bridge is never provisioned.
-- The port must be part of the `server` value. With `ssl: true` and no port, EMQX falls back to plain `1883` and the TLS handshake is dropped.
+- Use `expert.centralBroker.server` (a single `host:port` string). Do not use `expert.broker.address` / `expert.broker.port` here: those key names apply only to the Helm chart, which translates them internally. 
 - The bridge is provisioned through the EMQX admin API, so the Team Broker must be enabled with valid `api` credentials. Without them the bridge cannot be created and chat receives no response.
 
 ### Kubernetes


### PR DESCRIPTION
## Description

The self-hosted Expert handbook page documented the broker configuration only in the Kubernetes section, using `forge.expert.broker.address` / `port`. Those are Helm chart values that the chart translates internally; in a raw Docker `flowforge.yml` they are ignored, and the platform reads `expert.centralBroker.server` instead. The Docker section only covered the tokens, so a Docker user had no correct broker example to follow.

This adds a "Broker configuration" subsection under Docker showing:
- `expert.centralBroker.server` (a single `host:port` string) and `ssl: true`.
- The team broker requirement, including the `broker.teamBroker.api` credentials the bridge uses to provision itself.
- Notes that `broker.address`/`port` are Helm-only, and that the port must be part of the `server` value (with `ssl: true`, omitting it drops EMQX to plain 1883 and the handshake fails).

The Kubernetes section is unchanged (its keys are correct for Helm).