### PR TITLE
Fix: restore full-width prose images on blog, changelog, stories & whitepaper

### DIFF
--- a/nuxt/pages/docs/[...slug].vue
+++ b/nuxt/pages/docs/[...slug].vue
@@ -79,7 +79,7 @@ const breadcrumbItems = computed(() => {
         <!-- Page content -->
         <div class="w-full">
           <div class="order-last md:order-first">
-            <div class="mt-6 mb-4 prose prose-blue main-content handbook-content">
+            <div class="mt-6 mb-4 prose prose-blue main-content handbook-content prose-natural-size-images">
               <FeatureTierBadges :plans="plans" />
               <ContentRenderer v-if="page" :value="page" />
             </div>

--- a/nuxt/pages/handbook/[...slug].vue
+++ b/nuxt/pages/handbook/[...slug].vue
@@ -97,7 +97,7 @@ defineOgImage('Default', {
         <!-- Page content -->
         <div class="w-full">
           <div class="order-last md:order-first">
-            <div class="mt-6 mb-4 prose prose-blue main-content handbook-content">
+            <div class="mt-6 mb-4 prose prose-blue main-content handbook-content prose-natural-size-images">
               <ContentRenderer v-if="page" :value="page" />
             </div>
           </div>

--- a/src/_includes/layouts/documentation.njk
+++ b/src/_includes/layouts/documentation.njk
@@ -29,7 +29,7 @@ date: git Last Modified
         <div class="w-full">
             <!-- Main Content -->
             <div class="order-last md:order-first">
-                <div class="mt-6 mb-4 prose prose-blue main-content">
+                <div class="mt-6 mb-4 prose prose-blue main-content prose-natural-size-images">
                     {{ content | rewriteHandbookLinks(page) | safe }}
                 </div>
             </div>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -94,6 +94,7 @@
         --tw-prose-bold: var(--color-gray-500);
     }
     .prose img { max-width: 100%; }
+    .prose:not(.prose-natural-size-images) img { width: 100%; height: auto; }
 }
 
 @import "./style.page.css";


### PR DESCRIPTION
## Description

- `.prose img` in `src/css/style.css` only had `max-width: 100%`, so images render at their native pixel size instead of filling the prose column.
- Before the changelog's move to Nuxt, 11ty's `eleventy-img` pipeline resized every markdown image to the prose column's width (650px), which is why images always looked full-width. The new `nuxt/components/content/ProseImg.vue` just passes the image through with no resizing, so screenshots narrower than the column now render smaller than expected.
- Added `.prose:not(.prose-natural-size-images) img { width: 100%; height: auto; }` to restore the fill-the-column look for blog, changelog, customer-stories, and whitepaper pages.
- Added the new `prose-natural-size-images` class to handbook, docs, and the `/node-red/**` layout (`layouts/documentation.njk`), since those keep inline screenshots at their natural size.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

