### PR TITLE
Clarify recruiter comp range timing in handbook

### DIFF
--- a/nuxt/content/handbook/peopleops/hiring/recruiters.md
+++ b/nuxt/content/handbook/peopleops/hiring/recruiters.md
@@ -23,9 +23,10 @@ When we open a role:
 ## Recruiter Compensation
 
 Recruiters are compensated with a fixed rate based on the average candidate's
-first-year base compensation package. The target compensation range for each
-role is established before recruiters begin submitting candidates. This
-structure:
+first-year base compensation package. The compensation range for a role is
+agreed with the recruiter before the hiring process kicks off, so the fee
+basis is set before candidates are sourced rather than being subject to
+negotiation later. This structure:
 
 * Provides predictable costs for FlowFuse
 * Eliminates potential conflicts of interest during salary negotiations


### PR DESCRIPTION
## Summary
- Tightens the "Recruiter Compensation" wording in the hiring handbook to make explicit that the comp range must be agreed with the recruiter before the hiring process kicks off, so the fee basis is fixed before candidates are sourced/negotiation happens.

## Test plan
- [ ] Docs-only change; verify handbook page renders correctly at `/handbook/peopleops/hiring/recruiters/`