### PR TITLE
Handbook: Commercial Organization Phase 2 — function pages

### DIFF
--- a/nuxt/content/handbook/sales/customer-success.md
+++ b/nuxt/content/handbook/sales/customer-success.md
@@ -6,6 +6,12 @@ navigation:
 
 # Customer Success
 
+The Customer Success function owns the customer relationship after the commercial
+close: onboarding, adoption, renewals, and expansion. The **Customer Success
+Manager (CSM)** is the role within Customer Success, accountable for account
+health and for the value customers realize from FlowFuse — measured by customer
+outcomes, not just retention.
+
 FlowFuse CSMs are to drive adoption and expansion within accounts. Customers
 should be provided help and support to connect their assets, build applications
 for their organisation, and automate workflows. To do so, a playbook is created

--- a/nuxt/content/handbook/sales/index.md
+++ b/nuxt/content/handbook/sales/index.md
@@ -20,9 +20,9 @@ lifecycle:
 
 - **[Sales](./sales-team.md)** — Identify, qualify, and convert opportunities
   into customers; own the commercial process through close and expansion.
-- **Solution Engineering** — Serve as technical advisors across the lifecycle:
-  discovery, tailored demos, proof-of-value evaluations, onboarding, and
-  architecture guidance. _(Dedicated page coming soon.)_
+- **[Solution Engineering](./solution-engineering.md)** — Serve as technical
+  advisors across the lifecycle: discovery, tailored demos, proof-of-value
+  evaluations, onboarding, and architecture guidance.
 - **[Customer Success](./customer-success.md)** — Own onboarding, adoption,
   renewals, and expansion; measured by customer outcomes, not just retention.
 - **[Professional Services](./professional-services.md)** — Deliver scoped,
@@ -56,7 +56,7 @@ Each function is accountable for a specific phase of the customer journey:
 | Function | Primary focus |
 |----------|---------------|
 | **[Sales](./sales-team.md)** | New business, opportunity qualification, demos, proposals, closing new and expansion ARR |
-| **Solution Engineering** | Technical discovery, demos, proofs of value, onboarding, architecture and expansion advisory |
+| **[Solution Engineering](./solution-engineering.md)** | Technical discovery, demos, proofs of value, onboarding, architecture and expansion advisory |
 | **[Customer Success](./customer-success.md)** | Onboarding, adoption, renewals, advocacy, and driving account health and growth |
 | **[Sales Partnerships](./partnerships.md)** | Reseller, referrer, and system-integrator motions; partner enablement |
 | **[Professional Services](./professional-services.md)** | Scoped implementation, integration, and enablement services |

--- a/nuxt/content/handbook/sales/partnerships.md
+++ b/nuxt/content/handbook/sales/partnerships.md
@@ -6,6 +6,11 @@ navigation:
 
 # Partnerships
 
+The Sales Partnerships function extends FlowFuse's reach through resellers,
+referrers, and system integrators. Partner-led and co-sell motions grow pipeline
+and revenue beyond the direct team, and the function owns partner enablement and
+the commercial terms that govern those relationships.
+
 FlowFuse engages with both hardware parters and referral partners. Here are [our standard terms](https://docs.google.com/document/d/1BVls7LEC1CBQ6wlrb8GeWSYr2vj9fMqgdsWiWLoQZOY/edit#heading=h.gjdgxs).
 
 ## Reseller Agreement

--- a/nuxt/content/handbook/sales/professional-services.md
+++ b/nuxt/content/handbook/sales/professional-services.md
@@ -4,6 +4,13 @@ navigation:
   order: 4
 ---
 
+# Professional Services
+
+The Professional Services function delivers scoped, high-impact engagements that
+accelerate implementation and time-to-value beyond standard product support. Work
+is captured in a Statement of Work (SoW), separate from the subscription, and
+owned end-to-end by the person who delivers it.
+
 FlowFuse offers Professional Services (PS) to help customers deliver work that
 goes beyond standard product support, such as migrations, integrations, and
 solution builds. PS is scoped and captured in a Statement of Work (SoW),

--- a/nuxt/content/handbook/sales/solution-engineering.md
+++ b/nuxt/content/handbook/sales/solution-engineering.md
@@ -1,0 +1,93 @@
+---
+title: "Solution Engineering"
+navigation:
+  order: 2
+---
+
+# Solution Engineering
+
+The Solution Engineering function is the technical backbone of the Commercial
+Organization. Solution Engineers (SEs) act as trusted technical advisors across
+the customer lifecycle — from first technical conversation through discovery,
+tailored demos, proof-of-value evaluations, onboarding, and ongoing architecture
+guidance. Where the Account Executive owns the commercial outcome, the Solution
+Engineer owns technical credibility and the customer's confidence that FlowFuse
+will work in their environment.
+
+## Purpose
+
+Solution Engineers are responsible for demonstrating, validating, and de-risking
+the technical fit of FlowFuse for each customer. They translate customer
+requirements into a solution the customer can trust, and they carry that
+technical context forward so nothing is lost between the sale and delivery.
+
+SEs are not a demo function. They are accountable for the technical outcomes that
+underpin a commercial decision: that the customer understands how FlowFuse
+addresses their problem, that a proof of value proves the right thing, and that
+the proposed architecture will stand up in production.
+
+---
+
+## Scope and Responsibilities
+
+Solution Engineers own:
+
+- Technical discovery and requirements gathering alongside the Account Executive
+- Tailored demos mapped to the customer's use case, not a generic script
+- Proof-of-value (PoV) and proof-of-concept (PoC) design, delivery, and success criteria
+- Architecture and integration guidance, including deployment topology and security posture
+- Technical objection handling and competitive differentiation
+- Onboarding and technical handoff to Customer Success and Professional Services
+- Expansion advisory — surfacing new technical use cases within existing accounts
+
+SEs are accountable for **technical fit and credibility**, working in close
+partnership with the Account Executive who owns the commercial outcome.
+
+---
+
+## Collaboration Model
+
+Solution Engineers operate across the Commercial Organization:
+
+- **Sales**
+  Partner with the Account Executive on discovery, demos, and PoV scope; provide
+  the technical assessment that informs deal qualification and progression.
+
+- **Customer Success**
+  Hand off technical context at close so onboarding starts from what was learned
+  during the sale, not from scratch.
+
+- **Professional Services**
+  Flag where scoped delivery is needed and feed technical requirements into SoW
+  scoping (see [Professional Services](/handbook/sales/professional-services/)).
+
+- **Product & Engineering**
+  Carry field feedback back into the product, and validate that proposed
+  solutions match current and roadmap capability.
+
+While SEs lead on technical direction, the **Account Executive remains
+accountable** for opportunity progression and commercial decisions.
+
+---
+
+## Metrics and Accountability
+
+Solution Engineering performance is measured by:
+
+- Technical win rate on evaluated opportunities
+- PoV / PoC success rate against agreed criteria
+- Technical influence on pipeline progression and stage conversion
+- Quality of handoff to Customer Success and Professional Services
+- Time-to-value from first technical engagement to validated fit
+
+---
+
+## How This Page Is Used
+
+This page defines **what Solution Engineers own**. Detailed guidance on *how* SEs
+execute lives in the process and meeting pages:
+
+- [Sales Meetings](/handbook/sales/meetings/) — [Discovery](/handbook/sales/meetings/discovery/), [Demo](/handbook/sales/meetings/demo/), [PoC](/handbook/sales/meetings/poc/)
+- [Processes](/handbook/sales/processes/) — the process and methodology index
+
+This separation keeps ownership clear and execution flexible.


### PR DESCRIPTION
Phase 2 of the Commercial Organization handbook restructure (follows #5467 spine, #5490 nav order).

## Changes
- **New Solution Engineering page** (`solution-engineering.md`, `navigation.order: 2`) — the reserved SE slot in the left-nav, modeled on the existing `sales-team.md` function page (Purpose, Scope & Responsibilities, Collaboration Model, Metrics, How this page is used).
- **Index updated** — the "Solution Engineering" entries in the *What we do* list and the org-structure table are now links; the "coming soon" markers are removed.
- **Mandate intros** added to Customer Success, Professional Services, and Partnerships, framing each as a Commercial Organization function in the same voice as the Sales page. Professional Services also gains its missing `# Professional Services` H1.

## Notes
- URLs unchanged — pages stay under `/handbook/sales/`.
- All internal links verified against existing files; section-index links use folder URLs (no `/index.md`), per the CI link-checker convention.
- No numeric filename prefixes (route-breaking in this @nuxt/content setup); ordering is via `navigation.order`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)