### PR TITLE
Open sign-up in a popup window instead of navigating away (draft)

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -141,6 +141,7 @@ module.exports = function(eleventyConfig) {
     eleventyConfig.addPassthroughCopy("src/js/ai-expert-modal.js");
     eleventyConfig.addPassthroughCopy("src/js/hm-promo-banner.js");
     eleventyConfig.addPassthroughCopy("src/js/nav-tracking.js");
+    eleventyConfig.addPassthroughCopy("src/js/signup-popup.js");
 
     // Watch content images for the image pipeline
     eleventyConfig.addWatchTarget("src/**/*.{svg,webp,png,jpeg,gif}");

--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -291,6 +291,9 @@ export default defineNuxtConfig({
                 // Explicit nav-click tracking. Source is src/js/nav-tracking.js;
                 // prod:eleventy-nuxt copies the 11ty output into nuxt/public/.
                 { src: '/js/nav-tracking.js', defer: true },
+                // Experimental: open sign-up in a small popup window on desktop/tablet.
+                // Source is src/js/signup-popup.js; copied the same way as nav-tracking.js.
+                { src: '/js/signup-popup.js', defer: true },
             ]
         }
     },

--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -291,7 +291,7 @@ export default defineNuxtConfig({
                 // Explicit nav-click tracking. Source is src/js/nav-tracking.js;
                 // prod:eleventy-nuxt copies the 11ty output into nuxt/public/.
                 { src: '/js/nav-tracking.js', defer: true },
-                // Experimental: open sign-up in a small popup window on desktop/tablet.
+                // Opens sign-up in a small popup window on desktop/tablet.
                 // Source is src/js/signup-popup.js; copied the same way as nav-tracking.js.
                 { src: '/js/signup-popup.js', defer: true },
             ]

--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -1,6 +1,6 @@
 {
     "baseURL": "https://flowfuse.com",
-    "appURL": "https://app.flowfuse.com",
+    "appURL": "http://localhost:3000",
     "jobBoard": "https://boards.greenhouse.io/flowfuse",
     "messaging": {
         "tagLine": "The Edge-Native Platform for Industrial Applications",

--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -1,6 +1,6 @@
 {
     "baseURL": "https://flowfuse.com",
-    "appURL": "http://localhost:3000",
+    "appURL": "https://app.flowfuse.com",
     "jobBoard": "https://boards.greenhouse.io/flowfuse",
     "messaging": {
         "tagLine": "The Edge-Native Platform for Industrial Applications",

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -158,6 +158,8 @@ eleventyComputed:
     <script type="module" src="/js/flowrenderer.min.js"></script>
     <!-- Explicit nav-click tracking; keep in sync with the Nuxt copy -->
     <script defer src="/js/nav-tracking.js"></script>
+    <!-- Experimental: open sign-up in a small popup window on desktop/tablet -->
+    <script defer src="/js/signup-popup.js"></script>
 
     {%- if not DEV_MODE -%}
     {% include "analytics/head.html" %}

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -158,7 +158,7 @@ eleventyComputed:
     <script type="module" src="/js/flowrenderer.min.js"></script>
     <!-- Explicit nav-click tracking; keep in sync with the Nuxt copy -->
     <script defer src="/js/nav-tracking.js"></script>
-    <!-- Experimental: open sign-up in a small popup window on desktop/tablet -->
+    <!-- Opens sign-up in a small popup window on desktop/tablet -->
     <script defer src="/js/signup-popup.js"></script>
 
     {%- if not DEV_MODE -%}

--- a/src/js/signup-popup.js
+++ b/src/js/signup-popup.js
@@ -36,6 +36,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
             event.preventDefault()
 
+            // Explicit signal for the product to key its popup-specific
+            // layout off, instead of `window.opener` — that's also set for
+            // an ordinary ctrl/cmd-click "open in new tab", which isn't
+            // this popup at all.
+            const popupUrl = new URL(link.href)
+            popupUrl.searchParams.set('context', 'popup')
+
             const width = 420
             const height = Math.min(900, window.innerHeight * 0.75)
 
@@ -52,7 +59,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const top = viewportTop + (window.innerHeight - height) / 2
 
             const popup = window.open(
-                link.href,
+                popupUrl.href,
                 'flowfuse-signup',
                 `width=${width},height=${height},left=${left},top=${top},menubar=no,toolbar=no,location=no,status=no`
             )

--- a/src/js/signup-popup.js
+++ b/src/js/signup-popup.js
@@ -1,0 +1,91 @@
+// Opens the sign-up page in a small popup window on desktop/tablet, centered
+// over the visible page content, with a dark overlay behind it.
+// On mobile, leaves the link's default navigation untouched.
+document.addEventListener('DOMContentLoaded', () => {
+    let overlay = null
+
+    function showOverlay (popup) {
+        overlay = document.createElement('div')
+        overlay.setAttribute('id', 'signup-popup-overlay')
+        overlay.style.position = 'fixed'
+        overlay.style.inset = '0'
+        overlay.style.background = 'rgba(0, 0, 0, 0.45)'
+        overlay.style.zIndex = '9999'
+        overlay.addEventListener('click', () => {
+            if (!popup.closed) {
+                popup.close()
+            }
+            hideOverlay()
+        })
+        document.body.appendChild(overlay)
+    }
+
+    function hideOverlay () {
+        if (overlay) {
+            overlay.remove()
+            overlay = null
+        }
+    }
+
+    document.querySelectorAll('a[href*="/account/create"]').forEach((link) => {
+        link.addEventListener('click', (event) => {
+            const isDesktopOrTablet = window.matchMedia('(min-width: 768px)').matches
+            if (!isDesktopOrTablet) {
+                return
+            }
+
+            event.preventDefault()
+
+            const width = 420
+            const height = Math.min(900, window.innerHeight * 0.75)
+
+            // outerWidth/outerHeight include browser chrome (toolbars, a
+            // vertical tab strip, etc). Subtracting innerWidth/innerHeight
+            // estimates that chrome so we can center over the visible page
+            // content instead of the full browser window.
+            const chromeWidth = window.outerWidth - window.innerWidth
+            const chromeHeight = window.outerHeight - window.innerHeight
+            const viewportLeft = window.screenX + chromeWidth
+            const viewportTop = window.screenY + chromeHeight
+
+            const left = viewportLeft + (window.innerWidth - width) / 2
+            const top = viewportTop + (window.innerHeight - height) / 2
+
+            const popup = window.open(
+                link.href,
+                'flowfuse-signup',
+                `width=${width},height=${height},left=${left},top=${top},menubar=no,toolbar=no,location=no,status=no`
+            )
+
+            if (!popup) {
+                return
+            }
+
+            showOverlay(popup)
+            popup.focus()
+
+            const pollClosed = setInterval(() => {
+                if (popup.closed) {
+                    clearInterval(pollClosed)
+                    hideOverlay()
+                }
+            }, 100)
+
+            // On macOS (and similar window managers), the first click on an
+            // unfocused window only refocuses it — it doesn't reach the
+            // overlay's own click handler. That refocus fires this 'focus'
+            // event immediately, so treat it as the "click outside" signal:
+            // close the popup and drop the overlay right away, in one click.
+            window.addEventListener('focus', () => {
+                if (!overlay) {
+                    return
+                }
+                if (!popup.closed) {
+                    popup.close()
+                }
+                clearInterval(pollClosed)
+                hideOverlay()
+            })
+        })
+    })
+})

--- a/src/js/signup-popup.js
+++ b/src/js/signup-popup.js
@@ -2,97 +2,114 @@
 // over the visible page content, with a dark overlay behind it.
 // On mobile, leaves the link's default navigation untouched.
 document.addEventListener('DOMContentLoaded', () => {
-    let overlay = null
+    // Tracks the one popup/overlay pair that can be open at a time, so
+    // there's a single thing to clean up instead of separate mutable
+    // variables that a second click could overwrite and orphan.
+    let session = null
 
-    function showOverlay (popup) {
-        overlay = document.createElement('div')
+    function closeSession () {
+        if (!session) {
+            return
+        }
+        if (!session.popup.closed) {
+            session.popup.close()
+        }
+        clearInterval(session.pollClosed)
+        session.overlay.remove()
+        session = null
+    }
+
+    function openPopup (href) {
+        if (session) {
+            if (!session.popup.closed) {
+                // Already have one open - bring it forward instead of
+                // opening a second popup and orphaning this one's overlay.
+                session.popup.focus()
+                return
+            }
+            closeSession()
+        }
+
+        const width = 420
+        const height = Math.min(900, window.innerHeight * 0.75)
+
+        // outerWidth/outerHeight include browser chrome (toolbars, a
+        // vertical tab strip, etc). Subtracting innerWidth/innerHeight
+        // estimates that chrome so we can center over the visible page
+        // content instead of the full browser window.
+        const chromeWidth = window.outerWidth - window.innerWidth
+        const chromeHeight = window.outerHeight - window.innerHeight
+        const viewportLeft = window.screenX + chromeWidth
+        const viewportTop = window.screenY + chromeHeight
+
+        const left = viewportLeft + (window.innerWidth - width) / 2
+        const top = viewportTop + (window.innerHeight - height) / 2
+
+        const popup = window.open(
+            href,
+            'flowfuse-signup',
+            `width=${width},height=${height},left=${left},top=${top},menubar=no,toolbar=no,location=no,status=no`
+        )
+
+        if (!popup) {
+            return
+        }
+
+        const overlay = document.createElement('div')
         overlay.setAttribute('id', 'signup-popup-overlay')
         overlay.style.position = 'fixed'
         overlay.style.inset = '0'
         overlay.style.background = 'rgba(0, 0, 0, 0.45)'
         overlay.style.zIndex = '9999'
-        overlay.addEventListener('click', () => {
-            if (!popup.closed) {
-                popup.close()
-            }
-            hideOverlay()
-        })
+        overlay.addEventListener('click', closeSession)
         document.body.appendChild(overlay)
+
+        const pollClosed = setInterval(() => {
+            if (popup.closed) {
+                closeSession()
+            }
+        }, 100)
+
+        session = { popup, overlay, pollClosed }
+        popup.focus()
     }
 
-    function hideOverlay () {
-        if (overlay) {
-            overlay.remove()
-            overlay = null
+    // Delegated on `document` (rather than binding each matching link once)
+    // so this also catches anchors rendered after this script ran - e.g.
+    // Nuxt's client-side route navigation swapping in a new CtaSignUp link
+    // without a full page load.
+    document.addEventListener('click', (event) => {
+        const link = event.target.closest('a[href*="/account/create"]')
+        if (!link) {
+            return
         }
-    }
 
-    document.querySelectorAll('a[href*="/account/create"]').forEach((link) => {
-        link.addEventListener('click', (event) => {
-            const isDesktopOrTablet = window.matchMedia('(min-width: 768px)').matches
-            if (!isDesktopOrTablet) {
-                return
-            }
+        const isDesktopOrTablet = window.matchMedia('(min-width: 768px)').matches
+        if (!isDesktopOrTablet) {
+            return
+        }
 
-            event.preventDefault()
+        event.preventDefault()
 
-            // Explicit signal for the product to key its popup-specific
-            // layout off, instead of `window.opener` — that's also set for
-            // an ordinary ctrl/cmd-click "open in new tab", which isn't
-            // this popup at all.
-            const popupUrl = new URL(link.href)
-            popupUrl.searchParams.set('context', 'popup')
+        // Explicit signal for the product to key its popup-specific
+        // layout off, instead of `window.opener` — that's also set for
+        // an ordinary ctrl/cmd-click "open in new tab", which isn't
+        // this popup at all.
+        const popupUrl = new URL(link.href)
+        popupUrl.searchParams.set('context', 'popup')
 
-            const width = 420
-            const height = Math.min(900, window.innerHeight * 0.75)
-
-            // outerWidth/outerHeight include browser chrome (toolbars, a
-            // vertical tab strip, etc). Subtracting innerWidth/innerHeight
-            // estimates that chrome so we can center over the visible page
-            // content instead of the full browser window.
-            const chromeWidth = window.outerWidth - window.innerWidth
-            const chromeHeight = window.outerHeight - window.innerHeight
-            const viewportLeft = window.screenX + chromeWidth
-            const viewportTop = window.screenY + chromeHeight
-
-            const left = viewportLeft + (window.innerWidth - width) / 2
-            const top = viewportTop + (window.innerHeight - height) / 2
-
-            const popup = window.open(
-                popupUrl.href,
-                'flowfuse-signup',
-                `width=${width},height=${height},left=${left},top=${top},menubar=no,toolbar=no,location=no,status=no`
-            )
-
-            if (!popup) {
-                return
-            }
-
-            showOverlay(popup)
-            popup.focus()
-
-            const pollClosed = setInterval(() => {
-                if (popup.closed) {
-                    clearInterval(pollClosed)
-                    hideOverlay()
-                }
-            }, 100)
-
-            // On macOS (and similar window managers), the first click on an
-            // unfocused window only refocuses it — it doesn't reach the
-            // overlay's own click handler. That refocus fires this 'focus'
-            // event immediately, so treat it as the "click outside" signal:
-            // close the popup and drop the overlay right away, in one click.
-            window.addEventListener('focus', () => {
-                if (!overlay) {
-                    return
-                }
-                if (!popup.closed) {
-                    popup.close()
-                }
-                clearInterval(pollClosed)
-                hideOverlay()
-            })
-        })
+        openPopup(popupUrl.href)
     })
+
+    // Deliberate trade-off, not an oversight: closing on any window focus
+    // (e.g. switching tabs/apps and coming back) can cancel an in-progress,
+    // not-yet-submitted sign-up. That's judged preferable to the
+    // alternative - the popup falling behind this window with no auto-close,
+    // which leaves the overlay covering the page with no visible popup and
+    // no clear reason why, reading as the site being stuck rather than a
+    // sign-up that's still open one window over. Nothing of substance is
+    // lost by closing early here: this only ever covers the initial,
+    // unsubmitted form step. Added once (not per click) so listeners don't
+    // accumulate across retries.
+    window.addEventListener('focus', closeSession)
 })


### PR DESCRIPTION
## Description

Intercepts clicks on any link to `/account/create` and opens it in a small, centered popup window (with a dark overlay behind it) instead of navigating away from the site. Falls back to normal full-page navigation on mobile.

This is the popup experience discussed in this thread: https://flowfuse.slack.com/archives/C032Q63FGG1/p1786398271612039

## Status

- [x] Product-side support for the popup context (conditional layout + handoff to a full tab past the form step) shipped via https://github.com/FlowFuse/flowfuse/pull/8228.
- [x] appURL points at production (https://app.flowfuse.com).
- [x] ~Still pending a decision on https://github.com/FlowFuse/CloudProject/issues/1538, whether to reuse the existing "above the form" text or add a popup-specific one, since reusing it could be redundant with the left column in the normal full-tab view. [See related comments on the PR.](https://github.com/FlowFuse/flowfuse/issues/8196#issuecomment-5359995323)~
Resolved by https://github.com/FlowFuse/flowfuse/pull/8360
- [ ] https://github.com/FlowFuse/CloudProject/issues/1538

## Known, accepted trade-offs: 
- The popup briefly flashes open for already-logged-in users before handing off to a full tab, since the marketing site can't reliably check login state before opening it. Only affects that edge case, not the main sign-up flow.
- The popup closes on any window focus (e.g. switching tabs/apps and back), not just a deliberate click outside it. The alternative (not auto-closing) left the popup silently pushed behind the main window while the overlay stayed up, reading as the site being stuck rather than a popup one window over. Since this only ever cancels an unsubmitted form, the simpler behavior was judged the better trade-off.

## How to test

1. Click any "Sign up" / "Try for free" CTA on desktop or tablet width.
1. On mobile widths, confirm it still falls back to normal full-page navigation.

## Related Issue(s)

https://github.com/FlowFuse/flowfuse/issues/8196 (resolved via [#8228](https://github.com/FlowFuse/flowfuse/pull/8228))
https://github.com/FlowFuse/CloudProject/issues/1538 (pending)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

