### PR TITLE
docs: remove EXPERT_BROKER_SERVER override from Docker table

### DIFF
--- a/nuxt/content/handbook/engineering/ops/self-hosted-assistant.md
+++ b/nuxt/content/handbook/engineering/ops/self-hosted-assistant.md
@@ -59,7 +59,6 @@ If you need to override a default, use these `.env` variables. Leave them unset 
 
 | Variable | Purpose |
 | --- | --- |
-| `EXPERT_BROKER_SERVER` | Central Expert broker host (defaults to `expert-broker.flowfuse.com`) |
 | `BROKER_API_KEY` / `BROKER_API_SECRET` | Local EMQX admin API credentials used to provision the bridge |
 
 None of these changes should be made without updating to the latest release of the `docker-compose.yml` file first.


### PR DESCRIPTION
## Description

The Docker broker override table listed `EXPERT_BROKER_SERVER` as a way to point at a different central Expert broker host. Self-hosted deployments do not run their own Expert, so chat always has to reach the central broker on FlowFuse Cloud (`expert-broker.flowfuse.com`). Overriding this host does not produce a working setup, so listing it as a supported override is misleading.

Removed the `EXPERT_BROKER_SERVER` row. The `BROKER_API_KEY` / `BROKER_API_SECRET` override for the local EMQX admin credentials stays.

## Impact

Handbook wording only.