### PR TITLE
Fix broken Nunjucks include in blog post sign-up link

### DIFF
--- a/src/blog/2026/08/connect-agvs-vda-5050-mqtt.md
+++ b/src/blog/2026/08/connect-agvs-vda-5050-mqtt.md
@@ -208,7 +208,7 @@ The standard ships [JSON schemas](https://github.com/VDA5050/VDA5050/tree/main/j
 
 ### What you need
 
-- A running FlowFuse instance on your edge device. If you do not have an account, [sign up for a free trial]({% include "sign-up-url.njk" %}) and set up your instance following the instructions in this [guide](/docs/device-agent/quickstart/).
+- A running FlowFuse instance on your edge device. If you do not have an account, [sign up for a free trial](https://app.flowfuse.com/account/create) and set up your instance following the instructions in this [guide](/docs/device-agent/quickstart/).
 - An MQTT broker your AGVs (or an AGV simulator) already publish to, or FlowFuse's [built-in team broker](/docs/user/teambroker/) if you're prototyping. If you're still [choosing a broker](/blog/2024/01/unified-namespace-what-broker/), any one with retained messages, last will, and per-client topic permissions will do.
 - At least one vehicle or simulator publishing VDA 5050 topics, so you have real messages to work with.
 


### PR DESCRIPTION
## Summary
- The VDA 5050 blog post ([#5564](https://github.com/FlowFuse/website/pull/5564)) contained a leftover `{% include "sign-up-url.njk" %}` inside a markdown link, a leftover from when blog posts were 11ty/Nunjucks templates.
- Blog posts are now rendered by Nuxt/MDC, which doesn't process Nunjucks tags, so the sign-up link rendered as literal broken text instead of a working URL.
- Replaced it with the literal URL the include resolved to (`https://app.flowfuse.com/account/create`), matching the fixed href the site's `CtaSignUp` component already uses.

cc @sumitshinde-84 (introduced this instance in #5564) @Yndira-E (author of the original `sign-up-url.njk` partial) — flagging in case there are other posts drafted with the same pattern that haven't merged yet.

## Test plan
- [x] Confirm the rendered blog post link now points to `https://app.flowfuse.com/account/create`