### PR TITLE
Nuxt: Only fire blog-cta when the click lands on the CTA link

### DIFF
--- a/nuxt/components/BlogPostCta.vue
+++ b/nuxt/components/BlogPostCta.vue
@@ -39,7 +39,13 @@ const currentCta = computed(() => CTA_VARIANTS[ctaType.value])
 
 // Kept as-is from Eleventy for data continuity - fires alongside, not
 // instead of, each Cta* component's own cta-* event.
-function onCtaClick () {
+// Delegated from the wrapping row, since the three Cta* components own their
+// own root element. That row is the full width of the card while the button
+// is ~130px, so without the closest('a') guard a click on the empty space
+// beside the button reports a CTA click that never happened.
+function onCtaClick (event: MouseEvent) {
+    const target = event.target as Element | null
+    if (!target?.closest('a')) return
     if (typeof (window as any).capture === 'function') {
         (window as any).capture('blog-cta', { reference: `Blog: ${props.title}`, cta_type: ctaType.value })
     }


### PR DESCRIPTION
## Description

Follow-up to #5517, targeting its branch.

`onCtaClick` is delegated from the row wrapping the CTA button. That row spans the full width of the card (638px at 1440px) while the button is 115-137px, so a click on the empty space beside it fired a fully populated `blog-cta` event with no navigation. Measured on all three CTA types in the #5517 preview; production fires nothing on the same click.

Guard on `closest('a')`, so only clicks that reach the link count.

## Related Issue(s)

Follow-up to #5517

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))
