### PR TITLE
Cancel superseded test runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,13 @@ name: Tests
 
 on: push
 
+# Pushing again to a branch replaces the commit the running build was checking, so cancel
+# that build rather than pay for a result nobody will look at. main is exempt: every commit
+# there keeps its own run, since those are the ones the ruleset and the history rely on.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   # The build itself lives in FlowFuse/github-actions-workflows so this repository and
   # FlowFuse/flowfuse documentation pull requests share one definition. The check this


### PR DESCRIPTION
## Description

`on: push` with no concurrency group means a branch pushed to repeatedly runs a full site build per commit, and none of the obsolete ones are cancelled. Over the last two weeks of runs, roughly a fifth of all workflow minutes went to builds whose commit had already been replaced.

Group by ref and cancel the outdated run. `main` is exempt, so every commit there still gets its own run for the ruleset and for history.

This does not make any single build faster.

## Related Issue(s)

None.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))
