### PR TITLE
Render docs nav labels as their authors wrote them

### DIFF
--- a/nuxt/components/Breadcrumbs.vue
+++ b/nuxt/components/Breadcrumbs.vue
@@ -27,10 +27,11 @@ const displayItems = computed(() => props.items.map((item, index) => ({
 </script>
 
 <template>
+  <!-- No `capitalize`: every crumb is an authored page title, so capitalising each word only
+       mangles them, the same way it did in the sidebar. -->
   <UBreadcrumb
     :items="displayItems"
     color="neutral"
-    class="capitalize"
     :ui="{ link: 'text-sm' }"
   >
     <template #separator>

--- a/src/css/style.handbook.css
+++ b/src/css/style.handbook.css
@@ -7,9 +7,13 @@
     @apply flex flex-col-reverse lg:grid lg:max-w-screen-xl 2xl:max-w-[1920px] 2xl:grid-cols-[300px,minmax(0,1fr),270px];
 }
 
+/* No text-transform here: labels render as the docs authors wrote them. Capitalising every
+   word made a section named after its directory look like a word ("install" -> "Install"),
+   which is no longer how any label is produced, and it mangled the rest: "Upgrading the
+   Node-RED version" became "Upgrading The Node-RED Version", and Bosch Rexroth's ctrlX
+   became CtrlX. 42 of the sidebar's 117 labels were altered this way. */
 .handbook-nav {
     border-right: 1px solid right;
-    text-transform: capitalize;
     --nav-weight: 500;
     --nav-color: var(--color-gray-700);
     --nav-bg: transparent;


### PR DESCRIPTION
## Description

The docs sidebar capitalised every word, which altered 42 of its 117 labels. `Installing a license` read as `Installing A License`, and Bosch Rexroth's `ctrlX` as `CtrlX`.

The rule existed to make a section named after its directory look like a word, turning `install` into `Install`. Section labels now come from the section's own `navTitle`, so nothing needs the transform. Breadcrumbs carried the same `capitalize` on the same authored titles, so that goes too.

Two files: drop `text-transform: capitalize` from `.handbook-nav`, drop `class="capitalize"` from `Breadcrumbs.vue`.

Only the docs sidebar renders `.handbook-nav`. The handbook has its own component, and no page uses the Eleventy layout that shared the class.

## Related Issue(s)

None.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))
