### PR TITLE
Require Contract Term and Payment Terms fields at deal close

### DIFF
--- a/nuxt/content/handbook/operations/commission-payment.md
+++ b/nuxt/content/handbook/operations/commission-payment.md
@@ -44,6 +44,14 @@ You need to have the following columns enabled:
    * Deal Type
    * Annual recurring revenue
    * Annual contract value
+   * Contract Term (months)
+   * Payment Terms
+
+Contract Term and Payment Terms are required to apply the multi-year commission
+tiering from the [Sales Compensation Plan](/handbook/sales/commission-plan/)
+(Exhibit A, Sections 10-11). Without them in the export, the sheet cannot tell
+a multi-year deal from a standard 1-year term, which has caused at least one
+overpayment.
 
 When the deal board is updated with on the won deals of last month, 
 click "Export View" and export as CSV. Download this file

--- a/nuxt/content/handbook/sales/engagements.md
+++ b/nuxt/content/handbook/sales/engagements.md
@@ -111,12 +111,22 @@ as evidenced by a PO or signed quote, is the sole determinant.
      - Company address
      - Renewal Date
      - Use Case
+     - Contract Term (months): the total length of the agreement.
+     - Payment Terms: Upfront or Annual Installments. Required whenever
+       Contract Term exceeds 12 months.
      - Spiced
      - Amount in USD based on Deal Type:
        - New Business: ACV (Annual Contract Value)
        - Expansions/Renewals: Incremental ARR
    - Under contract management; check the box for MSA if a custom subscription
      agreement is agreed upon.
+   - Contract Term and Payment Terms drive multi-year commission tiering
+     (see [Sales Compensation Plan](/handbook/sales/commission-plan/), Exhibit
+     A, Sections 10-11): multi-year deals paid upfront get 100% commission
+     credit, while deals paid in annual installments are credited 100%/50%/25%
+     by contract year. If these fields aren't set at close, payouts default to
+     treating the deal as a standard 1-year term, which has caused at least
+     one overpayment.
 1. Upload the documents to the Google Drive in the correct directory
    - [Signed quotes and P.O.'s](https://drive.google.com/drive/folders/1Nb3UqFiE56ymgQnyfkDKHMAe6L3akNzQ)
    - If negotiated custom, the


### PR DESCRIPTION
## Summary
- Adds two required HubSpot Deal fields to the "Steps for the AE to complete" checklist in `/handbook/sales/engagements`: **Contract Term (months)** and **Payment Terms** (Upfront or Annual Installments, required when Contract Term exceeds 12 months).
- Adds the same two fields to the required column list in `/handbook/operations/commission-payment` so they're included in the monthly HubSpot export the commission spreadsheet is built from.
- Notes in both places why: these fields drive multi-year commission tiering in the Sales Compensation Plan (Exhibit A, Sections 10-11) — 100% credit for upfront multi-year deals, or 100%/50%/25% by contract year for annual-installment deals.

## Why
Commission calculations have defaulted at least one multi-year deal to a standard 1-year term because Contract Term and Payment Terms weren't set on the HubSpot Deal at close (and weren't part of the monthly export either), resulting in an overpayment. This closes that gap end-to-end: AEs set the fields at close, and Ops pulls them into the monthly commission export.

## Test plan
- [ ] Docs-only change; verify the rendered handbook pages at `/handbook/sales/engagements` and `/handbook/operations/commission-payment` show the updates correctly.