### PR TITLE
Fix broken ANDON dashboard image link from PR #5560

### DIFF
--- a/src/blog/2024/02/node-red-unified-namespace-architecture.md
+++ b/src/blog/2024/02/node-red-unified-namespace-architecture.md
@@ -47,4 +47,4 @@ Contrastingly, direct actors can interact with the UNS out of the box. Modern in
 Node-RED's prowess extends beyond middleware capabilities; it can also derive actionable insights. Our example architecture includes Dashboards for both the Human Machine Interface on the Shopfloor and an OEE Dashboard in the Service Layer. These dashboards engage with the UNS, calculating KPIs directly within Node-RED. For manufacturing applications, our [Blueprint Library](/blueprints/) serves as a robust starting point, offering one-click deployment to your Node-RED managed instance.
 Node-RED emerges not just as a translator between machines and UNS but as an interpreter and analyst, generating real-time insights that drive decision-making and operational efficiency. The role of Node-RED in UNS architecture, therefore, is not ancillary; it is central to realizing the vision of a connected, intelligent industrial ecosystem.
 
-![Andon Live Dashboard](/img/ANDON-Screenshot-D4DBvWieJZ-650.avif)
+![Andon Live Dashboard](https://flowfuse.com/img/ANDON-Screenshot-D4DBvWieJZ-650.avif)


### PR DESCRIPTION
## Summary
PR #5560 relativized internal links across several blog posts, but also caught the ANDON dashboard image (`ANDON-Screenshot-D4DBvWieJZ-650.avif`) in `src/blog/2024/02/node-red-unified-namespace-architecture.md`. That filename is a CMS-generated derivative asset served from flowfuse.com's image pipeline — not a file in this repo, and not in `blueprint-library` either — so making it a relative `/img/...` path broke the `test_website` link-checker job.

This reverts just that one image reference back to an absolute URL, consistent with the other out-of-scope exceptions #5560 already carved out (email signature, `ai-expert-modal.js`, blueprints/docs assets).

## Test plan
- [x] Confirmed the asset isn't tracked in this repo or in `blueprint-library`
- [ ] Confirm `test_website` link-checker job passes on this PR