### PR TITLE
Add PLC Integration link to Platform > Capabilities nav

### DIFF
--- a/src/_data/chrome.json
+++ b/src/_data/chrome.json
@@ -85,7 +85,7 @@
                     {
                         "title": "Capabilities",
                         "titleGrid": "md:col-start-3 md:row-start-1 xl:col-start-4",
-                        "listClasses": "row-span-[7] md:col-start-3 md:row-start-2 xl:col-start-4",
+                        "listClasses": "row-span-[8] md:col-start-3 md:row-start-2 xl:col-start-4",
                         "links": [
                             {
                                 "label": "Industrial AI",
@@ -121,11 +121,16 @@
                                 "label": "Data Integration",
                                 "href": "/use-cases/data-integration/",
                                 "icon": "arrows-right-left"
+                            },
+                            {
+                                "label": "PLC Integration",
+                                "href": "/landing/plc/",
+                                "icon": "cog-6-tooth"
                             }
                         ]
                     }
                 ],
-                "megaClasses": "narrow mega md:grid md:grid-flow-col md:grid-rows-[repeat(8,auto)] md:pr-1 md:auto-rows-auto items-center",
+                "megaClasses": "narrow mega md:grid md:grid-flow-col md:grid-rows-[repeat(9,auto)] md:pr-1 md:auto-rows-auto items-center",
                 "highlight": "platform"
             },
             {
@@ -524,6 +529,10 @@
                             {
                                 "label": "Data Integration",
                                 "href": "/use-cases/data-integration/"
+                            },
+                            {
+                                "label": "PLC Integration",
+                                "href": "/landing/plc/"
                             }
                         ],
                         "classes": "lg:col-start-2 lg:row-start-1 lg:row-span-2"


### PR DESCRIPTION
Links the existing /landing/plc/ page from the main nav (header + footer) so it's discoverable, not just reachable via direct URL/SEO.

## Description

<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

