### PR TITLE
Drop trailing whitespace in the docs stylesheet

### DIFF
--- a/src/css/style.docs.css
+++ b/src/css/style.docs.css
@@ -1,7 +1,7 @@
 @layer components {
 
 .checklist {
-    
+
 }
 
 .checklist label {


### PR DESCRIPTION
## Description

Removes trailing whitespace from one line of the docs stylesheet, so the shared website build has a harmless change to run against. This is a pull request for testing.

## Related Issue(s)

https://github.com/FlowFuse/engineering/issues/237

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))
