### PR TITLE
Fix cookie preferences link on book-demo fallback

### DIFF
--- a/nuxt/components/HubSpotMeetings.vue
+++ b/nuxt/components/HubSpotMeetings.vue
@@ -54,7 +54,8 @@ onMounted(() => {
         Prefer to view availability on this page?<br>
         <a
           class="cursor-pointer text-indigo-200 underline"
-          @click="() => (window as any).CookieConsent && (window as any).CookieConsent.showPreferences()"
+          type="button"
+          data-cc="show-preferencesModal"
         >Enable analytics cookies.</a>
       </p>
     </div>


### PR DESCRIPTION
## Description

The "Enable analytics cookies" link on `/book-demo/` wasn't opening the cookie banner. Fixed by using vanilla-cookieconsent's own `data-cc="show-preferencesModal"` attribute.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

