### PR TITLE
Fix bare heading sizes on Nuxt pages

### DIFF
--- a/nuxt/assets/css/theme.css
+++ b/nuxt/assets/css/theme.css
@@ -1,4 +1,7 @@
-@import "tailwindcss";
+/* Skips the preflight reset (unlike the "tailwindcss" shorthand) — it would
+   duplicate the one src/css/style.css already serves for both 11ty and Nuxt. */
+@import "tailwindcss/theme.css" layer(theme);
+@import "tailwindcss/utilities.css" layer(utilities);
 @import "@nuxt/ui";
 
 /* Utility classes for the nav and footer live in this data file rather than in

--- a/nuxt/components/ChangelogListing.vue
+++ b/nuxt/components/ChangelogListing.vue
@@ -79,7 +79,7 @@ onUnmounted(() => {
       <div>
         <!-- Sized explicitly: .ff-blog leaves h1 at 16px/400, identical to the subtitle
              below it, so the heading does not read as one. -->
-        <h1 class="mb-0 text-2xl font-medium">What's new</h1>
+        <h1 class="mb-0 font-medium">What's new</h1>
         <p class="my-0 text-gray-500">Every feature, improvement and fix we ship, newest first.</p>
       </div>
       <!-- Search runs on the same Algolia index as the blog, docs and handbook, filtered

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -173,8 +173,12 @@ html, body {
 
 /*
     Standard FlowFuse Sizings
+
+    In `components`, not `base` — beats @nuxt/ui's preflight reset (also in
+    `base`) since a later layer always wins, while still losing to explicit
+    size classes (e.g. `text-4xl`) in `utilities`.
 */
-@layer base {
+@layer components {
     h1 {
         font-size: 2.75rem;
         line-height: 3.1rem;


### PR DESCRIPTION
## Description

- Bare h1-h5 tags (no explicit Tailwind size class) on Nuxt-served pages rendered at browser-default size instead of the site's intended defaults, because @nuxt/ui's Tailwind v4 preflight reset shared the same `base` layer as style.css's heading rules and won on source order.
- Moved the heading-size rules to the `components` layer, which always wins over `base` regardless of load order, while still losing to explicit size utilities (e.g. `text-4xl`).
- Also removed a duplicate Tailwind preflight: `nuxt/assets/css/theme.css` was pulling in its own preflight via the `tailwindcss` shorthand import, redundant with the one `style.css` already serves for both 11ty and Nuxt.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

