### PR TITLE
changelog: land a release deep link at the top of the viewport

### DIFF
--- a/nuxt/components/ChangelogListing.vue
+++ b/nuxt/components/ChangelogListing.vue
@@ -105,7 +105,7 @@ onUnmounted(() => {
         v-for="group in visibleGroups"
         :id="anchorId(group.release)"
         :key="group.release"
-        class="flex scroll-mt-24"
+        class="flex"
       >
         <!-- pt-7 so the label lines up with the first entry's title rather than sitting
              above it: each entry carries `my-2 py-6` before its title, which this column


### PR DESCRIPTION
## TL;DR

Follow-up to #5590. A link like `/changelog/#release-2-30` did not put that release at the top of the screen. It stopped well short, with the tail end of the newer release still visible above it, so it was not obvious which release the link meant.

One class removed. The group now lands just under the sticky header.

## Description

The release group had `scroll-mt-24` (96px) on it, and `src/css/style.css` already sets `scroll-padding-top: 75px` on the document for every anchor on the site. Those two add together rather than one replacing the other, so a release deep link came to rest roughly 170px down the viewport. Removing the class leaves the site-wide inset to do the job.

Draft while CI runs and the deploy preview builds. Worth checking on the preview at a narrow width as well as desktop, since the header height changes with the breakpoint.

## Related Issue(s)

None.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))