### PR TITLE
Make docs section URLs actually redirect

### DIFF
--- a/nuxt/lib/docs-redirects.mjs
+++ b/nuxt/lib/docs-redirects.mjs
@@ -1,0 +1,105 @@
+// Turns the `layout: redirect` pages synced from FlowFuse/flowfuse into Nitro route
+// rules. Kept free of Nuxt and filesystem imports so it can be unit tested with
+// `node --test`; modules/docs-source.ts is the thin filesystem wrapper around this.
+//
+// Before this existed the pages redirected from inside the docs page component, which
+// the prerenderer turns into an HTML file holding a `<meta http-equiv="refresh">`. That
+// answers the URL with a 200 and no redirect status at all, so an inbound link to
+// /docs/install/ passes nothing on to /docs/install/introduction. A route rule gives
+// Netlify a real 301, the same way nuxt/redirects.ts does for the retired 11ty paths.
+
+// js-yaml rather than yaml: it is the declared root dependency, and `node --test`
+// resolves it as raw ESM without Vite's CommonJS interop in the way. Same reasoning as
+// feature-catalog.test.mjs.
+import jsYaml from 'js-yaml'
+
+// Only the leading block, so a `---` used as a horizontal rule in the body is not read as
+// the closing fence. Docs synced from another repo may end at `---` with no trailing
+// newline, hence the `$` alternative.
+const FRONTMATTER = /^---[ \t]*\r?\n([\s\S]*?)\r?\n?---[ \t]*(?:\r?\n|$)/
+
+function frontmatterOf (source) {
+    const block = FRONTMATTER.exec(source ?? '')
+    if (!block) return null
+
+    let data
+    try {
+        data = jsYaml.load(block[1])
+    } catch {
+        // The docs are authored in another repo, so one malformed page must not fail the
+        // build. It keeps prerendering as an ordinary page instead.
+        return null
+    }
+
+    return data && typeof data === 'object' && !Array.isArray(data) ? data : null
+}
+
+/**
+ * @param {Array<{route: string, source: string}>} pages route docs-source would prerender,
+ *   plus the raw markdown behind it
+ * @returns {Record<string, {redirect: {to: string, statusCode: number}}>} keyed by route,
+ *   ready to spread into `nuxt.options.routeRules`
+ */
+export function docsRedirectRules (pages) {
+    const rules = {}
+
+    for (const { route, source } of pages) {
+        const data = frontmatterOf(source)
+
+        // Both keys, the same pair the page component required: a `to` on a page that
+        // still renders content of its own is not a redirect.
+        if (data?.layout !== 'redirect') continue
+
+        const to = data.redirect?.to
+        if (typeof to !== 'string' || !to) continue
+
+        // The key stays the caller's route verbatim, so the same string can be matched
+        // against the prerender list. Normalising here would leave a meta-refresh stub
+        // sitting next to the rule, and the static file wins.
+        rules[route] = { redirect: { to, statusCode: 301 } }
+    }
+
+    return rules
+}
+
+// Route rules are matched by Nitro without caring about a trailing slash, and
+// nuxt/redirects.ts holds both `/docs/user/assistant` and `/docs/user/assistant/`, so
+// comparing raw strings would miss half of them.
+function withoutTrailingSlash (route) {
+    return route.length > 1 && route.endsWith('/') ? route.slice(0, -1) : route
+}
+
+/**
+ * The docs routes that are safe to prerender: everything a route rule does not already
+ * answer with a redirect.
+ *
+ * Prerendering a route that redirects writes an HTML file holding a
+ * `<meta http-equiv="refresh">`, served with a 200, and that static file answers the URL
+ * before the route rule is ever consulted. It happens whenever a docs page exists at a
+ * path some rule redirects: `nuxt/redirects.ts` maps `/docs/install/email_providers/` to
+ * the hyphenated slug, so an upstream docs tree that still carries the underscored
+ * filename silently loses the 301.
+ *
+ * @param {string[]} routes candidate prerender routes
+ * @param {Record<string, {redirect?: unknown}>} routeRules `nuxt.options.routeRules`, read
+ *   after this module has added its own, so one pass covers both sources
+ */
+export function prerenderableRoutes (routes, routeRules) {
+    const exact = new Set()
+    const prefixes = []
+
+    for (const [pattern, rule] of Object.entries(routeRules ?? {})) {
+        if (!rule || typeof rule !== 'object' || !rule.redirect) continue
+        // `/certified-nodes/**` style keys: a redirect on a whole subtree covers every
+        // route under it. Only this one wildcard form is recognised, which is the only
+        // one the site uses.
+        if (pattern.endsWith('/**')) prefixes.push(withoutTrailingSlash(pattern.slice(0, -3)))
+        else exact.add(withoutTrailingSlash(pattern))
+    }
+
+    return routes.filter(route => {
+        const path = withoutTrailingSlash(route)
+        if (exact.has(path)) return false
+        return !prefixes.some(prefix => path === prefix || path.startsWith(`${prefix}/`))
+    })
+}

--- a/nuxt/lib/docs-redirects.test.mjs
+++ b/nuxt/lib/docs-redirects.test.mjs
@@ -1,0 +1,176 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { docsRedirectRules, prerenderableRoutes } from './docs-redirects.mjs'
+
+// Shape of what docs-source reads off disk after syncDocs: the route it would have
+// prerendered, plus the raw markdown behind it.
+function page (route, frontmatter, body = '') {
+    return { route, source: `---\n${frontmatter}\n---\n${body}` }
+}
+
+const redirectPage = (route, to) => page(route, `navTitle: Installing FlowFuse\nredirect:\n  to: ${to}\nlayout: redirect`)
+
+test('a redirect page becomes a 301 route rule keyed on its route', () => {
+    const rules = docsRedirectRules([redirectPage('/docs/install/', '/docs/install/introduction')])
+
+    assert.deepEqual(rules, {
+        '/docs/install/': { redirect: { to: '/docs/install/introduction', statusCode: 301 } },
+    })
+})
+
+test('the key is the route verbatim, so docs-source can reuse it to skip prerendering', () => {
+    // collectRoutes emits a trailing slash for index.md and for nested pages alike; the
+    // skip list is Object.keys(rules), so any normalisation here would silently prerender
+    // a meta-refresh stub next to the rule and the stub would win.
+    const rules = docsRedirectRules([
+        redirectPage('/docs/install/', '/docs/install/introduction'),
+        redirectPage('/docs/community-support/', 'https://discourse.nodered.org/c/vendors/flowfuse/24'),
+    ])
+
+    assert.deepEqual(Object.keys(rules), ['/docs/install/', '/docs/community-support/'])
+})
+
+test('an off-site target is a 301 like any other', () => {
+    // docs/community-support.md points at the Node-RED forum, and docs/admin/licensing.md
+    // at /pricing/, which is still served by Eleventy. Neither is a docs page.
+    const rules = docsRedirectRules([
+        redirectPage('/docs/community-support/', 'https://discourse.nodered.org/c/vendors/flowfuse/24'),
+    ])
+
+    assert.equal(rules['/docs/community-support/'].redirect.to, 'https://discourse.nodered.org/c/vendors/flowfuse/24')
+    assert.equal(rules['/docs/community-support/'].redirect.statusCode, 301)
+})
+
+test('an ordinary docs page produces no rule', () => {
+    const rules = docsRedirectRules([
+        page('/docs/install/introduction/', 'navTitle: Introduction\nnavOrder: 1', '# Installing\n'),
+    ])
+
+    assert.deepEqual(rules, {})
+})
+
+test('redirect.to without layout: redirect is ignored', () => {
+    // Same pair of conditions the page component required, so this changes no behaviour:
+    // a `to` on a page that still renders itself is not a redirect.
+    const rules = docsRedirectRules([page('/docs/somewhere/', 'redirect:\n  to: /docs/elsewhere/')])
+
+    assert.deepEqual(rules, {})
+})
+
+test('layout: redirect without a target produces no rule, so the page keeps prerendering', () => {
+    // A rule of { redirect: { to: undefined } } would answer the URL with a broken 301.
+    // Emitting nothing leaves the route in the prerender list, which is the safe failure.
+    const rules = docsRedirectRules([page('/docs/half-done/', 'layout: redirect')])
+
+    assert.deepEqual(rules, {})
+})
+
+test('an empty redirect target is treated as absent', () => {
+    const rules = docsRedirectRules([page('/docs/half-done/', 'layout: redirect\nredirect:\n  to: ""')])
+
+    assert.deepEqual(rules, {})
+})
+
+test('trailing whitespace after the redirect key still parses', () => {
+    // docs/community-support.md is synced with `redirect: ` including the trailing space.
+    const rules = docsRedirectRules([page('/docs/community-support/', 'redirect: \n  to: /docs/support/\nlayout: redirect')])
+
+    assert.equal(rules['/docs/community-support/'].redirect.to, '/docs/support/')
+})
+
+test('a page with no frontmatter is skipped rather than throwing', () => {
+    const rules = docsRedirectRules([{ route: '/docs/plain/', source: '# Just a heading\n' }])
+
+    assert.deepEqual(rules, {})
+})
+
+test('unparseable frontmatter is skipped rather than failing the build', () => {
+    // The docs come from another repo, so a malformed page must not take the site down.
+    const rules = docsRedirectRules([
+        { route: '/docs/broken/', source: '---\nlayout: redirect\n  to: [unclosed\n---\n' },
+        redirectPage('/docs/install/', '/docs/install/introduction'),
+    ])
+
+    assert.deepEqual(Object.keys(rules), ['/docs/install/'])
+})
+
+test('frontmatter that parses to a scalar rather than a map is skipped', () => {
+    const rules = docsRedirectRules([{ route: '/docs/odd/', source: '---\njust a string\n---\n' }])
+
+    assert.deepEqual(rules, {})
+})
+
+test('a redirect page whose body has its own --- fence still reads the frontmatter', () => {
+    const rules = docsRedirectRules([
+        page('/docs/install/', 'redirect:\n  to: /docs/install/introduction\nlayout: redirect', 'text\n\n---\n\nmore text\n'),
+    ])
+
+    assert.equal(rules['/docs/install/'].redirect.to, '/docs/install/introduction')
+})
+
+test('no pages means no rules, and spreading {} into routeRules is a no-op', () => {
+    assert.deepEqual(docsRedirectRules([]), {})
+})
+
+const redirect = to => ({ redirect: { to, statusCode: 301 } })
+
+test('a route a rule redirects is dropped from the prerender list', () => {
+    const routes = prerenderableRoutes(
+        ['/docs/install/introduction/', '/docs/install/'],
+        { '/docs/install/': redirect('/docs/install/introduction/') },
+    )
+
+    assert.deepEqual(routes, ['/docs/install/introduction/'])
+})
+
+test('the trailing slash does not have to match on either side', () => {
+    // nuxt/redirects.ts carries /docs/user/assistant and /docs/user/assistant/ as separate
+    // keys, and collectPages always emits the trailing slash, so raw string equality would
+    // miss whichever form the rule happens to use.
+    const routes = prerenderableRoutes(
+        ['/docs/user/assistant/', '/docs/admin/user_management/', '/docs/user/expert/'],
+        {
+            '/docs/user/assistant': redirect('/docs/user/expert/'),
+            '/docs/admin/user_management/': redirect('/docs/admin/user-management/'),
+        },
+    )
+
+    assert.deepEqual(routes, ['/docs/user/expert/'])
+})
+
+test('a /** rule covers every route beneath it', () => {
+    const routes = prerenderableRoutes(
+        ['/docs/legacy/', '/docs/legacy/install/', '/docs/legacy-notes/', '/docs/current/'],
+        { '/docs/legacy/**': redirect('/docs/') },
+    )
+
+    // /docs/legacy-notes/ only shares a prefix as text, not as a path segment, so it stays.
+    assert.deepEqual(routes, ['/docs/legacy-notes/', '/docs/current/'])
+})
+
+test('rules that are not redirects leave the prerender list alone', () => {
+    const routes = prerenderableRoutes(
+        ['/docs/install/introduction/'],
+        { '/docs/install/introduction/': { robots: false }, '/docs/other/': {} },
+    )
+
+    assert.deepEqual(routes, ['/docs/install/introduction/'])
+})
+
+test('no route rules at all is not an error', () => {
+    assert.deepEqual(prerenderableRoutes(['/docs/a/'], undefined), ['/docs/a/'])
+    assert.deepEqual(prerenderableRoutes(['/docs/a/'], {}), ['/docs/a/'])
+})
+
+test('the rules this module generates are themselves enough to skip their routes', () => {
+    // docs-source extends routeRules first and filters afterwards, so one pass covers both
+    // the frontmatter redirects and the hand-written ones in nuxt/redirects.ts.
+    const pages = [
+        page('/docs/install/', 'redirect:\n  to: /docs/install/introduction\nlayout: redirect'),
+        page('/docs/install/introduction/', 'navTitle: Introduction'),
+    ]
+    const rules = docsRedirectRules(pages)
+
+    assert.deepEqual(prerenderableRoutes(pages.map(p => p.route), rules), ['/docs/install/introduction/'])
+})

--- a/nuxt/modules/docs-source.ts
+++ b/nuxt/modules/docs-source.ts
@@ -1,5 +1,5 @@
-import { defineNuxtModule, useLogger } from '@nuxt/kit'
-import { existsSync, readdirSync } from 'node:fs'
+import { defineNuxtModule, extendRouteRules, useLogger } from '@nuxt/kit'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { join, basename, dirname } from 'node:path'
 
 // Lives in nuxt/lib/, not alongside this file: Nuxt auto-registers everything in
@@ -9,21 +9,23 @@ import { syncDocs } from '../lib/docs-sync.mjs'
 // @ts-ignore same
 import { syncGuides } from '../lib/guides-sync.mjs'
 // @ts-ignore same
+import { docsRedirectRules, prerenderableRoutes } from '../lib/docs-redirects.mjs'
 
 const logger = useLogger('docs-source')
 
-function collectRoutes(dir: string, basePath: string): string[] {
-    const routes: string[] = []
+function collectPages(dir: string, basePath: string): Array<{ route: string, file: string }> {
+    const pages: Array<{ route: string, file: string }> = []
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
         if (entry.name.startsWith('.')) continue
+        const path = join(dir, entry.name)
         if (entry.isDirectory()) {
-            routes.push(...collectRoutes(join(dir, entry.name), `${basePath}/${entry.name}`))
+            pages.push(...collectPages(path, `${basePath}/${entry.name}`))
         } else if (entry.name.endsWith('.md')) {
             const slug = basename(entry.name, '.md')
-            routes.push(slug === 'index' ? `${basePath}/` : `${basePath}/${slug}/`)
+            pages.push({ route: slug === 'index' ? `${basePath}/` : `${basePath}/${slug}/`, file: path })
         }
     }
-    return routes
+    return pages
 }
 
 export default defineNuxtModule({
@@ -43,19 +45,43 @@ export default defineNuxtModule({
 
         // Collected after the overlay, so the guide pages get prerendered with the rest
         // of /docs and need no route list of their own in nuxt.config.
-        const docsRoutes = collectRoutes(contentDocsDir, '/docs')
+        const docsPages = collectPages(contentDocsDir, '/docs')
         // A floor rather than a log line, following the same call in nuxt.config.ts for the
         // integrations. Collecting nothing means the tree above did not land, and on the
         // netlify preset unprerendered routes still SSR, so the only symptom would be a
         // thinner static site and slow cold pages - nothing that looks like a failure.
-        if (docsRoutes.length === 0) {
+        // Checked on what was collected, not on what survives the redirect filter below:
+        // that filter is meant to drop routes, so a floor on its output would be a floor
+        // on how many redirects the docs happen to declare.
+        if (docsPages.length === 0) {
             throw new Error(
-                '[docs-source] collected 0 docs routes to prerender - refusing to build /docs with no pages'
+                '[docs-source] collected 0 docs pages to prerender - refusing to build /docs with no pages'
             )
         }
+
+        // A page whose frontmatter is only `layout: redirect` + `redirect.to` (e.g.
+        // docs/install/index.md) becomes a real 301 instead of a rendered page. Reading the
+        // frontmatter here rather than through queryCollection because route rules have to
+        // exist before the content database does.
+        const redirectRules = docsRedirectRules(
+            docsPages.map(({ route, file }) => ({ route, source: readFileSync(file, 'utf8') }))
+        )
+        for (const [route, rule] of Object.entries(redirectRules)) {
+            extendRouteRules(route, rule)
+        }
+
+        // A redirected route must also stay out of the prerender list, or the stub written
+        // for it answers the URL with a 200 before the rule is consulted. Filtering against
+        // routeRules after extending them covers the redirects declared here and the
+        // hand-written docs entries in nuxt/redirects.ts in one pass.
+        const prerenderRoutes = prerenderableRoutes(
+            docsPages.map(({ route }) => route),
+            nuxt.options.routeRules
+        )
+
         nuxt.options.nitro.prerender ??= {}
         const existing = (nuxt.options.nitro.prerender.routes as string[] | undefined) ?? []
-        nuxt.options.nitro.prerender.routes = [...existing, ...docsRoutes]
-        logger.info(`Added ${docsRoutes.length} docs routes for prerendering`)
+        nuxt.options.nitro.prerender.routes = [...existing, ...prerenderRoutes]
+        logger.info(`Added ${prerenderRoutes.length} docs routes for prerendering, and ${Object.keys(redirectRules).length} docs redirects as route rules`)
     },
 })

--- a/nuxt/pages/docs/[...slug].vue
+++ b/nuxt/pages/docs/[...slug].vue
@@ -21,12 +21,10 @@ if (!page.value) {
     throw createError({ statusCode: 404, statusMessage: 'Page not found' })
 }
 
-// Handle redirect pages
-if (page.value.layout === 'redirect' && page.value.redirect?.to) {
-    const target = page.value.redirect.to
-    const isExternal = target.startsWith('http://') || target.startsWith('https://')
-    throw navigateTo(target, { redirectCode: 301, external: isExternal })
-}
+// No redirect handling here: modules/docs-source.ts turns `layout: redirect` frontmatter
+// into a Nitro route rule at build time, so those URLs never reach this component. Doing it
+// here meant the prerenderer wrote a `<meta http-equiv="refresh">` stub served with a 200
+// instead of a 301.
 
 // The order is asserted in nuxt/lib/docs-page-title.mjs, which explains why it is that
 // order. It decides the <title> of every page under /docs and getting it wrong shows up


### PR DESCRIPTION
## Description

Docs section URLs do not redirect. `/docs/install/` answers 200 with a `<meta http-equiv="refresh">` page instead of a 301. A reader still lands on the right page. A crawler or an inbound link gets nothing, because no redirect status is ever sent. This is live on flowfuse.com today.

**Why it happens.** The docs page component redirects while rendering. The prerenderer writes that render out as a static HTML file. Netlify serves a matching static file before it consults a redirect rule, so the rule never runs.

**What this changes.** `docs-source` now reads the `layout: redirect` frontmatter at build time and turns it into a Nitro route rule. Those routes also stay out of the prerender list, so no stub file is written that could win over the rule. The netlify preset compiles the rules into `dist/_redirects`, and they resolve at the edge.

The prerender filter matches any rule that redirects, not only the generated ones. `redirects.ts` maps a few underscored docs slugs to hyphenated names, and a docs tree still carrying the old filenames used to prerender a stub that beat the rule.

The URLs this affects:

| URL | Redirects to |
|---|---|
| `/docs/user/` | `/docs/user/introduction` |
| `/docs/cloud/` | `/docs/cloud/introduction` |
| `/docs/admin/` | `/docs/admin/introduction` |
| `/docs/install/` | `/docs/install/introduction` |
| `/docs/hardware/` | `/docs/hardware/introduction` |
| `/docs/migration/` | `/docs/migration/introduction` |
| `/docs/contribute/` | `/docs/contribute/introduction` |
| `/docs/device-agent/` | `/docs/device-agent/introduction` |
| `/docs/device-agent/install/` | `/docs/device-agent/install/overview` |
| `/docs/admin/hardening/` | `/docs/admin/hardening/kubernetes/` |
| `/docs/admin/licensing/` | `/pricing/` |
| `/docs/community-support/` | Node-RED forum |

**The stub pages have to stay.** Deleting them is not an alternative fix. There is no Netlify rule for any of these paths, so the frontmatter is the only place the redirect is declared. The same frontmatter is also the docs nav definition: each stub carries the `navGroup`, `navGroupOrder`, `navTitle` and `navOrder` its whole section is grouped and labelled by, and the leaf pages do not. #5551 dropped the stubs from the sidebar and d1a2528ef had to put that metadata back.

## Related Issue(s)

None.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [x] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))
