### PR TITLE
Add previous/next links to docs pages

### DIFF
--- a/nuxt/composables/useDocsNav.ts
+++ b/nuxt/composables/useDocsNav.ts
@@ -1,7 +1,7 @@
 // The builder lives in nuxt/lib/ as plain JS so `node --test` can run it directly
 // (same reason as docs-sync.mjs); this file is the typed surface components import.
 // @ts-ignore untyped module
-import { buildDocsNav as build, findDocsBreadcrumb as findBreadcrumb } from '../lib/docs-nav.mjs'
+import { buildDocsNav as build, findDocsBreadcrumb as findBreadcrumb, findDocsSurround as findSurround, flattenDocsNav as flatten } from '../lib/docs-nav.mjs'
 
 export interface DocsNavNode {
     // Matches @nuxt/content's ContentNavigationItem shape (title/path/children)
@@ -12,7 +12,17 @@ export interface DocsNavNode {
     order: number
     // false when this section's index page is a redirect stub - see nuxt/lib/docs-nav.mjs.
     link?: boolean
+    // Whether a page of the collection sits at this path. False for a redirect stub and for
+    // a position invented to hold children: such a node names a section without being one
+    // of its pages, so it is not a stop in the reading order.
+    isPage: boolean
     children: DocsNavNode[]
+}
+
+export interface DocsNavEntry {
+    path: string
+    title: string
+    group: string
 }
 
 export interface DocsNavGroup {
@@ -44,6 +54,16 @@ export function buildDocsNav (pages: DocsNavPage[]): DocsNavGroup[] {
 
 export function findDocsBreadcrumb (groups: DocsNavGroup[], path: string): DocsNavNode[] {
     return findBreadcrumb(groups, path)
+}
+
+/** Every docs page in sidebar reading order, redirect stubs and invented positions left out. */
+export function flattenDocsNav (groups: DocsNavGroup[]): DocsNavEntry[] {
+    return flatten(groups)
+}
+
+/** The pages either side of `path` in that order, as `[previous, next]`. */
+export function findDocsSurround (groups: DocsNavGroup[], path: string): [DocsNavEntry | null, DocsNavEntry | null] {
+    return findSurround(groups, path)
 }
 
 export const useDocsNavTree = () =>

--- a/nuxt/lib/docs-nav.mjs
+++ b/nuxt/lib/docs-nav.mjs
@@ -87,6 +87,12 @@ export function buildDocsNav (pages) {
                     group: isLeaf ? (page.navGroup ?? undefined) : undefined,
                     groupOrder: isLeaf ? (page.navGroupOrder ?? undefined) : undefined,
                     order: isLeaf ? (page.navOrder ?? Infinity) : Infinity,
+                    // True only where a page of the collection actually sits. False for a
+                    // position the tree invented to hold children (e.g. /docs/user/teams
+                    // when the only page is /docs/user/teams/billing) and for a redirect
+                    // stub, which never reaches here because it is not in `linkable`.
+                    // Once true it stays true: the update below only runs at a leaf.
+                    isPage: isLeaf,
                     children: {},
                 }
             } else if (isLeaf) {
@@ -95,6 +101,7 @@ export function buildDocsNav (pages) {
                 current[part].group = page.navGroup ?? undefined
                 current[part].groupOrder = page.navGroupOrder ?? undefined
                 current[part].order = page.navOrder ?? Infinity
+                current[part].isPage = true
             }
 
             current = current[part].children
@@ -108,6 +115,7 @@ export function buildDocsNav (pages) {
             group: node.group,
             groupOrder: node.groupOrder,
             order: node.order,
+            isPage: node.isPage,
             children: toDocsNavNodes(node.children),
         }))
     }
@@ -158,4 +166,55 @@ export function findDocsBreadcrumb (groups, path) {
     // findPageBreadcrumb excludes the current page by default - callers here want the
     // full chain (they decide themselves whether the last crumb should link anywhere).
     return findPageBreadcrumb(groups.flatMap(g => g.children), path, { current: true })
+}
+
+function withoutTrailingSlash (path) {
+    return path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path
+}
+
+/**
+ * Every docs page in sidebar reading order: groups in `navGroupOrder`, sections in
+ * `navOrder`, each section followed by its own children.
+ *
+ * Only nodes with `isPage` are stops, so redirect stubs and the positions the tree
+ * invented to hold children are walked through rather than offered. Each entry carries
+ * its group name, because the sequence runs straight through the manual and a reader
+ * crossing from the last page of one group into the first of the next deserves to be told.
+ *
+ * @param {ReturnType<typeof buildDocsNav>} groups
+ * @returns {Array<{path: string, title: string, group: string}>}
+ */
+export function flattenDocsNav (groups) {
+    const pages = []
+
+    function walk (nodes, group) {
+        for (const node of nodes) {
+            if (node.isPage) pages.push({ path: node.path, title: node.title, group })
+            walk(node.children, group)
+        }
+    }
+
+    for (const group of groups ?? []) walk(group.children, group.name)
+
+    return pages
+}
+
+/**
+ * The pages either side of `path` in that reading order, as `[previous, next]`, with null
+ * where there is nothing to go to.
+ *
+ * A path that is not a page of its own, an invented node or an unknown URL, gets no
+ * neighbours rather than the neighbours of the nearest position: offering a pair of links
+ * on a page that does not render is worse than offering none.
+ *
+ * @param {ReturnType<typeof buildDocsNav>} groups
+ * @param {string} path
+ */
+export function findDocsSurround (groups, path) {
+    const pages = flattenDocsNav(groups)
+    const current = pages.findIndex(page => page.path === withoutTrailingSlash(path ?? ''))
+
+    if (current === -1) return [null, null]
+
+    return [pages[current - 1] ?? null, pages[current + 1] ?? null]
 }

--- a/nuxt/lib/docs-nav.test.mjs
+++ b/nuxt/lib/docs-nav.test.mjs
@@ -1,7 +1,7 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 
-import { buildDocsNav, findDocsBreadcrumb } from './docs-nav.mjs'
+import { buildDocsNav, findDocsBreadcrumb, findDocsSurround, flattenDocsNav } from './docs-nav.mjs'
 
 // A section is a direct child of /docs; its index page carries the group frontmatter.
 function section (path, { group, groupOrder, order, navTitle } = {}) {
@@ -206,4 +206,126 @@ test('breadcrumbs through a stubbed section use its real title', () => {
         findDocsBreadcrumb(nav, '/docs/user/concepts').map(c => c.title),
         ['Using FlowFuse', 'Concepts'],
     )
+})
+
+// A node the tree only invented to hold children, e.g. /docs/user/teams when the only page
+// beneath it is /docs/user/teams/billing, or a section whose index page is a redirect stub
+// and so never reaches `linkable`. Both are navigable positions, neither is a page.
+test('isPage separates real pages from the nodes the tree invented', () => {
+    const nav = buildDocsNav([
+        section('/docs/user', { group: 'User Manuals', groupOrder: 1, navTitle: 'Using FlowFuse' }),
+        section('/docs/user/teams/billing', { order: 1, navTitle: 'Billing' }),
+    ])
+
+    const user = nav[0].children[0]
+    assert.equal(user.isPage, true)
+    assert.equal(user.children[0].path, '/docs/user/teams')
+    assert.equal(user.children[0].isPage, false, 'teams holds billing but has no page of its own')
+    assert.equal(user.children[0].children[0].isPage, true)
+})
+
+test('a stubbed section names and groups its pages without being one of them', () => {
+    const nav = buildDocsNav([
+        redirectStub('/docs/install', { group: 'Self-Hosted', groupOrder: 1, navTitle: 'Installing FlowFuse' }),
+        section('/docs/install/introduction', { order: 1, navTitle: 'Introduction' }),
+    ])
+
+    const install = nav[0].children[0]
+    assert.equal(install.title, 'Installing FlowFuse')
+    assert.equal(install.isPage, false, 'a reader cannot land on it')
+    assert.equal(install.children[0].isPage, true)
+})
+
+test('a redirect section is not a reading stop, but its pages are', () => {
+    const nav = buildDocsNav([
+        redirectStub('/docs/install', { group: 'Self-Hosted', groupOrder: 1, navTitle: 'Installing FlowFuse' }),
+        section('/docs/install/introduction', { order: 1, navTitle: 'Introduction' }),
+        section('/docs/install/kubernetes', { order: 2, navTitle: 'Kubernetes' }),
+    ])
+
+    assert.deepEqual(flattenDocsNav(nav).map(p => p.path), ['/docs/install/introduction', '/docs/install/kubernetes'])
+    assert.deepEqual(findDocsSurround(nav, '/docs/install/introduction').map(p => p && p.path), [null, '/docs/install/kubernetes'])
+})
+
+const docsFixture = () => buildDocsNav([
+    section('/docs/user', { group: 'User Manuals', groupOrder: 1, navTitle: 'Using FlowFuse', order: 1 }),
+    section('/docs/user/concepts', { order: 2, navTitle: 'Concepts' }),
+    section('/docs/user/teams/billing', { order: 1, navTitle: 'Billing' }),
+    section('/docs/cloud', { group: 'Cloud', groupOrder: 2, navTitle: 'FlowFuse Cloud', order: 1 }),
+    section('/docs/cloud/billing', { order: 2, navTitle: 'Cloud Billing' }),
+])
+
+test('flattenDocsNav reads in sidebar order, depth first, groups in group order', () => {
+    assert.deepEqual(flattenDocsNav(docsFixture()).map(p => p.path), [
+        '/docs/user',
+        '/docs/user/concepts',
+        '/docs/user/teams/billing',
+        '/docs/cloud',
+        '/docs/cloud/billing',
+    ])
+})
+
+test('flattenDocsNav leaves out the invented nodes', () => {
+    // /docs/user/teams sits between concepts and billing in the tree and must not appear.
+    assert.ok(!flattenDocsNav(docsFixture()).some(p => p.path === '/docs/user/teams'))
+})
+
+test('each flattened page carries its group, so a card can say where it is going', () => {
+    const byPath = Object.fromEntries(flattenDocsNav(docsFixture()).map(p => [p.path, p.group]))
+
+    assert.equal(byPath['/docs/user/concepts'], 'User Manuals')
+    assert.equal(byPath['/docs/cloud/billing'], 'Cloud')
+})
+
+test('a page in the middle gets both neighbours', () => {
+    const [prev, next] = findDocsSurround(docsFixture(), '/docs/user/concepts')
+
+    assert.deepEqual([prev.path, prev.title], ['/docs/user', 'Using FlowFuse'])
+    assert.deepEqual([next.path, next.title], ['/docs/user/teams/billing', 'Billing'])
+})
+
+test('the reading path continues across a group boundary', () => {
+    // Last page of User Manuals leads into the first page of Cloud, which is why each
+    // neighbour carries its group name.
+    const [prev, next] = findDocsSurround(docsFixture(), '/docs/user/teams/billing')
+
+    assert.equal(next.path, '/docs/cloud')
+    assert.equal(next.group, 'Cloud')
+    assert.equal(prev.group, 'User Manuals')
+})
+
+test('the first page has no previous and the last has no next', () => {
+    const nav = docsFixture()
+
+    assert.equal(findDocsSurround(nav, '/docs/user')[0], null)
+    assert.equal(findDocsSurround(nav, '/docs/cloud/billing')[1], null)
+})
+
+test('a trailing slash on the current path still finds the neighbours', () => {
+    // route.path arrives with the trailing slash on a prerendered page; the tree stores
+    // paths without it.
+    const [prev, next] = findDocsSurround(docsFixture(), '/docs/user/concepts/')
+
+    assert.equal(prev.path, '/docs/user')
+    assert.equal(next.path, '/docs/user/teams/billing')
+})
+
+test('an unknown path, or an invented node, has no neighbours at all', () => {
+    const nav = docsFixture()
+
+    // Offering neighbours for a position that renders no page would put a pair of links
+    // on a page that does not exist.
+    assert.deepEqual(findDocsSurround(nav, '/docs/user/teams'), [null, null])
+    assert.deepEqual(findDocsSurround(nav, '/docs/nonexistent'), [null, null])
+})
+
+test('a single-page manual has no neighbours either way', () => {
+    const nav = buildDocsNav([section('/docs/only', { group: 'G', groupOrder: 1 })])
+
+    assert.deepEqual(findDocsSurround(nav, '/docs/only'), [null, null])
+})
+
+test('flattening an empty tree is empty, not an error', () => {
+    assert.deepEqual(flattenDocsNav([]), [])
+    assert.deepEqual(findDocsSurround([], '/docs/user'), [null, null])
 })

--- a/nuxt/pages/docs/[...slug].vue
+++ b/nuxt/pages/docs/[...slug].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useDocsNavTree, findDocsBreadcrumb } from '~/composables/useDocsNav'
+import { useDocsNavTree, findDocsBreadcrumb, findDocsSurround } from '~/composables/useDocsNav'
 import { docsPageTitle } from '~/lib/docs-page-title.mjs'
 
 definePageMeta({ layout: 'default' })
@@ -69,6 +69,21 @@ const breadcrumbItems = computed(() => {
         ...(i === withRoot.length - 1 ? {} : { to: crumb.path }),
     }))
 })
+
+// Previous and next page in sidebar reading order, so a reader finishing a page has
+// somewhere to go. Order comes from the same tree the sidebar renders, rather than from
+// queryCollectionItemSurroundings, which reads in collection order and would disagree with
+// the nav on every page. The group name rides along as the card's description, because the
+// sequence runs straight through the manual and the last page of one group leads into the
+// first of the next.
+const surround = computed(() => {
+    const [previous, next] = findDocsSurround(navGroups.value ?? [], route.path)
+    return [previous, next].map(entry => entry && ({
+        path: entry.path,
+        title: entry.title,
+        description: entry.group,
+    }))
+})
 </script>
 
 <template>
@@ -99,6 +114,7 @@ const breadcrumbItems = computed(() => {
               <FeatureTierBadges :plans="plans" />
               <ContentRenderer v-if="page" :value="page" />
             </div>
+            <UContentSurround :surround="surround" class="not-prose mb-10" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description

A reader finishing a docs page has no forward path through the manual. This adds a previous/next pair at the end of every docs page, ordered by the sidebar rather than by collection order, so it never disagrees with the nav.

Getting a trustworthy order meant fixing why it was wrong. A page whose only job is `redirect: { to }` was filtered out before the nav tree was built, so that nothing would link to a URL answering with a 301. But those pages declare their section's `navTitle`, `navGroup` and `navGroupOrder`, so twelve sections lost both: the sidebar labelled them with the directory slug (`admin`, `cloud`, `install`) and dropped them in a catch-all `Other`.

They now stay in the tree and contribute their frontmatter, with `isPage` marking them as somewhere a reader cannot land, and the linking decision moves to render time:

- a section that only redirects renders as an unlinked heading above its pages
- a childless redirect entry links to its target, so Community Support still reaches the Node-RED forum and Licensing still reaches `/pricing/`
- breadcrumbs point at a redirect crumb's target instead of the crumb

Nothing links to a redirecting URL, which was the original concern, and the sidebar gets real titles back with six real groups instead of four including `Other`.

Verified on a full production build (0 link-checker errors, no new warnings) and in the browser at 1280px and 390px.

Two pre-existing things this makes more visible, left alone here: `src/css/style.handbook.css` applies `text-transform: capitalize` to the whole nav, so a sentence-case title renders as `Migrating A Node-RED Project To FlowFuse`; and two groups contain a section of the same name, because the docs frontmatter names both the same.

## Related Issue(s)

None.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [x] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))
