### PR TITLE
Correct two stale comments in the docs sync

### DIFF
--- a/nuxt/lib/docs-sync.mjs
+++ b/nuxt/lib/docs-sync.mjs
@@ -15,7 +15,8 @@ const CLONE_BACKOFF_MS = 2000
 
 // Whatever checkout sits next to the website repo wins. CI puts the flowfuse repo there,
 // so a build validates the docs of the caller's checkout rather than whatever main
-// happens to be. The release pipeline depends on this.
+// happens to be. The `Test Documentation with website` job in FlowFuse/flowfuse checks
+// both repos out side by side and relies on this.
 const SIBLING_PATHS = ['../dev-env/packages/flowfuse', '../flowfuse', '../flowforge']
 
 export const MANIFEST_FILE = '.source.json'

--- a/scripts/sync_docs.mjs
+++ b/scripts/sync_docs.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-// Populates nuxt/content/docs outside of a Nuxt build, so CI can commit the result as a
-// snapshot. Uses only node builtins: this runs before `npm install`.
+// Populates nuxt/content/docs outside of a Nuxt build, so CI can resolve the docs before
+// installing dependencies. Uses only node builtins: this runs before `npm install`.
 
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'


### PR DESCRIPTION
## Description

Comments only, no behaviour change. Both were left inaccurate by #5473.

`nuxt/lib/docs-sync.mjs` said the sibling-checkout precedence exists because "the release
pipeline depends on this". It does not: releases are cut by `release-publish.yml` in
FlowFuse/flowfuse, which builds and npm-publishes and never touches docs or the website.
What actually relies on sibling resolution is the `Test Documentation with website` job,
which checks both repos out side by side. The old wording reads as though docs publishing
were part of the release pipeline.

`scripts/sync_docs.mjs` said it exists "so CI can commit the result as a snapshot".
#5473 removed the snapshot. It now runs so CI can resolve the docs before `npm install`.

## Related Issue(s)

None.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))
