### PR TITLE
Fix more blog posts failing to render due to bare placeholder tags

### DIFF
--- a/src/blog/2022/12/create-http-trigger-with-authentication.md
+++ b/src/blog/2022/12/create-http-trigger-with-authentication.md
@@ -47,7 +47,7 @@ curl -X POST https://example.flowforge.cloud/http-trigger
 => Unauthorized
 ```
 
-Let’s get it working again: (replace <username> and <password> with the details from the sticky note)
+Let’s get it working again: (replace `<username>` and `<password>` with the details from the sticky note)
 
 ```
 curl -X POST https://<username>:<password>@example.flowforge.cloud/http-trigger

--- a/src/blog/2023/07/influxdb-historical-data.md
+++ b/src/blog/2023/07/influxdb-historical-data.md
@@ -105,7 +105,7 @@ After installing this package you will see three new nodes in your flow editor.
 
 ![Screenshot showing the installed influxdb nodes in the palette](images/influxdb-historical-data/influxdb-nodes-15.png "Screenshot showing the installed influxdb nodes in the palette")
 
-Drag and drop the “influxdb out” node into your flow, double click on it, and start filling out the needed fields.  The naming convention of “test&lt;<THING>>” works well for initial setups to make it clear what names should go where.
+Drag and drop the “influxdb out” node into your flow, double click on it, and start filling out the needed fields.  The naming convention of `test&lt;<THING>>` works well for initial setups to make it clear what names should go where.
 
 !["Screenshot showing the influxdb-out node config"](images/influxdb-historical-data/influxdb-out-node-16.png "Screenshot showing the influxdb-out node config")
 


### PR DESCRIPTION
## Summary
- Same bug class as #5544: MDC parses a bare `<placeholder>` in prose as an HTML/Vue tag rather than literal text, which throws and fails the whole post's render.
- Wrapped the two remaining occurrences found in a repo-wide sweep in backticks:
  - `src/blog/2022/12/create-http-trigger-with-authentication.md` — `<username>`/`<password>` in prose
  - `src/blog/2023/07/influxdb-historical-data.md` — `<THING>` in prose
- Checked every other `<placeholder>`-like token across `src/blog` and `src/changelog`; all others were already safely inside backticks/fenced code blocks, or were legitimate HTML/Vue tags. FAQ frontmatter fields with similar placeholders are rendered via plain Vue text interpolation (not MDC), so they're unaffected.

## Test plan
- [ ] Verify both posts render on the Nuxt dev server (`npm run dev:nuxt`) without MDC parse errors