### PR TITLE
Prerender routes concurrently

### DIFF
--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -363,7 +363,13 @@ export default defineNuxtConfig({
                     ...collectHandbookRoutes(join(__dirname, 'content/handbook'), '/handbook'),
                 ]
             })(),
-            crawlLinks: false
+            crawlLinks: false,
+            // Nitro renders one route at a time by default, which serialises much the
+            // longest phase of the build. A sizeable share of that phase is fixed per-route
+            // overhead rather than render work, and that part overlaps away as soon as
+            // several routes render at once. Matched to the vCPU count on GitHub's standard
+            // runner. Raising it further trades peak memory for wall time.
+            concurrency: 4
         }
     },
 


### PR DESCRIPTION
## Description

Nitro's prerender concurrency defaults to 1, so every route renders one after another. This sets it to 4, matching the vCPU count on GitHub's standard runner.

**Measured, and it does not shorten the build on its own.** Comparing this branch against a branch that changes nothing else, both building the same commit range:

| | reported per-route render time | prerender phase |
|---|---|---|
| unchanged | 938s | 1222s |
| this branch | 195s | 1182s |

So the flag takes effect, and the rendering itself gets nearly five times cheaper, but the phase does not move. The phase is not bound by rendering.

What it is bound by, at least in part: the build emits thousands of `[Icon] failed to load icon` warnings per run (`lucide:mail`, `heroicons:chevron-left` and others, each retried per page), and roughly 30% of the prerender phase elapses immediately after those warning lines. `@iconify-json/lucide` and `@iconify-json/heroicons` are both already declared in `nuxt/package.json`, so something in the resolution path is still going remote and timing out. That looks like the actual lever, and it is a correctness problem as well, since a failed icon renders as nothing.

Keeping this open because once the icon stalls are gone, rendering becomes the bottleneck again and this is what uncaps it. It should not be merged on a promise of saving minutes today.

Worth watching: peak memory.

## Related Issue(s)

None.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))
