### PR TITLE
Add active voice bullet with education link

### DIFF
--- a/nuxt/content/handbook/marketing/brand-voice.md
+++ b/nuxt/content/handbook/marketing/brand-voice.md
@@ -64,6 +64,8 @@ This “character” comes through in everything we do: product design, document
 Whether writing an email, blog post, tweet, UI message, or sales pitch:
 
 - **Lead with clarity.** Avoid intros that bury the point. Say what matters, early.
+- **Write in active voice.** Name who does the thing. "FlowFuse deploys your flows", not "your flows are deployed by FlowFuse". Passive voice hides the actor and adds words.
+  - See [Use the active voice](https://writing.wisc.edu/handbook/ccs_activevoice/) for how to spot and fix it — and the handful of cases where passive is the better choice.
 - **Support with value.** Back up claims with real features, use cases, or customer wins.
 - **Reflect empathy.** Know your audience’s context and pain points.
 - **Use consistent terminology.** Refer to our features, solutions, and mission the same way across channels.


### PR DESCRIPTION
## Description

This PR adds a bullet point to write in `active voice`. Active voice places the focus on the subject and the action the subject's taking, making the copy more direct and engaging.

## Related Issue(s)

None, I'm just _persnickety_.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

