### PR TITLE
Handbook: order Commercial Organization left-nav

### DIFF
--- a/nuxt/content/handbook/sales/commission-plan/.navigation.yml
+++ b/nuxt/content/handbook/sales/commission-plan/.navigation.yml
@@ -1,3 +1,4 @@
 title: "Sales Compensation Plan"
 navigation:
+  order: 18
   icon: i-lucide-dollar-sign

--- a/nuxt/content/handbook/sales/customer-success.md
+++ b/nuxt/content/handbook/sales/customer-success.md
@@ -1,5 +1,7 @@
 ---
 title: "Customer Success"
+navigation:
+  order: 3
 ---
 
 # Customer Success

--- a/nuxt/content/handbook/sales/dashboard-v2.md
+++ b/nuxt/content/handbook/sales/dashboard-v2.md
@@ -1,5 +1,7 @@
 ---
 title: "Self Hosted Dashboard v2 Multi User"
+navigation:
+  order: 16
 ---
 
 # Self Hosted Dashboard v2 Multi User Plugin

--- a/nuxt/content/handbook/sales/edge-connect-process.md
+++ b/nuxt/content/handbook/sales/edge-connect-process.md
@@ -1,5 +1,7 @@
 ---
 title: "Edge Connectivity Sales Process"
+navigation:
+  order: 15
 ---
 
 # Edge Connectivity Sales Process

--- a/nuxt/content/handbook/sales/engagements.md
+++ b/nuxt/content/handbook/sales/engagements.md
@@ -1,5 +1,7 @@
 ---
 title: "Engagements & Pricing"
+navigation:
+  order: 10
 ---
 
 # Engagements

--- a/nuxt/content/handbook/sales/forecast-review.md
+++ b/nuxt/content/handbook/sales/forecast-review.md
@@ -1,5 +1,7 @@
 ---
 title: "Forecast Review"
+navigation:
+  order: 11
 ---
 
 # Forecast Review

--- a/nuxt/content/handbook/sales/hubspot.md
+++ b/nuxt/content/handbook/sales/hubspot.md
@@ -1,5 +1,7 @@
 ---
 title: "HubSpot"
+navigation:
+  order: 12
 ---
 
 We use [HubSpot](https://www.hubspot.com/) to track and manage all of our customer interactions.

--- a/nuxt/content/handbook/sales/legal.md
+++ b/nuxt/content/handbook/sales/legal.md
@@ -1,5 +1,7 @@
 ---
 title: "Legal"
+navigation:
+  order: 17
 ---
 
 # Legal

--- a/nuxt/content/handbook/sales/meetings/.navigation.yml
+++ b/nuxt/content/handbook/sales/meetings/.navigation.yml
@@ -1,3 +1,4 @@
 title: "Sales Meetings"
 navigation:
+  order: 9
   icon: i-lucide-calendar

--- a/nuxt/content/handbook/sales/operating-principles.md
+++ b/nuxt/content/handbook/sales/operating-principles.md
@@ -1,5 +1,7 @@
 ---
 title: "Sales Team Operating Principles"
+navigation:
+  order: 6
 description: "Professional standards and expectations for the FlowFuse Sales organization."
 ---
 

--- a/nuxt/content/handbook/sales/partnerships.md
+++ b/nuxt/content/handbook/sales/partnerships.md
@@ -1,5 +1,7 @@
 ---
 title: "Partnerships"
+navigation:
+  order: 5
 ---
 
 # Partnerships

--- a/nuxt/content/handbook/sales/pricing-decks.md
+++ b/nuxt/content/handbook/sales/pricing-decks.md
@@ -1,5 +1,7 @@
 ---
 title: "Pricing Decks"
+navigation:
+  order: 14
 ---
 
 # Pricing Decks

--- a/nuxt/content/handbook/sales/processes/.navigation.yml
+++ b/nuxt/content/handbook/sales/processes/.navigation.yml
@@ -1,3 +1,4 @@
 title: Processes
 navigation:
+  order: 8
   icon: i-lucide-workflow

--- a/nuxt/content/handbook/sales/professional-services.md
+++ b/nuxt/content/handbook/sales/professional-services.md
@@ -1,5 +1,7 @@
 ---
 title: "Professional Services"
+navigation:
+  order: 4
 ---
 
 FlowFuse offers Professional Services (PS) to help customers deliver work that

--- a/nuxt/content/handbook/sales/regions.md
+++ b/nuxt/content/handbook/sales/regions.md
@@ -1,5 +1,7 @@
 ---
 title: "Sales Regions"
+navigation:
+  order: 7
 ---
 
 We manage our sales opportunities across three primary sales regions:

--- a/nuxt/content/handbook/sales/sales-deck.md
+++ b/nuxt/content/handbook/sales/sales-deck.md
@@ -1,5 +1,7 @@
 ---
 title: "Sales Deck"
+navigation:
+  order: 13
 ---
 
 # Sales Deck

--- a/nuxt/content/handbook/sales/sales-team.md
+++ b/nuxt/content/handbook/sales/sales-team.md
@@ -1,5 +1,7 @@
 ---
 title: "Sales"
+navigation:
+  order: 1
 ---
 
 # Sales

--- a/nuxt/content/handbook/sales/subscription-agreement-1.5.md
+++ b/nuxt/content/handbook/sales/subscription-agreement-1.5.md
@@ -1,6 +1,8 @@
 ---
 # Note: Do not delete this file. It's still referenced in contracts and quotes.
 title: "Subscription Agreement 1.5"
+navigation:
+  order: 19
 ---
 
 Below is the FlowFuse subscription agreement that applies to Team and Enterprise tier customers buying annual subscriptions. If you'd like to make alterations for your organization, please download the .docx file in the following form and initiate the legal part of the negotiation through your account executive.


### PR DESCRIPTION
## What

Orders the pages in the **Commercial Organization** handbook section's left nav. Previously they listed **alphabetically** — `HandbookLeftNav` sorts by `navigation.order` and falls back to `path.localeCompare` when it's absent — which buried the **Sales** function page and interleaved the five functions with supporting/reference pages.

Sets an explicit `navigation.order` on each page (and on the `processes`, `meetings`, and `commission-plan` section `.navigation.yml` files). New order — **functions (lifecycle) → how we work → assets → legal/comp**:

| # | Page | # | Page |
|---|------|---|------|
| 1 | Sales | 10 | Engagements & Pricing |
| *(2)* | *reserved for Solution Engineering (Phase 2)* | 11 | Forecast Review |
| 3 | Customer Success | 12 | HubSpot |
| 4 | Professional Services | 13 | Sales Deck |
| 5 | Sales Partnerships | 14 | Pricing Decks |
| 6 | Operating Principles | 15 | Edge Connect Process |
| 7 | Regions | 16 | Dashboard v2 |
| 8 | Processes | 17 | Legal |
| 9 | Meetings | 18 | Compensation Plan |
|   |  | 19 | Subscription Agreement |

## Approach note

The first revision of this PR tried numeric **filename prefixes** (`01.sales-team.md`). CI caught that this @nuxt/content setup does **not** strip the prefix from the route — nav links became `/handbook/sales/01.sales-team/` and 404'd. Reverted. This revision uses the codebase's actual ordering knob — the `navigation.order` frontmatter field (declared in `content.config.ts`, read by `HandbookLeftNav`, already used by `recent-changes.md`). **Filenames and URLs are unchanged.**

Slot `2` is intentionally left open for the new Solution Engineering page in the next PR (Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)