### PR TITLE
Handbook: Commercial Organization Phase 3 — supporting pages

### DIFF
--- a/nuxt/content/handbook/sales/commission-plan/.navigation.yml
+++ b/nuxt/content/handbook/sales/commission-plan/.navigation.yml
@@ -1,4 +1,4 @@
 title: "Sales Compensation Plan"
 navigation:
-  order: 18
+  order: 22
   icon: i-lucide-dollar-sign

--- a/nuxt/content/handbook/sales/customer-journey.md
+++ b/nuxt/content/handbook/sales/customer-journey.md
@@ -1,0 +1,43 @@
+---
+title: "Customer Journey Alignment"
+navigation:
+  order: 10
+---
+
+# Customer Journey Alignment
+
+The Commercial Organization coordinates across functions to guide prospects and
+customers through the entire lifecycle — from first awareness to long-term
+success. A shared understanding of the journey keeps us delivering the right
+value at the right time, with clear ownership at every stage.
+
+## Lifecycle stages
+
+| Stage | What it means | Primary owners |
+| --- | --- | --- |
+| **1. Identified / Node-RED awareness** | ICP account or contact identified via inbound interest or outbound targeting; prospect is exploring or already using Node-RED. | Partnerships, Marketing, Sales |
+| **2. FlowFuse awareness** | Prospect becomes aware of FlowFuse as a way to operationalize and scale Node-RED — a webinar, content, or the website. | Partnerships, Marketing, Sales |
+| **3. Interested** | Prospect engages with Sales; early discovery is underway to understand business and technical context. | Sales, Solution Engineering |
+| **4. Considering** | Technical evaluation or trial phase — demos, PoVs, and security or procurement reviews. | Sales, Solution Engineering |
+| **5. Selection** | Prospect agrees FlowFuse is the preferred solution; commercial terms are finalized. | Sales |
+| **6. Purchase** | Customer completes the first transaction and begins onboarding; handoff to Customer Success and Solution Engineering. | Customer Success, Solution Engineering |
+| **7. Onboarding / adoption** | Customer is live in production; focus shifts to expansion, integration, and operational maturity. | Customer Success, Solution Engineering, Professional Services |
+| **8. Advocacy** | Customer is realizing strong value and may join case studies, referrals, or roadmap feedback. | Customer Success, Partnerships, Marketing |
+
+## Cross-team coordination
+
+Each stage has defined entry and exit criteria and internal coordination
+touchpoints, so that:
+
+- Handoffs between Sales, Solution Engineering, and Customer Success are smooth.
+- Account status and maturity are visible across functions.
+- The right stakeholders from each function engage at the right time.
+
+---
+
+For how each function maps to these stages, see the function pages —
+[Sales](/handbook/sales/sales-team/),
+[Solution Engineering](/handbook/sales/solution-engineering/),
+[Customer Success](/handbook/sales/customer-success/),
+[Professional Services](/handbook/sales/professional-services/), and
+[Sales Partnerships](/handbook/sales/partnerships/).

--- a/nuxt/content/handbook/sales/dashboard-v2.md
+++ b/nuxt/content/handbook/sales/dashboard-v2.md
@@ -1,7 +1,7 @@
 ---
 title: "Self Hosted Dashboard v2 Multi User"
 navigation:
-  order: 16
+  order: 20
 ---
 
 # Self Hosted Dashboard v2 Multi User Plugin

--- a/nuxt/content/handbook/sales/edge-connect-process.md
+++ b/nuxt/content/handbook/sales/edge-connect-process.md
@@ -1,7 +1,7 @@
 ---
 title: "Edge Connectivity Sales Process"
 navigation:
-  order: 15
+  order: 19
 ---
 
 # Edge Connectivity Sales Process

--- a/nuxt/content/handbook/sales/engagements.md
+++ b/nuxt/content/handbook/sales/engagements.md
@@ -1,7 +1,7 @@
 ---
 title: "Engagements & Pricing"
 navigation:
-  order: 10
+  order: 14
 ---
 
 # Engagements

--- a/nuxt/content/handbook/sales/forecast-review.md
+++ b/nuxt/content/handbook/sales/forecast-review.md
@@ -1,7 +1,7 @@
 ---
 title: "Forecast Review"
 navigation:
-  order: 11
+  order: 15
 ---
 
 # Forecast Review

--- a/nuxt/content/handbook/sales/hubspot.md
+++ b/nuxt/content/handbook/sales/hubspot.md
@@ -1,7 +1,7 @@
 ---
 title: "HubSpot"
 navigation:
-  order: 12
+  order: 16
 ---
 
 We use [HubSpot](https://www.hubspot.com/) to track and manage all of our customer interactions.

--- a/nuxt/content/handbook/sales/index.md
+++ b/nuxt/content/handbook/sales/index.md
@@ -70,8 +70,8 @@ rules.
 
 ## How we work
 
-- [Sales Team Operating Principles](./operating-principles.md)
-- [Working Norms](./working-norms.md) — how we communicate and collaborate
+- [Commercial Team Operating Principles](./operating-principles.md) — individual conduct standards
+- [Working Norms](./working-norms.md) — meeting cadence and escalation routing
 - [Customer Journey Alignment](./customer-journey.md) — lifecycle stages and ownership
 - [Systems & Tools](./tools.md) — the commercial tech stack
 - [Onboarding & Development](./onboarding.md) — ramping and growing the team

--- a/nuxt/content/handbook/sales/index.md
+++ b/nuxt/content/handbook/sales/index.md
@@ -71,6 +71,10 @@ rules.
 ## How we work
 
 - [Sales Team Operating Principles](./operating-principles.md)
+- [Working Norms](./working-norms.md) — how we communicate and collaborate
+- [Customer Journey Alignment](./customer-journey.md) — lifecycle stages and ownership
+- [Systems & Tools](./tools.md) — the commercial tech stack
+- [Onboarding & Development](./onboarding.md) — ramping and growing the team
 - [Processes](./processes/) — the process and methodology index
 - [Sales Meetings](./meetings/) — [Discovery](./meetings/discovery.md), [Demo](./meetings/demo.md), [PoC](./meetings/poc.md)
 - [Engagements & Pricing](./engagements.md)
@@ -84,31 +88,8 @@ rules.
 - [Ideal Customer Profile](https://docs.google.com/document/d/1krMIUJvosw8xUQog_iq_FEvI9R5WEo9ZyWUCdTb9XnQ/edit#heading=h.3rr2wuny55dl)
 - [Customer Licenses (internal)](https://docs.google.com/spreadsheets/d/1wM_o8IWjjkwi-WMRueKfS-lrmkQYzV83xm4BIzZNAO0/edit#gid=0)
 
-### Sales tech stack
-
-FlowFuse uses a streamlined, integrated tech stack to manage the entire sales
-process, from initial research to closed-won tracking. Our foundation is
-[HubSpot](./hubspot.md) as the primary CRM, supplemented by specialized tools for
-enrichment, intelligence, and meeting capture.
-
-| Capability | Tool | Primary use case |
-| --- | --- | --- |
-| **CRM (source of truth)** | **HubSpot** | Managing all customer relationships, pipeline data, and contact records. |
-| **Emails, calls & sequences** | **HubSpot** | Executing outreach, standardizing email templates, and running automated cadences. |
-| **Subscription tracking** | **HubSpot** | Monitoring customer lifecycles, upgrades, renewals, and ongoing subscriptions. |
-| **Call recording** | **Fathom** | Recording, transcribing, and summarizing customer calls and meetings. |
-| **Data enrichment** | **Clay** | Automatically pulling in missing contact or company data to build targeted lead lists. |
-| **Account research & planning** | **Claude** | Synthesizing account data, deep-dive strategic research, and planning personalized outreach. |
-| **Account-based outreach** | **LinkedIn Sales Navigator** | Research and outreach to prospects on LinkedIn. |
-
-#### Primary GTM Tools
-
-- Warmly (data from RB2B, Vector.co)
-- Claude
-- Clay
-- Hubspot
-- Swan (getswan.com)
-- ZenABM
+The full commercial tech stack — CRM, enrichment, communication, and demo
+environments — is documented on the [Systems & Tools](./tools.md) page.
 
 ## Contact us
 

--- a/nuxt/content/handbook/sales/legal.md
+++ b/nuxt/content/handbook/sales/legal.md
@@ -1,7 +1,7 @@
 ---
 title: "Legal"
 navigation:
-  order: 17
+  order: 21
 ---
 
 # Legal

--- a/nuxt/content/handbook/sales/meetings/.navigation.yml
+++ b/nuxt/content/handbook/sales/meetings/.navigation.yml
@@ -1,4 +1,4 @@
 title: "Sales Meetings"
 navigation:
-  order: 9
+  order: 13
   icon: i-lucide-calendar

--- a/nuxt/content/handbook/sales/onboarding.md
+++ b/nuxt/content/handbook/sales/onboarding.md
@@ -1,0 +1,57 @@
+---
+title: "Onboarding & Development"
+navigation:
+  order: 11
+---
+
+# Onboarding & Development
+
+Effective onboarding and continuous development are how we build a high-performing,
+collaborative team. This page outlines how new team members get up to speed and
+how ongoing growth is supported across the Commercial Organization.
+
+## Onboarding structure
+
+- **Pre-start access** — accounts and tooling provisioned before day one.
+- **Day 1 orientation** — welcome with the VP of Sales; overview of mission, team
+  structure, and expectations.
+- **Week 1 goals:**
+  - Review the company handbook and department pages.
+  - Complete HubSpot CRM training and a workflow walk-through.
+  - Shadow discovery, demo, or onboarding calls as applicable.
+  - Get introduced to key product resources and customer stories.
+
+## Role-specific tracks
+
+Each role has a tailored onboarding plan covering systems training, role-play
+sessions, use-case deep dives, and territory or account alignment. Tracks are
+maintained and assigned with Sales leadership and the relevant team leads.
+
+## Enablement resources
+
+- Sales playbooks for discovery and qualification.
+- Sales and Success SOPs for key workflows.
+- Call library (Fathom) with tagged recordings for common objections, use cases,
+  and demo flows.
+- The [customer journey](/handbook/sales/customer-journey/) framework to align
+  activities by stage.
+
+## Ongoing development
+
+- Regular enablement sessions led by the VP of Sales, Product, or Solution
+  Engineering.
+- Case-study reviews and win/loss retrospectives.
+- Optional certifications and an external training budget.
+- Peer shadowing and mentoring.
+
+## Performance feedback & growth
+
+- 1:1s with your manager to review performance, challenges, and development goals.
+- Quarterly feedback cycles.
+- Clear growth paths across functions — AE → Strategic AE, SE → Architect,
+  CSM → Account Manager, and more.
+
+---
+
+New to the team? Start with the [Commercial Organization overview](/handbook/sales/)
+and the [Working Norms](/handbook/sales/working-norms/).

--- a/nuxt/content/handbook/sales/operating-principles.md
+++ b/nuxt/content/handbook/sales/operating-principles.md
@@ -1,22 +1,23 @@
 ---
-title: "Sales Team Operating Principles"
+title: "Commercial Team Operating Principles"
 navigation:
   order: 6
-description: "Professional standards and expectations for the FlowFuse Sales organization."
+description: "Professional standards and expectations for the FlowFuse Commercial Organization."
 ---
 
-# Sales Team Operating Principles
+# Commercial Team Operating Principles
 
-The Sales Team Operating Principles define how FlowFuse sales team members conduct themselves in internal and external interactions. These principles create consistency, set expectations, and support a high-performing sales organization.
+The Commercial Team Operating Principles define how FlowFuse team members conduct themselves in internal and external interactions. These principles create consistency, set expectations, and support a high-performing organization.
 
 ## Purpose
 
 These principles outline the professional behaviors, standards, and habits required to represent FlowFuse effectively.
-They apply to all Sales team members and complement related pages in the Sales Handbook, including Discovery, Follow-Up, SPICED, and CRM Requirements.
+They apply to all members of the Commercial Organization and complement related pages in this handbook, including Discovery, Follow-Up, SPICED, and CRM Requirements.
+For the team's operating rhythm and escalation routing, see [Working Norms](./working-norms.md).
 
 ## Professional Presence
 
-Sales team members represent FlowFuse at all times. Expectations:
+Commercial team members represent FlowFuse at all times. Expectations:
 
 * Join meetings from a professional, quiet, and distraction-free environment
 * Ensure stable internet and high-quality audio
@@ -35,7 +36,7 @@ Being prepared and on time reflects professionalism and respect:
 
 ## Meeting Preparedness
 
-Every meeting requires clear preparation and shared expectations. Sales team members:
+Every meeting requires clear preparation and shared expectations. Commercial team members:
 
 * Review previous call notes, Fathom transcripts, HubSpot activity, and prior correspondence
 * Research the company, use case, buyer personas, and relevant industry context
@@ -48,7 +49,7 @@ Every meeting requires clear preparation and shared expectations. Sales team mem
 
 ## Meeting and Call Excellence
 
-Sales calls follow the standards outlined in the Sales Methodology:
+Customer calls follow the standards outlined in the Sales Methodology:
 
 * Use Fathom Notetaker for all customer calls
 * Follow the SPICED discovery framework
@@ -73,12 +74,12 @@ Timely follow-up maintains momentum and demonstrates reliability:
 
 ## Internal Collaboration
 
-Sales operates as a single team. Expectations:
+The Commercial Organization operates as a single team. Expectations:
 
 * Ask for help early to avoid delays later in the cycle
 * Use shared Slack channels for visibility
 * Provide full context when requesting assistance from other teams
-* Share common objections, patterns, and discoveries with Sales leadership
+* Share common objections, patterns, and discoveries with leadership
 * Use internal communication tools consistently and transparently
 
 ## Data Hygiene and Operational Discipline
@@ -93,7 +94,7 @@ Accurate CRM and process discipline ensure high-quality forecasting and customer
 
 ## Professional Ethics and Conduct
 
-Sales team members uphold FlowFuse’s values and maintain customer trust:
+Commercial team members uphold FlowFuse’s values and maintain customer trust:
 
 * Represent product capabilities and pricing with accuracy
 * Maintain confidentiality and follow NDA requirements
@@ -103,7 +104,7 @@ Sales team members uphold FlowFuse’s values and maintain customer trust:
 
 ## Continuous Improvement
 
-FlowFuse sales culture emphasizes learning, growth, and refinement:
+FlowFuse's commercial culture emphasizes learning, growth, and refinement:
 
 * Participate actively in call reviews and team training
 * Regularly self-review calls and opportunities
@@ -113,7 +114,7 @@ FlowFuse sales culture emphasizes learning, growth, and refinement:
 ## Accountability
 
 These principles guide expectations for professional conduct.
-Sales leadership reinforces them through:
+Leadership reinforces them through:
 
 * Coaching
 * Performance reviews

--- a/nuxt/content/handbook/sales/pricing-decks.md
+++ b/nuxt/content/handbook/sales/pricing-decks.md
@@ -1,7 +1,7 @@
 ---
 title: "Pricing Decks"
 navigation:
-  order: 14
+  order: 18
 ---
 
 # Pricing Decks

--- a/nuxt/content/handbook/sales/processes/.navigation.yml
+++ b/nuxt/content/handbook/sales/processes/.navigation.yml
@@ -1,4 +1,4 @@
 title: Processes
 navigation:
-  order: 8
+  order: 12
   icon: i-lucide-workflow

--- a/nuxt/content/handbook/sales/sales-deck.md
+++ b/nuxt/content/handbook/sales/sales-deck.md
@@ -1,7 +1,7 @@
 ---
 title: "Sales Deck"
 navigation:
-  order: 13
+  order: 17
 ---
 
 # Sales Deck

--- a/nuxt/content/handbook/sales/subscription-agreement-1.5.md
+++ b/nuxt/content/handbook/sales/subscription-agreement-1.5.md
@@ -2,7 +2,7 @@
 # Note: Do not delete this file. It's still referenced in contracts and quotes.
 title: "Subscription Agreement 1.5"
 navigation:
-  order: 19
+  order: 23
 ---
 
 Below is the FlowFuse subscription agreement that applies to Team and Enterprise tier customers buying annual subscriptions. If you'd like to make alterations for your organization, please download the .docx file in the following form and initiate the legal part of the negotiation through your account executive.

--- a/nuxt/content/handbook/sales/tools.md
+++ b/nuxt/content/handbook/sales/tools.md
@@ -1,0 +1,62 @@
+---
+title: "Systems & Tools"
+navigation:
+  order: 8
+---
+
+# Systems & Tools
+
+The Commercial Organization relies on an integrated set of systems to support our
+workflows across Sales, Solution Engineering, Customer Success, Sales
+Partnerships, and Professional Services. This page is the reference for what we
+use and what each tool is for. [HubSpot](/handbook/sales/hubspot/) is our source
+of truth; everything else feeds it or extends it.
+
+## CRM & sales enablement
+
+| Tool | Primary use |
+| --- | --- |
+| **[HubSpot](/handbook/sales/hubspot/)** | Source of truth for deal management, pipeline, subscriptions, contacts, tasks, quoting, meeting scheduling, and email sequences. |
+| **HubSpot Playbooks** | Guide discovery calls and keep qualification and documentation consistent. |
+| **Clay** | Lead and account enrichment, plus automation workflows for prospecting. |
+| **Google Sheets** | Pricing calculations and deal-specific commercial structures. |
+
+## Research, intent & prospecting
+
+| Tool | Primary use |
+| --- | --- |
+| **Claude** | Synthesizing account data, deep-dive strategic research, and planning personalized outreach. |
+| **Warmly** | Website-visitor intent and lead identification (data from RB2B and Vector.co). |
+| **ZenABM** | Account-based marketing targeting and campaign measurement. |
+| **Swan AI** | LinkedIn and email sequence automation for outbound campaigns. |
+
+## Communication, scheduling & calendar
+
+| Tool | Primary use |
+| --- | --- |
+| **Slack** | Primary channel for internal communication; Slack Huddles for quick internal calls. |
+| **Google Meet** | Standard for external customer-facing video calls and scheduled internal meetings. |
+| **HubSpot Scheduling** | Booking meetings through personalized links in email or website flows. |
+| **Google Calendar** | Scheduling, calendar visibility, and HubSpot integration. |
+| **LinkedIn Sales Navigator** | Research and outreach to prospects on LinkedIn. |
+
+## Documentation & collaboration
+
+| Tool | Primary use |
+| --- | --- |
+| **Google Drive** | Central repository for shared documents, spreadsheets, and resources. |
+| **Google Slides** | Preparing and delivering customer-facing presentations. |
+| **Fathom** | Meeting recording and transcription, with HubSpot integration for call logging and summaries. |
+
+## Product access & demo environment
+
+| Tool | Primary use |
+| --- | --- |
+| **FlowFuse Cloud** | Live demo and sandbox environments for evaluations and trials. |
+| **Self-hosted trial licenses** | Issued to qualified prospects evaluating the enterprise edition on-premise. |
+
+---
+
+This list evolves as our toolset changes. Tool-specific usage guidance lives in
+the relevant function and process pages — for CRM conventions see
+[HubSpot](/handbook/sales/hubspot/).

--- a/nuxt/content/handbook/sales/working-norms.md
+++ b/nuxt/content/handbook/sales/working-norms.md
@@ -6,19 +6,11 @@ navigation:
 
 # Working Norms
 
-The Commercial Organization operates as a distributed, high-performance team.
-These norms describe how we collaborate, communicate, and execute so we stay
-aligned and move quickly as we grow.
-
-## Communication
-
-- Slack is our default for internal communication — use channels over DMs to keep
-  things transparent.
-- Slack Huddles are for quick, informal internal calls and ad hoc check-ins.
-- Google Meet is the standard for external customer-facing calls and scheduled
-  internal meetings.
-- Use threads in public channels to keep context organized.
-- Be mindful of time zones and availability when tagging people.
+The Commercial Organization operates as a distributed team across Sales, Solution
+Engineering, Customer Success, Professional Services, and Sales Partnerships.
+These norms cover the team's operating rhythm and how work escalates. For
+individual conduct standards — presence, preparation, follow-through, and ethics
+— see [Commercial Team Operating Principles](/handbook/sales/operating-principles/).
 
 ## Meeting cadence
 
@@ -28,21 +20,7 @@ aligned and move quickly as we grow.
 - Cross-functional syncs with Marketing, Product, and Engineering as needed.
 - Quarterly business reviews (QBRs) for key accounts, led by Customer Success.
 
-## Documentation & knowledge sharing
-
-- Use HubSpot Notes and Playbooks to document discovery, qualification, and deal
-  progress.
-- Store shared documents in Google Drive and link them from the relevant record
-  or Slack thread.
-- Maintain internal processes and SOPs in this handbook.
-
-## Collaboration
-
-- Default to async updates in Slack unless something is urgent or blocking.
-- Tag the right people when sharing context or requesting input.
-- Assume good intent and optimize for clarity over formality.
-
-## Escalation paths
+## Escalation routing
 
 - Raise deal-strategy questions to the VP of Sales.
 - Route technical escalations to Solution Engineering.
@@ -50,6 +28,4 @@ aligned and move quickly as we grow.
 
 ---
 
-For the systems referenced here, see [Systems & Tools](/handbook/sales/tools/).
-For the principles behind how we sell, see
-[Operating Principles](/handbook/sales/operating-principles/).
+For the systems these norms rely on, see [Systems & Tools](/handbook/sales/tools/).

--- a/nuxt/content/handbook/sales/working-norms.md
+++ b/nuxt/content/handbook/sales/working-norms.md
@@ -1,0 +1,55 @@
+---
+title: "Working Norms"
+navigation:
+  order: 9
+---
+
+# Working Norms
+
+The Commercial Organization operates as a distributed, high-performance team.
+These norms describe how we collaborate, communicate, and execute so we stay
+aligned and move quickly as we grow.
+
+## Communication
+
+- Slack is our default for internal communication — use channels over DMs to keep
+  things transparent.
+- Slack Huddles are for quick, informal internal calls and ad hoc check-ins.
+- Google Meet is the standard for external customer-facing calls and scheduled
+  internal meetings.
+- Use threads in public channels to keep context organized.
+- Be mindful of time zones and availability when tagging people.
+
+## Meeting cadence
+
+- Weekly team meetings for Sales, Customer Success, and Solution Engineering.
+- Weekly [pipeline review](/handbook/sales/meetings/) (Friday) and
+  [forecast review](/handbook/sales/forecast-review/) (Monday).
+- Cross-functional syncs with Marketing, Product, and Engineering as needed.
+- Quarterly business reviews (QBRs) for key accounts, led by Customer Success.
+
+## Documentation & knowledge sharing
+
+- Use HubSpot Notes and Playbooks to document discovery, qualification, and deal
+  progress.
+- Store shared documents in Google Drive and link them from the relevant record
+  or Slack thread.
+- Maintain internal processes and SOPs in this handbook.
+
+## Collaboration
+
+- Default to async updates in Slack unless something is urgent or blocking.
+- Tag the right people when sharing context or requesting input.
+- Assume good intent and optimize for clarity over formality.
+
+## Escalation paths
+
+- Raise deal-strategy questions to the VP of Sales.
+- Route technical escalations to Solution Engineering.
+- Use the relevant Slack channel to coordinate support across departments.
+
+---
+
+For the systems referenced here, see [Systems & Tools](/handbook/sales/tools/).
+For the principles behind how we sell, see
+[Operating Principles](/handbook/sales/operating-principles/).


### PR DESCRIPTION
Phase 3 of the Commercial Organization handbook restructure. Adds the four cross-functional supporting pages from the Commercial Organization model and cleans up the section index. Branches off `main` after Phase 2 ([#5496](https://github.com/FlowFuse/website/pull/5496)) merged.

## New pages

| Page | Nav order | Source |
|------|-----------|--------|
| **Systems & Tools** (`tools.md`) | 8 | Tech stack moved out of the section index |
| **Working Norms** (`working-norms.md`) | 9 | Communication, cadence, collaboration, escalation |
| **Customer Journey Alignment** (`customer-journey.md`) | 10 | The eight lifecycle stages + stage ownership |
| **Onboarding & Development** (`onboarding.md`) | 11 | Internal onboarding and growth |

## Index changes

- Removed the **Sales tech stack** block — that content now lives on the Systems & Tools page, which the index links to.
- Added the four new pages to the **How we work** list.

## Nav ordering

New pages slot at orders 8–11 (after Regions=7), and the tactical process pages below them are bumped down by four so the sidebar stays in reading order. Every renumbered file is a single-line frontmatter change; final order is contiguous 1–23.

All internal links verified against existing files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)