### PR TITLE
Stop the raw markdown endpoint serving the handbook

### DIFF
--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -170,6 +170,16 @@ export default defineNuxtConfig({
         notes: [
             'This file only covers pages served by the Nuxt frontend. Some sections of flowfuse.com are still served by a legacy Eleventy site not represented here.',
         ],
+
+        // /raw/<path>.md, the per-page markdown endpoint the links below point at, is served
+        // by @nuxt/content's own llms feature rather than by nuxt-llms, and it searches every
+        // page-type collection by default. That included the handbook, so the exclusion above
+        // only held for llms.txt while /raw/handbook/company.md answered with the same content
+        // in markdown. Same reasoning applies to both surfaces.
+        contentRawMarkdown: {
+            excludeCollections: ['handbook'],
+        },
+
         sections: [
             {
                 title: 'Documentation',


### PR DESCRIPTION
## Description

`llms.txt` deliberately leaves the handbook out, as internal company content rather than product documentation. The `/raw/<path>.md` endpoint did not: `/raw/handbook/company.md` answered 200 with the same page as markdown, so the exclusion held for one surface out of two.

`/raw/` is served by `@nuxt/content`'s own llms feature, not by `nuxt-llms`, and it searches every page-type collection unless told otherwise. Excluding the collection makes both surfaces agree.

The handbook pages stay public HTML, as they always were. This is about which surfaces present them as product documentation.

Verified on a dev server: `/raw/handbook.md`, `/raw/handbook/company.md`, `/raw/handbook/company/index.md` and `/raw/handbook/engineering/product.md` now 404, `/raw/docs/index.md` and `/raw/blog/...` still 200, `llms.txt` and `llms-full.txt` unchanged (their handbook mentions are outbound links written into docs and blog prose, not handbook content).

Two collections are still raw-readable while absent from `llms.txt`, left alone deliberately: `pages` and `stories`. Both are public product and marketing content, so exposing them is arguably a feature. Say if you would rather they match too.

## Related Issue(s)

None.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))
