### PR TITLE
prose-pre: render the filename and highlighted lines a fence asks for

### DIFF
--- a/nuxt/components/prose/ProsePre.vue
+++ b/nuxt/components/prose/ProsePre.vue
@@ -67,7 +67,23 @@ async function copyCode () {
 
 <template>
   <div v-if="language === 'mermaid'" ref="mermaidRef" class="mermaid-diagram overflow-x-auto py-4" />
-  <div v-else class="code-block group relative">
+  <div
+    v-else
+    class="code-block group relative"
+    :class="{ 'code-block--titled': filename, 'code-block--highlighted': highlights?.length }"
+  >
+    <!--
+      A fence can name the file it shows (```js [server.js]). The header sits flush on
+      top of the block, in the same slate tones as the copy button, and takes the
+      block's top margin so the two read as one object. It leaves room on the right
+      for the copy button, which then lands inside the header rather than over code.
+    -->
+    <div
+      v-if="filename"
+      class="code-block__filename mt-6 truncate rounded-t-md bg-slate-700 px-4 py-2 pr-20 font-mono text-xs text-slate-200"
+    >
+      {{ filename }}
+    </div>
     <!--
       Nuxt UI's own ProsePre ships a copy button, but this component shadows it to
       render mermaid blocks, so the button is reproduced here rather than adopting
@@ -98,5 +114,28 @@ pre {
 /* Keep code clear of the copy button in the top right corner. */
 .code-block pre {
     padding-right: 4.5rem;
+}
+
+/* With a filename header above it the block keeps one outline: the header carries the
+   top margin the <pre> would have had, and the <pre> squares off its top corners. */
+.code-block--titled pre {
+    margin-top: 0;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+}
+
+/* A fence can name lines to call out (```js {2,4-6}). The parser expands the ranges and
+   the shiki highlighter already tags those lines `highlight`, so the band is only CSS.
+   A .line is a block inside an inline <code>, which makes it stop at the <pre> content
+   box; max-content keeps the band under a line that runs on past the right edge. */
+.code-block--highlighted pre code .line.highlight {
+    width: max-content;
+    min-width: 100%;
+    /* Neutral band, brand accent down the side: readable against the near-black block
+       without competing with the syntax colours. The second, offset shadow repaints the
+       band across the right padding the copy button reserves above, so it reaches the
+       block edge. A shadow rather than a wider box, which would add a scrollbar. */
+    background-color: rgb(148 163 184 / 18%);
+    box-shadow: inset 2px 0 0 #818cf8, 4.5rem 0 0 rgb(148 163 184 / 18%);
 }
 </style>


### PR DESCRIPTION
## TL;DR

Code blocks in docs and the handbook can now say which file they are, and point at the lines that matter. Writing this in a markdown fence:

````
```js [server.js]{2,4-6}
````

gives the reader a `server.js` label on top of the block and a highlight band across lines 2, 4, 5 and 6. Both of those were already being parsed out of the fence and then thrown away, so this is turning on something the stack was doing anyway.

Nothing changes on the live site the moment this merges: no fence in the synced docs uses the syntax yet. It becomes visible when docs start using it, which is a follow-up in FlowFuse/flowfuse.

## Description

`nuxt/components/prose/ProsePre.vue` declared `filename` and `highlights` and rendered neither, so a fence like ```` ```js [server.js]{2,4-6} ```` silently lost both the file name and the called-out lines, everywhere in docs and the handbook.

- `filename` now renders as a header flush on top of the block, in the same slate tones as the copy button. The header takes the block's top margin and the block squares off its top corners, so the two read as one object. The copy button lands inside the header when there is one.
- Highlighted lines needed no new markup. The parser already expands `{2,4-6}` into line numbers and the shiki highlighter already tags those lines `highlight`, so this is a band plus a left accent rule.

A block with neither prop renders exactly as before, and the mermaid branch is untouched.

Checked in the Nuxt dev server against fences covering: filename only, a single highlighted line, a highlighted range, both props together, a plain fence, a fence with highlights and no language, and a mermaid fence. Copy button and mermaid rendering both re-verified.

## Related Issue(s)

None.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

