### PR TITLE
Fix Nuxt's default meta description to match 11ty

### DIFF
--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -140,7 +140,7 @@ export default defineNuxtConfig({
     site: {
         url: site.baseURL,
         name: 'FlowFuse',
-        description: 'Low-code application development platform for Node-RED and industrial IoT.',
+        description: site.messaging.subtitle,
         defaultLocale: 'en',
     },
 


### PR DESCRIPTION
## Description

`site.json` is the single source of truth for site-wide messaging (tagline, subtitle, etc.). Nuxt's default meta description (used as a fallback by `@nuxtjs/seo` when a page doesn't set its own) was hardcoded to a different string than 11ty's fallback description. This PR points it at `site.messaging.subtitle` instead, matching what `base.njk` already falls back to on the 11ty side.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

