### PR TITLE
Speed up CI build via nitro.prerender.concurrency

### DIFF
--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -224,6 +224,12 @@ export default defineNuxtConfig({
             }
         ],
         prerender: {
+            // Nitro's default concurrency is 1 - CI logs showed ~560 routes rendered
+            // strictly serially, with the sum of per-route times matching total wall
+            // time almost exactly. Most of the per-route cost is async (content
+            // queries, template rendering) rather than CPU-bound, so this can safely
+            // exceed the runner's core count.
+            concurrency: 10,
             routes: (() => {
                 const changelog = collectChangelogRoutes(join(__dirname, '../src/changelog'), '/changelog')
                 const changelogPageCount = Math.max(1, Math.ceil(changelog.entryCount / 19))


### PR DESCRIPTION
## Summary
- The `Tests` workflow's `Build the forge` step (`npm run build:nuxt:skip-images`) has consistently taken ~13.6 minutes across recent `main` runs.
- Log analysis (job 90934536001 and others) showed ~11.4 of those minutes are spent in Nitro's prerender phase, rendering ~560 routes. The sum of every individual route's render time matched the phase's total wall-clock time almost exactly - i.e. routes were rendering **strictly serially**.
- `nuxt.config.ts`'s `nitro.prerender` block never set `concurrency`, so it was stuck at Nitro's default of 1.
- Set `concurrency: 10`. Most of the per-route cost is async (content collection queries, SSR template rendering) rather than CPU-bound, so this can reasonably exceed the runner's core count (GH-hosted `ubuntu-latest` = 4 vCPUs).

## Test plan
- [x] Verified locally that prerendering all routes completes successfully at `concurrency: 10` (logged `Prerendering 1069 routes` and proceeded normally into the next build phase, no errors)
- [ ] Confirm on this PR's own CI run that `Build the forge` completes faster than the ~13.6 minute baseline, and that nothing regresses (in particular, watch for any race condition in build-time route-collection helpers that assumed serial execution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)