### PR TITLE
fix(deps): pin comark to registry 0.3.2 instead of ephemeral pkg.pr.new preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11213,8 +11213,8 @@
         },
         "node_modules/comark": {
             "version": "0.3.2",
-            "resolved": "https://pkg.pr.new/comark@83a427d",
-            "integrity": "sha512-0TomeebOQ3O99dKr36LmJ/3VI5D8JNXJoYlTRAhbDRDZCIJ8pUsh5dy1YjxcRDVXrBZY5Fv/YSkg3oNqeAtiQw==",
+            "resolved": "https://registry.npmjs.org/comark/-/comark-0.3.2.tgz",
+            "integrity": "sha512-wZ16V3PPItX49EScg6yDswqQ24bsMAhujZUGIf1dBKMmZjqGBa4HmXDe+WZNeqNQSOd8v4AJJT1NKyrvgdf3dA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
         "vanilla-cookieconsent": "^3.0.0"
     },
     "overrides": {
+        "comark": "0.3.2",
         "yaml": ">=1.10.3",
         "simple-update-notifier": {
             "semver": ">=7.5.2"


### PR DESCRIPTION
## TL;DR

`main` CI (the **Tests** / `test_website` job) can fail at `npm install` for **any** commit, because a transitive dependency resolves to an ephemeral `pkg.pr.new` preview build whose availability is intermittent. This pins it to the equivalent published npm release. @ZJvandeWeg — flagging you since this comes from the `nuxt-studio` integration in #5204.

## Diagnosis

The Tests job died here (seen on the #5496 run, `test_website`):

```
npm error code E404
npm error 404 Not Found - GET https://pkg.pr.new/comark@83a427d
```

- `comark` is a **transitive** dependency of `nuxt-studio@1.7.0` — the vendored local tarball at `nuxt/.local-packages/nuxt-studio-1.7.0.tgz`, whose internal `package.json` declares `"comark": "https://pkg.pr.new/comark@83a427d"`.
- `pkg.pr.new` serves **continuous preview releases** built per-commit. Those builds are not permanent artifacts — availability is intermittent (cold storage / rate limiting). At the time #5496's Tests job ran, `comark@83a427d` returned **404**, so `npm install` aborted before a single page was rendered. Rechecked later, the same URL returned **200** — i.e. it's a coin-flip, not a permanent outage. That's why earlier commits (#5484, #5493) went green and #5496 didn't: **it's time-of-run dependent, not commit dependent.**
- The pin was introduced in #5204 (2026-06-15, `nuxt-studio` feature-branch publish strategy). It is unrelated to any content change — the merge that surfaced it (#5496) touched only handbook markdown.
- Only the job that runs `npm install` against that URL is affected; **Build Site** and **SAST** were green on the same commit.

## Fix

Add an npm `overrides` entry pinning `comark` to the published registry release **`0.3.2`**:

```json
"overrides": {
    "comark": "0.3.2",
    ...
}
```

**Why `0.3.2` specifically —** I pulled the preview tarball down and read its own `package.json`: `83a427d` **is** comark `0.3.2` (same `dependencies`, `peerDependencies`, and `peerDependenciesMeta` as the registry `0.3.2`, verified field-by-field). So this is a like-for-like swap — identical version, reliable source — with **no API-drift risk**, not a version bump.

The lockfile change is the minimal two-field update on the `node_modules/comark` entry (`resolved` + `integrity` → registry). I verified `npm install --package-lock-only` is a **no-op** against the result (lockfile is consistent with `package.json` + the override, so `npm ci` will accept it), and a clean full regen produces the same comark resolution. The vendored tarball is untouched, and npm intentionally keeps nuxt-studio's declared URL spec in the tree — the override redirects resolution to the registry.

## Diff
- `package.json` — one override line
- `package-lock.json` — `comark` `resolved` + `integrity` now point at `registry.npmjs.org` (tarball confirmed reachable, integrity matches)

## For your call, @ZJvandeWeg
This unblocks CI now. Longer term you may prefer to **repin `comark` inside the `nuxt-studio` package itself** (so the vendored tarball no longer references `pkg.pr.new` at all) and re-vendor it — this override is the low-risk, reviewable stopgap. Happy to do that follow-up if you'd rather fix it at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)