### PR TITLE
docs: correct Expert default URL version to v2.33.2

### DIFF
--- a/nuxt/content/handbook/engineering/ops/self-hosted-assistant.md
+++ b/nuxt/content/handbook/engineering/ops/self-hosted-assistant.md
@@ -99,4 +99,4 @@ forge:
 
 NOTE: For FlowFuse Helm chart v2.84.0 and onward the Expert central broker address is configured by default, so `forge.expert.broker.address` and `forge.expert.broker.port` no longer need to be set.
 
-NOTE: For FlowFuse v2.29.0 and onward the urls (`forge.assistant.service.url` & `forge.expert.service.url`) can be omitted from the configuration as they have preset defaults
+NOTE: For FlowFuse v2.33.2 and onward the urls (`forge.assistant.service.url` & `forge.expert.service.url`) can be omitted from the configuration as they have preset defaults


### PR DESCRIPTION
## Description

The self-hosted Expert handbook note said the assistant and expert service URLs can be omitted from v2.29.0 onward because they have preset defaults. That was not accurate: the preset defaults pointed at `https://expert.flowfuse/...` (missing `.com`), so omitting the URLs failed with `getaddrinfo ENOTFOUND expert.flowfuse`.

The defaults are corrected in FlowFuse/flowfuse#8057, which ships in v2.33.2. This updates the note to reference v2.33.2 as the first release where omitting the URLs actually works.

## Impact

Handbook wording only.