### PR TITLE
handbook: raise coworking space allowance to $250 a month

### DIFF
--- a/nuxt/content/handbook/peopleops/expenses.md
+++ b/nuxt/content/handbook/peopleops/expenses.md
@@ -250,7 +250,7 @@ before making such arrangements.
 ### Coworking space allowance
 
 If you want to occasionally use a separate workspace to your home, the company
-will cover up to $150 a month in charges for renting a desk in a co-working
+will cover up to $400 a month in charges for renting a desk in a co-working
 space after manager approval.
 
 ### Mileage

--- a/nuxt/content/handbook/peopleops/expenses.md
+++ b/nuxt/content/handbook/peopleops/expenses.md
@@ -250,7 +250,7 @@ before making such arrangements.
 ### Coworking space allowance
 
 If you want to occasionally use a separate workspace to your home, the company
-will cover up to $400 a month in charges for renting a desk in a co-working
+will cover up to $250 a month in charges for renting a desk in a co-working
 space after manager approval.
 
 ### Mileage


### PR DESCRIPTION
## Description

Raises the coworking space allowance from $150 to $400 a month. Coworking desks
across Europe cost well above $150, and because the allowance is set in USD, part
of it is lost again to the USD to EUR conversion.

## Related Issue(s)

None.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))
