### PR TITLE
Put By Industry ahead of By Use Case under Solutions

### DIFF
--- a/src/_data/chrome.json
+++ b/src/_data/chrome.json
@@ -114,31 +114,9 @@
                 "label": "Solutions",
                 "columns": [
                     {
-                        "title": "By Use Case",
-                        "titleGrid": "xl:col-start-2 xl:row-start-1",
-                        "listClasses": "row-span-3 xl:col-start-2 xl:row-start-2",
-                        "links": [
-                            {
-                                "label": "Production Monitoring",
-                                "href": "/use-cases/production-monitoring/",
-                                "icon": "pulse"
-                            },
-                            {
-                                "label": "Shop Floor Communication",
-                                "href": "/use-cases/shop-floor-communication/",
-                                "icon": "chat"
-                            },
-                            {
-                                "label": "See all use cases",
-                                "href": "/use-cases/",
-                                "icon": "arrow-right"
-                            }
-                        ]
-                    },
-                    {
                         "title": "By Industry",
-                        "titleGrid": "md:col-start-2 md:row-start-1 xl:col-start-3",
-                        "listClasses": "row-span-[9] md:col-start-2 md:row-start-2 xl:col-start-3",
+                        "titleGrid": "xl:col-start-2 xl:row-start-1",
+                        "listClasses": "row-span-[9] xl:col-start-2 xl:row-start-2",
                         "links": [
                             {
                                 "label": "Automotive",
@@ -183,6 +161,28 @@
                             {
                                 "label": "See all industries",
                                 "href": "/industries/",
+                                "icon": "arrow-right"
+                            }
+                        ]
+                    },
+                    {
+                        "title": "By Use Case",
+                        "titleGrid": "md:col-start-2 md:row-start-1 xl:col-start-3",
+                        "listClasses": "row-span-3 md:col-start-2 md:row-start-2 xl:col-start-3",
+                        "links": [
+                            {
+                                "label": "Production Monitoring",
+                                "href": "/use-cases/production-monitoring/",
+                                "icon": "pulse"
+                            },
+                            {
+                                "label": "Shop Floor Communication",
+                                "href": "/use-cases/shop-floor-communication/",
+                                "icon": "chat"
+                            },
+                            {
+                                "label": "See all use cases",
+                                "href": "/use-cases/",
                                 "icon": "arrow-right"
                             }
                         ]
@@ -505,23 +505,6 @@
                 "gridClasses": "grid grid-cols-2 sm:grid-cols-3 gap-x-8 gap-y-8",
                 "groups": [
                     {
-                        "title": "By Use Case",
-                        "links": [
-                            {
-                                "label": "Production Monitoring",
-                                "href": "/use-cases/production-monitoring/"
-                            },
-                            {
-                                "label": "Shop Floor Communication",
-                                "href": "/use-cases/shop-floor-communication/"
-                            },
-                            {
-                                "label": "See all use cases",
-                                "href": "/use-cases/"
-                            }
-                        ]
-                    },
-                    {
                         "title": "By Industry",
                         "links": [
                             {
@@ -559,6 +542,23 @@
                             {
                                 "label": "See all industries",
                                 "href": "/industries/"
+                            }
+                        ]
+                    },
+                    {
+                        "title": "By Use Case",
+                        "links": [
+                            {
+                                "label": "Production Monitoring",
+                                "href": "/use-cases/production-monitoring/"
+                            },
+                            {
+                                "label": "Shop Floor Communication",
+                                "href": "/use-cases/shop-floor-communication/"
+                            },
+                            {
+                                "label": "See all use cases",
+                                "href": "/use-cases/"
                             }
                         ]
                     },


### PR DESCRIPTION
## Description

Swaps the **By Industry** and **By Use Case** columns under Solutions, so Industry comes first. Applied in the top nav mega panel and the footer's Solutions section, on both the 11ty templates and the Nuxt components.

Above 860px the stylesheet places the mega panel's category groups by DOM order with `!important`, so source order drives the visual order. Between 768 and 859px the markup's `col-start` utilities are still in play, so the slot tokens move with the groups; each group keeps its own `row-span`. The footer columns are plain auto-flow divs, so there the source order is the whole change.

No links added or removed — the `href` set is byte-identical on all three files.

## Related Issue(s)

None.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))
