### PR TITLE
Remove /email-signature from legacy.ts's still-to-migrate list

### DIFF
--- a/nuxt/server/middleware/legacy.ts
+++ b/nuxt/server/middleware/legacy.ts
@@ -14,7 +14,7 @@ const NUXT_PREFIXES = ['/handbook', '/ebooks', '/whitepaper', '/pricing', '/docs
 
 // Top-level routes still on 11ty, not yet ported to Nuxt (everything not listed above
 // already falls through to the 11ty proxy by default). Remove entries here as they migrate:
-// / (homepage), /about, /ai, /blueprints, /careers, /community, /email-signature, /events,
+// / (homepage), /about, /ai, /blueprints, /careers, /community, /events,
 // /free-consultation, /industries, /landing, /node-red, /partners, /platform,
 // /professional-services, /support, /use-cases, /vs, /webinars
 


### PR DESCRIPTION
## Summary
- `/email-signature` was retired (not migrated) once the handbook got a live inline signature example, so it no longer belongs in the "still on 11ty" comment in `nuxt/server/middleware/legacy.ts`.

## Test plan
- [x] Verified every current Nuxt route/prefix under `nuxt/pages/` is correctly listed in `legacy.ts`'s `NUXT_ROUTES`/`NUXT_ROUTE_PREFIXES`/`NUXT_PREFIXES`.