### PR TITLE
Fix stripped onclick warning on blog live-demo links

### DIFF
--- a/nuxt/components/content/LiveDemoLink.vue
+++ b/nuxt/components/content/LiveDemoLink.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+// Inline tracked link for blog markdown: ::live-demo-link{href="..." label="..."}
+// Fires click tracking via a real Vue handler instead of a raw onclick attribute,
+// which @nuxtjs/mdc strips as an unsafe attribute.
+import { useCapture } from '../../composables/useCapture'
+
+const props = defineProps<{
+    href: string
+    label: string
+}>()
+
+const EVENT = 'blog-live-demo'
+
+const capture = useCapture()
+
+// Provided by nuxt/pages/blog/[...slug].vue - avoids repeating the title per instance.
+const postTitle = inject<Ref<string> | undefined>('blogPostTitle', undefined)
+
+function onClick () {
+    capture(EVENT, { reference: `Blog: ${postTitle?.value || ''}` })
+}
+</script>
+
+<template>
+  <a :href="props.href" @click="onClick">{{ props.label }}</a>
+</template>

--- a/src/blog/2026/07/build-downtime-logger.md
+++ b/src/blog/2026/07/build-downtime-logger.md
@@ -58,7 +58,7 @@ In this tutorial, you'll build a machine downtime tracking application using Flo
 ![Screenshot: completed dashboard with KPI cards and stoppages table](./images/downtime-logger.png)
 _The finished dashboard: KPI cards on top, unresolved stoppages below._
 
-You can interact with the live demo here: <a href="https://cheerful-western-sandpiper-1404.flowfuse.cloud/dashboard/downtime-events" onclick="if (typeof capture !== 'undefined') { capture('blog-live-demo', { reference: 'Blog: {{ title | escape }}' }); }">Try the Machine Downtime Tracking Demo</a>.
+You can interact with the live demo here: :live-demo-link{href="https://cheerful-western-sandpiper-1404.flowfuse.cloud/dashboard/downtime-events" label="Try the Machine Downtime Tracking Demo"}.
 
 By the end, you'll have a foundation you can extend into OEE, production reporting, maintenance dashboards, or MES integrations.
 

--- a/src/blog/2026/07/calibration-management-dashboard.md
+++ b/src/blog/2026/07/calibration-management-dashboard.md
@@ -73,7 +73,7 @@ In this article, we'll build a calibration application in FlowFuse. It will show
 
 > **Note:** This tutorial reads from a `calibration_assets` table in FlowFuse Tables, filled with sample instruments. Everything here works the same against a real calibration register, a CMMS, or an ERP endpoint. Only the query nodes change.
 
-You can interact with the live demo here: <a href="https://clever-garden-warbler-2554.flowfuse.cloud/dashboard/home" onclick="if (typeof capture !== 'undefined') { capture('blog-live-demo', { reference: 'Blog: {{ title | escape }}' }); }">Try the Calibration Status Dashboard Demo</a>.
+You can interact with the live demo here: :live-demo-link{href="https://clever-garden-warbler-2554.flowfuse.cloud/dashboard/home" label="Try the Calibration Status Dashboard Demo"}.
 
 ## What You'll Need
 

--- a/src/blog/2026/07/defect-and-quality-monitoring.md
+++ b/src/blog/2026/07/defect-and-quality-monitoring.md
@@ -57,7 +57,7 @@ Every production line produces defects. On their own they're easy to wave off, a
 
 In this tutorial, you'll build a defect tracking and quality monitoring dashboard using FlowFuse in about 30 minutes. It reads defects from a database, calculates the KPIs a quality engineer actually looks at, and renders them live, filtered by line, shift, and date range.
 
-You can interact with the live demo here: <a href="https://defect-monitoring-dashboard.flowfuse.cloud/dashboard/defects" onclick="if (typeof capture !== 'undefined') { capture('blog-live-demo', { reference: 'Blog: {{ title | escape }}' }); }">Try the Quality Monitoring Dashboard</a>.
+You can interact with the live demo here: :live-demo-link{href="https://defect-monitoring-dashboard.flowfuse.cloud/dashboard/defects" label="Try the Quality Monitoring Dashboard"}.
 
 By the end, you'll have a foundation you can extend into broader production monitoring or OEE tracking, or a plant-wide quality report.
 

--- a/src/blog/2026/07/digital-work-instruction.md
+++ b/src/blog/2026/07/digital-work-instruction.md
@@ -69,7 +69,7 @@ In this article, we'll build a digital work instructions app in FlowFuse: an ope
 
 > **Note:** This demo is deliberately configured with a preset demo user so anyone can try it, even without being on the team where it's deployed. The version you build following this article uses FlowFuse User Authentication, which limits dashboard access to members of the same team.
 
-You can interact with the live demo here: <a href="https://expensive-pied-flycatcher-5052.flowfuse.cloud/dashboard/home" onclick="if (typeof capture !== 'undefined') { capture('blog-live-demo', { reference: 'Blog: {{ title | escape }}' }); }">Try the Digital Work Instruction Dashboard Demo</a>.
+You can interact with the live demo here: :live-demo-link{href="https://expensive-pied-flycatcher-5052.flowfuse.cloud/dashboard/home" label="Try the Digital Work Instruction Dashboard Demo"}.
 
 ## What You'll Need
 


### PR DESCRIPTION
## Summary
- Four July 2026 blog posts embedded raw HTML like `<a onclick="capture('blog-live-demo', { reference: 'Blog: {{ title | escape }}' })">` — leftover 11ty/Nunjucks-style templating that never resolves under Nuxt's `@nuxt/content`/`@nuxtjs/mdc` pipeline (blog is fully migrated), and the `onclick` attribute itself gets stripped by MDC's sanitizer regardless, producing a build warning.
- Added `nuxt/components/content/LiveDemoLink.vue`, a small MDC content component (same pattern as `CtaImage.vue`) that renders a plain `<a>` and fires `capture('blog-live-demo', ...)` via a real Vue `@click` handler.
- Swapped the raw HTML in the four posts for `:live-demo-link{href="..." label="..."}` MDC syntax.

## Test plan
- [x] Ran `npm run dev:nuxt`, confirmed the `[@nuxtjs/mdc] removing unsafe attribute` warning no longer appears
- [x] Fetched the rendered `build-downtime-logger` post and confirmed the link renders correctly with no `onclick`/unresolved template text
- [ ] Sumit to confirm the demo links still track/behave as expected on the live posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)