### PR TITLE
Changelog: Remove tier badges on changelog entries

### DIFF
--- a/nuxt/components/ChangelogListItem.vue
+++ b/nuxt/components/ChangelogListItem.vue
@@ -1,15 +1,9 @@
 <script setup lang="ts">
-import { findFeatureByChangelog, deriveTierLabel } from '../composables/useFeatureCatalog'
-
 const props = defineProps<{
     entry: { path: string, title: string, description?: string, date: string | Date, authors?: string[] }
 }>()
 
 const authorNames = computed(() => useAuthorNames(props.entry.authors))
-
-const catalogFeature = computed(() => findFeatureByChangelog(props.entry.path))
-const tierCloud = computed(() => deriveTierLabel(catalogFeature.value?.cloud))
-const tierSelfHosted = computed(() => deriveTierLabel(catalogFeature.value?.selfHosted))
 
 const formattedDate = computed(() => new Date(props.entry.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }))
 </script>
@@ -24,7 +18,6 @@ const formattedDate = computed(() => new Date(props.entry.date).toLocaleDateStri
           <div class="author">{{ authorNames }}</div>
         </div>
       </NuxtLink>
-      <ChangelogTierBadges :cloud="tierCloud" :self-hosted="tierSelfHosted" />
     </div>
     <div class="flex-grow pt-4">
       <div class="prose">

--- a/nuxt/pages/changelog/[...slug].vue
+++ b/nuxt/pages/changelog/[...slug].vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { findFeatureByChangelog, deriveTierLabel } from '../../composables/useFeatureCatalog'
-
 definePageMeta({ layout: 'default' })
 
 const route = useRoute()
@@ -26,10 +24,6 @@ const otherRecentEntries = computed(() =>
 )
 
 const authorMembers = computed(() => useAuthorMembers(page.value?.authors))
-
-const catalogFeature = computed(() => findFeatureByChangelog(page.value?.path || ''))
-const tierCloud = computed(() => deriveTierLabel(catalogFeature.value?.cloud))
-const tierSelfHosted = computed(() => deriveTierLabel(catalogFeature.value?.selfHosted))
 
 function issueHref(issue: string): string {
     if (issue.startsWith('#')) return `https://github.com/FlowFuse/flowfuse/issues/${issue.substring(1)}`
@@ -64,7 +58,6 @@ useSeoMeta({
         <label>Changelog</label>
         <h1>{{ page.title }}</h1>
         <h4 v-if="page.subtitle">{{ page.subtitle }}</h4>
-        <ChangelogTierBadges :cloud="tierCloud" :self-hosted="tierSelfHosted" />
       </div>
     </div>
 


### PR DESCRIPTION
## Description

The badges are outdated against our current packages, I'm disconnecting the changelog from that logic until it gets updated.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

