### PR TITLE
OPC UA docs: document stopping and changing monitored items

### DIFF
--- a/src/node-red/flowfuse/edge/opcua.md
+++ b/src/node-red/flowfuse/edge/opcua.md
@@ -469,6 +469,8 @@ Each notification carries `msg.sequenceNumber`. Watch it for gaps to detect drop
 - **Named JSON structure**, inject a JSON object whose leaf values are NodeIds (the shape Explore produces); notifications arrive in the same shape with current readings.
 - **Entire subtree**, use Explore once (output type `NodeId`) to discover all variables under a branch, then feed that structure into Monitor to watch them all live.
 
+In every injected mode the set you inject replaces the previous one. See [Changing or stopping what is monitored](#changing-or-stopping-what-is-monitored) to add, remove, or stop monitored items at runtime.
+
 ### Message properties (override node config per message)
 
 - `msg.outputType`, `Value` or `DataValue`.
@@ -495,6 +497,26 @@ msg.payload = [
 ```
 
 All items in the array share one subscription, sampling interval, and queue, more efficient than one Monitor node per variable. As a rough guide: under 10 items is trivial, 10–100 is the efficient sweet spot, 100–1000 may need tuned subscription parameters, and beyond 1000 split the work across multiple Monitor nodes.
+
+### Changing or stopping what is monitored
+
+The injected NodeId set is declarative: whatever you inject becomes the complete set of monitored items, replacing whatever was monitored before. The node has no separate stop or unsubscribe command because you do not need one, you change the set instead.
+
+- **Reduce the set**, inject a shorter array. The dropped NodeIds are released as monitored items on the server, not merely filtered out of the node's output.
+- **Stop monitoring**, inject an empty array (`[]`). Every monitored item is released and the node stops emitting.
+- **Restart monitoring**, inject the NodeId array again. The subscription itself persists while empty, which costs almost nothing and makes restarting immediate.
+
+This is how you start and stop monitoring programmatically, from an Inject node or a dashboard control, without editing and redeploying the flow.
+
+Example, stop monitoring:
+
+```js
+msg.payload = [];
+```
+
+{% note %}
+Injecting an empty array releases the monitored items but leaves the now-empty subscription in place on the connection, so it is the right way to pause and resume a stream. To tear the session down completely, disconnect the connection instead.
+{% endnote %}
 
 ### Deadband filtering
 

--- a/src/node-red/flowfuse/edge/opcua.md
+++ b/src/node-red/flowfuse/edge/opcua.md
@@ -469,7 +469,7 @@ Each notification carries `msg.sequenceNumber`. Watch it for gaps to detect drop
 - **Named JSON structure**, inject a JSON object whose leaf values are NodeIds (the shape Explore produces); notifications arrive in the same shape with current readings.
 - **Entire subtree**, use Explore once (output type `NodeId`) to discover all variables under a branch, then feed that structure into Monitor to watch them all live.
 
-In every injected mode the set you inject replaces the previous one. See [Changing or stopping what is monitored](#changing-or-stopping-what-is-monitored) to add, remove, or stop monitored items at runtime.
+In the array and named-structure modes, the set you inject replaces the previous one. See [Changing or stopping what is monitored](#changing-or-stopping-what-is-monitored) to add, remove, or stop monitored items at runtime.
 
 ### Message properties (override node config per message)
 
@@ -503,7 +503,7 @@ All items in the array share one subscription, sampling interval, and queue, mor
 The injected NodeId set is declarative: whatever you inject becomes the complete set of monitored items, replacing whatever was monitored before. The node has no separate stop or unsubscribe command because you do not need one, you change the set instead.
 
 - **Reduce the set**, inject a shorter array. The dropped NodeIds are released as monitored items on the server, not merely filtered out of the node's output.
-- **Stop monitoring**, inject an empty array (`[]`). Every monitored item is released and the node stops emitting.
+- **Stop monitoring**, inject an empty array (`[]`), or an empty object (`{}`) if you are injecting the named JSON structure. Every monitored item is released and the node stops emitting.
 - **Restart monitoring**, inject the NodeId array again. The subscription itself persists while empty, which costs almost nothing and makes restarting immediate.
 
 This is how you start and stop monitoring programmatically, from an Inject node or a dashboard control, without editing and redeploying the flow.


### PR DESCRIPTION
## Description

Documents how to stop and change what the certified OPC UA **Monitor** node is monitoring, at runtime.

The Monitor node's injected NodeId set is declarative: whatever you inject becomes the complete monitored set, replacing whatever was monitored before. So injecting a shorter array releases the dropped items server-side, and injecting an empty array (`[]`) stops monitoring entirely and can be restarted by re-injecting.

None of that was documented. The **Modes** section explains how to inject a single NodeId, an array, or a named JSON structure, but never says the injected set replaces the previous one, so there was no way for a reader to discover that stopping is possible at all. Someone looking for a stop or unsubscribe control finds nothing and reasonably concludes the node cannot do it.

This adds a `Changing or stopping what is monitored` subsection under `10. Monitor`, plus a one-line pointer to it from the end of `Modes`, where that reader lands first.

### Why this came up

A customer evaluating the certified node against `node-red-contrib-opcua` filed this as a missing feature ("needed unsubscribe capability in new node"). It is not missing, it is undocumented.

### Verification

Measured against `@flowfuse-certified-nodes/opcua@3.38.1` (current release, matches the latest tag on `FlowFuse/ffcn-opcua`), driving a 6 tag simulator instrumented to report live server-side counts from `server.engine._sessions` → `publishEngine.subscriptions` → `sub.monitoredItemCount`. Injection is on `msg.payload` throughout.

Array mode:

| Step | Injected | Server-side monitored items | Node output |
|---|---|---|---|
| Baseline | nothing | 0 | silent |
| Subscribe | 3 NodeIds | 3 | emitting |
| Shrink | 1 of those 3 | 1 | emitting |
| Stop | `[]` | 0 | silent for 13s while sim still churning |
| Restart | the same 3 | 3 | resumes immediately |
| Grow | all 6 (superset) | 6 | emitting |
| Reset | first 3 | 3 | emitting |
| **Disjoint swap** | **the other 3** | **3, not 6** | **emitting** |

The disjoint swap is the decisive one: replace predicts 3 monitored items, merge predicts 6. It measured 3. Payload identity agrees, not just the count. The two sets have distinct type signatures, so the emitted array shape flips from `[Double, Boolean, Double]` to `[Int32, Double, Boolean]` and back as the sets are swapped, confirming the node streams only the newly injected set.

Named JSON structure mode behaves the same way:

| Step | Injected | Server-side monitored items |
|---|---|---|
| Subscribe | object with 2 NodeId leaves | 2 |
| Shrink | object with 1 leaf | 1 |
| Stop | `{}` | 0 |

So the release is genuinely server-side rather than output filtering, and it is consistent across both set-valued inject modes. Throughout, the subscription object itself persists while empty (`subscriptions: 1`, `monitoredItems: 0`), which is what makes the restart immediate.

I scoped the `Modes` pointer to the array and named-structure modes, since those are the two I measured. Single-variable mode via `msg.nodeId` is scalar, so "the set replaces the previous one" does not really apply to it.

## Related Issue(s)

None, raised directly from customer feedback.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass <!-- n/a, documentation only -->
 - [x] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created <!-- n/a, not a blog PR -->
