### PR TITLE
Blog: restore features lost on the Nuxt migration

### DIFF
--- a/nuxt/components/BlogPostCta.vue
+++ b/nuxt/components/BlogPostCta.vue
@@ -27,13 +27,12 @@ const CTA_VARIANTS: Record<string, { title: string, description: string }> = {
     },
 }
 
-// Missing type defaults to 'contact'; an unrecognised one (e.g. typo'd
-// `type: signup`) falls back to 'sign-up' - same two fallbacks as before.
+// Missing type, or an unrecognised one (e.g. typo'd `type: signup`), falls
+// back to 'sign-up'.
 const KNOWN_TYPES = new Set(['sign-up', 'demo', 'contact', 'pricing'])
 const ctaType = computed(() => {
     const type = props.cta?.type
-    if (!type) return 'contact'
-    return KNOWN_TYPES.has(type) ? type : 'sign-up'
+    return type && KNOWN_TYPES.has(type) ? type : 'sign-up'
 })
 const currentCta = computed(() => CTA_VARIANTS[ctaType.value])
 

--- a/nuxt/pages/blog/[...slug].vue
+++ b/nuxt/pages/blog/[...slug].vue
@@ -59,14 +59,15 @@ const { data: allPosts } = await useAsyncData(
 
 const authorMembers = computed(() => useAuthorMembers(page.value?.authors))
 
+// page.body is a minimark tree: { value: MinimarkNode[] } where a node is
+// either a text string or an element array [tag, attrs, ...children].
 function extractText(node: any): string {
-    if (!node) return ''
-    if (node.type === 'text') return node.value || ''
-    if (Array.isArray(node.children)) return node.children.map(extractText).join(' ')
+    if (typeof node === 'string') return node
+    if (Array.isArray(node)) return node.slice(2).map(extractText).join(' ')
     return ''
 }
 const readingTime = computed(() => {
-    const words = extractText(page.value?.body).split(/\s+/).filter(Boolean).length
+    const words = (page.value?.body?.value || []).map(extractText).join(' ').split(/\s+/).filter(Boolean).length
     return Math.max(1, Math.ceil(words / 200))
 })
 
@@ -148,8 +149,8 @@ if (routeInfo.value.kind === 'post') {
         <label>Article</label>
         <h1>{{ page.title }}</h1>
         <h4 v-if="page.subtitle">{{ page.subtitle }}</h4>
-        <div class="flex flex-wrap items-center gap-2 text-sm text-gray-500 mt-4">
-          <div class="flex -space-x-2">
+        <div class="flex flex-wrap items-center gap-1 text-sm text-gray-500 mt-4">
+          <div class="flex -space-x-2 mr-1">
             <template v-if="authorMembers.length">
               <NuxtLink
                   v-for="author in authorMembers"

--- a/nuxt/pages/blog/[...slug].vue
+++ b/nuxt/pages/blog/[...slug].vue
@@ -46,10 +46,12 @@ const releaseFeatureComponents = {
     'feature-release-links': FeatureReleaseLinks,
 }
 
+// Fixed key so `nuxt generate`'s shared-prerender-data caching reuses one fetch across
+// every blog route - the callback must therefore return the same result regardless of
+// which route triggers it first, so it can't branch on this page's own routeInfo.
 const { data: allPosts } = await useAsyncData(
     'blog-all-for-related',
     async () => {
-        if (routeInfo.value.kind !== 'post') return []
         const all = await getAllBlogPosts()
         // Only the fields this page needs travel into its payload; the shared cache
         // itself holds the wider field set other pages (listing, author) need.

--- a/nuxt/pages/blog/[...slug].vue
+++ b/nuxt/pages/blog/[...slug].vue
@@ -148,7 +148,28 @@ if (routeInfo.value.kind === 'post') {
         <label>Article</label>
         <h1>{{ page.title }}</h1>
         <h4 v-if="page.subtitle">{{ page.subtitle }}</h4>
-        <div class="flex flex-wrap items-center gap-1 text-sm text-gray-500 mt-4">
+        <div class="flex flex-wrap items-center gap-2 text-sm text-gray-500 mt-4">
+          <div class="flex -space-x-2">
+            <template v-if="authorMembers.length">
+              <NuxtLink
+                  v-for="author in authorMembers"
+                  :key="author.slug"
+                  :to="authorPath(author.slug)"
+                  class="block w-8 h-8 rounded-full overflow-hidden bg-indigo-300 ring-2 ring-white"
+                  :title="author.name"
+              >
+                <img
+                    v-if="author.headshot"
+                    :src="`/images/team/headshot-${author.headshot}`"
+                    :alt="author.name"
+                    class="w-full h-full object-cover"
+                >
+              </NuxtLink>
+            </template>
+            <div v-else class="block w-8 h-8 rounded-full overflow-hidden bg-indigo-300 ring-2 ring-white" title="FlowFuse">
+              <img :src="'/images/flowfuse-icon.png'" alt="FlowFuse" class="w-full h-full object-cover">
+            </div>
+          </div>
           <span>By</span>
           <template v-if="authorMembers.length">
             <span v-for="(author, i) in authorMembers" :key="author.slug">

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2243,6 +2243,11 @@ lite-youtube {
     background-size: cover;
     background-position: center;
     border-radius: 0.75rem;
+    /* Overrides fixed inline width/height some posts embed this with, so it stays responsive. */
+    width: 100% !important;
+    max-width: 100%;
+    height: auto !important;
+    aspect-ratio: 16 / 9;
 }
 
 lite-youtube::before {


### PR DESCRIPTION
## Description

Restores a few things that got lost when the blog migrated from 11ty to Nuxt, and fixes some post-migration bugs:
- **Related/Recommended Articles** — restored the sidebar list linking to related posts (by shared tags) or, as a fallback, recent posts. This is a meaningful interlinking mechanism between blog pages and shouldn't have been dropped.
- **"Updated on" date** — restored on the byline when a post has a `lastUpdated` value.
- **Author avatar** — added a circular headshot next to the byline (indigo-300 background), matching how presenters are shown on webinar pages. Falls back to the FlowFuse icon for legacy author slugs that have no data file in `team`/`guests`, same as the old Eleventy `renderTeamMember` behavior.
- **Default CTA changed from `contact` to `sign-up`** — sign-up is the lowest-friction action, which makes sense as a safe default for now. Longer-term we should be more intentional and pick the CTA (and accompanying copy) based on the post's content rather than relying on a single default for everything.
- **Responsive video embeds** — posts with a raw `<lite-youtube>` embed in their markdown body had a fixed inline `width`, so the video didn't shrink on small screens. Fixed with a CSS override.
- **Reading time always showing "1 min read"** — `extractText` assumed a hast-like `{type, children}` body shape; `@nuxt/content` v3 actually returns a minimark tree (nodes are either strings or `[tag, attrs, ...children]`). Rewrote the walker for the real shape.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

