### PR TITLE
Handbook: require AE to set company Lifecycle Stage to Customer on close

### DIFF
--- a/nuxt/content/handbook/sales/engagements.md
+++ b/nuxt/content/handbook/sales/engagements.md
@@ -136,6 +136,7 @@ as evidenced by a PO or signed quote, is the sole determinant.
    - Finalize outstanding action points
 1. Move the deal to `Closing` in HubSpots Deal overview, update the close date
    to when the customer committed to purchasing.
+1. Set the `Lifecycle Stage` on the HubSpot **company** record to `Customer`.
 1. Send the CSM a direct message on slack with the following information:
    - Company Name
    - Key Champion


### PR DESCRIPTION
## Summary
- When closing a deal, the AE must set the `Lifecycle Stage` on the HubSpot **company** record to `Customer`, not just the contact.

## Test plan
- [ ] Docs-only change; verify rendered handbook page for `/handbook/sales/engagements/` looks correct