### PR TITLE
Include remote instances in hub feature table

### DIFF
--- a/nuxt/content/feature-catalog.yml
+++ b/nuxt/content/feature-catalog.yml
@@ -21,7 +21,7 @@ sections:
       - id: edge-development
         title: Edge Development
         description: "Develop and test Node-RED flows directly on edge devices with a remote editor proxy."
-        tiers: { edge: true, hub: false, fleet: true }
+        tiers: { edge: true, hub: true, fleet: true }
       - id: private-npm-registry
         title: Custom Node-RED Nodes
         description: "Create and manage your own private npm registry for Node-RED nodes, so you can share custom nodes across your team and devices without publishing them publicly."
@@ -54,7 +54,7 @@ sections:
       - id: edge-devices
         title: Edge Instances
         description: "Deploy and mange your Node-RED instances on edge PLCs and gateways, with full visibility and control from the cloud."
-        tiers: { edge: true, hub: false, fleet: true }
+        tiers: { edge: true, hub: true, fleet: true }
       - id: custom-hostnames
         title: Custom Hostnames
         tiers: { edge: false, hub: true, fleet: false }


### PR DESCRIPTION
This updates the pricing page to include edge instances in Hub - but without the more advanced features of Device Groups etc.

Rationale:

1. This is what had been documented internally in both the working doc and pricing spreadsheet following previous discussions. This PR brings the page inline with what had been agreed.
2. With trial accounts coming in at hub, *not* having edge instances available makes the edge onboarding harder for first-time users evaluating things
