### PR TITLE
SEO: rewrite titles/meta and trim length on 9 manufacturing blog posts

### DIFF
--- a/nuxt/redirects.ts
+++ b/nuxt/redirects.ts
@@ -105,6 +105,7 @@ export const redirects: Record<string, NitroRouteRules> = {
     '/blog/2025/04/building-oee-dashboard-with-flowfuse-2/': { redirect: { to: '/blog/2025/04/build-manufacturing-oee-dashboard/', statusCode: 301 } },
     '/blog/2025/04/building-oee-dashboard-with-flowfuse-part-3/': { redirect: { to: '/blog/2025/04/design-and-scale-oee-dashboard/', statusCode: 301 } },
     '/sign-up/': { redirect: { to: 'https://app.flowfuse.com/account/create', statusCode: 301 } },
+    '/blog/2025/12/what-is-mttf/': { redirect: { to: '/blog/2025/12/mttf-vs-mtbf-vs-mttr/', statusCode: 301 } },
 
     '/handbook/development/contributing/': { redirect: { to: '/handbook/engineering/contributing/', statusCode: 301 } },
     '/changelog/2025/06/instance-performance-view/': { redirect: { to: '/changelog/2025/06/team-performance-view/', statusCode: 301 } },

--- a/src/blog/2025/08/pareto-chart-manufacturing-guide.md
+++ b/src/blog/2025/08/pareto-chart-manufacturing-guide.md
@@ -1,15 +1,18 @@
 ---
 metaTitle: "Pareto Chart & Diagram: Formula & Examples"
-title: "Pareto Chart & Diagram: What It Is, Formula, Examples & Manufacturing Applications"
+title: "Pareto Chart & Diagram: What It Is, Formula & Examples"
 subtitle: "How the Pareto principle helps manufacturing teams focus where it matters most."
-description: "Learn how Pareto Charts and diagrams help manufacturing teams reduce defects by up to 80%, with formulas and real examples."
+description: "What is a Pareto chart? See the formula, a real manufacturing example, and how teams use the 80/20 rule to cut defects by up to 70%."
 date: 2025-08-28
 lastUpdated: 2025-12-29
 keywords: Pareto chart, Pareto diagram, Pareto analysis, manufacturing quality, defect reduction, quality control tools, root cause analysis, equipment maintenance, supply chain management, manufacturing efficiency
 authors: ["sumit-shinde"]
-image: /blog/2025/08/images/pareto-chart-manufacturing-guide.png
 tags:
   - flowfuse
+cta:
+  type: contact
+  title: "Turn Defect Data Into a Live Pareto Chart"
+  description: "FlowFuse connects to your production systems so your Pareto analysis updates itself instead of a static monthly report."
 meta:
   faq:
     - question: "Is a Pareto chart the same as a Pareto diagram?"
@@ -50,9 +53,11 @@ meta:
 tldr: "A Pareto chart pairs a descending bar chart with a cumulative percentage line to show which problems account for the greatest impact, based on the 80/20 principle. Manufacturing teams use it to decide where limited improvement resources will pay off most, and FlowFuse can generate one automatically from live production data."
 ---
 
-A Pareto Chart helps manufacturing teams cut through the chaos when problems arrive in clusters, defects, delays, downtime, and customer complaints all competing for attention. With limited resources and time, how do you decide which fire to put out first?
+When defects, delays, downtime, and customer complaints all show up at once, most teams don't have the resources to fix everything, so they end up fixing whatever's loudest instead of whatever matters most. A Pareto chart fixes that: it sorts the noise from the handful of causes actually driving your losses.
 
 <!--more-->
+
+## What Is a Pareto Chart?
 
 A Pareto Chart is a decision-making tool that reveals which problems deserve immediate attention and which can wait. Based on the principle that roughly 80% of problems stem from 20% of causes, this visual tool transforms chaos into clarity. It shows manufacturing teams exactly where to focus their efforts for maximum impact.
 
@@ -117,8 +122,6 @@ A Pareto diagram combines the best of both worlds, the immediate clarity of a ba
 
 - **The Axes Frame the Decision**: The left axis measures actual occurrences, the right shows cumulative percentage, and the horizontal axis lists your problem categories. Together, they create a complete picture that anyone can understand and act upon.
 
-This visualization does something remarkable: it makes the invisible visible. Problems that seemed equally important suddenly reveal their true impact. The path forward becomes clear.
-
 ## Pareto Real World Example
 
 ![Pareto diagram showing defect categories in manufacturing with bars for scratches, cracks, color issues, and other defects, alongside a cumulative percentage line.](./images/pareto-chart-image.png){data-zoomable}
@@ -164,17 +167,9 @@ Safety resources are precious. Pareto diagrams ensure they go where they will ha
 
 ## Why Pareto Charts Matter Now More Than Ever
 
-Manufacturing is more complex than ever. Global supply chains, tight margins, and higher quality expectations mean every decision and every resource matters. Pareto charts help teams focus on what truly drives problems and results.
+Manufacturing is more complex than ever, global supply chains, tight margins, and higher quality expectations mean every decision matters. Pareto charts cut analysis time from days to minutes: operators, engineers, and executives can read the same chart and reach the same conclusion without deep statistical knowledge.
 
-One major benefit is speed of decision-making. In manufacturing, slow decisions cost money. A Pareto chart reduces analysis time from days to minutes. With a quick look, teams can see which issues matter most and where action is needed.
-
-Another advantage is that Pareto charts are easy to understand. Operators, engineers, and executives can all read the same chart and reach the same conclusion. This shared understanding improves alignment and speeds up action without requiring deep statistical knowledge.
-
-Pareto charts also make progress visible. When charts are updated regularly, it becomes clear whether improvements are working. When the largest bars shrink or rankings change, teams can see real results instead of relying on assumptions.
-
-Beyond solving daily problems, Pareto charts support long-term strategy. Repeated patterns across multiple charts can reveal deeper issues. If supplier-related problems appear at the top again and again, it may signal the need to rethink sourcing. If equipment failures dominate, investment in maintenance, upgrades, or automation may be justified.
-
-Organizations that track Pareto trends over time can also prevent future problems. When a small issue starts moving up the chart month after month, teams can investigate early and address it before it becomes a major disruption.
+Updated regularly, they also make progress visible and reveal longer-term strategy. If supplier-related problems keep topping the chart, it may signal the need to rethink sourcing. If equipment failures dominate month after month, that's your signal to invest in maintenance or automation before a small issue becomes a major disruption.
 
 ## Conclusion
 
@@ -186,8 +181,4 @@ But knowing the principle and applying it in real-time are two different challen
 
 The first step is always the hardest, and the most important. Choose one persistent problem area this week. Gather the data. Build your first Pareto Chart. You'll be surprised how quickly priorities become obvious and how fast your team aligns around them.
 
-**Next up:** read our article on [building interactive Pareto diagrams in FlowFuse](/blog/2025/09/creating-pareto-chart/) that connect directly to your production systems.
-
-**Ready to transform your manufacturing data into actionable insights?** 
-
-Stop guessing which problems to tackle first. [Try FlowFuse free for 30 days](https://app.flowfuse.com/account/create) and build automated Pareto Charts that connect directly to your production data, or [see a live demo](/book-demo/) of how leading manufacturers identify their vital few problems in real-time.
+Read next: [building interactive Pareto diagrams in FlowFuse](/blog/2025/09/creating-pareto-chart/) that connect directly to your production systems.

--- a/src/blog/2025/09/it-vs-ot-difference-between-information-technology-and-operational-technology.md
+++ b/src/blog/2025/09/it-vs-ot-difference-between-information-technology-and-operational-technology.md
@@ -1,16 +1,19 @@
 ---
-metaTitle: "IT vs OT: Key Differences & Security Risks"
-title: "IT vs OT: Key Differences, Security Risks, and IT/OT Convergence"
+metaTitle: "IT vs OT: Key Differences & OT Cybersecurity"
+title: "IT vs OT: Key Differences, OT Cybersecurity, and IT/OT Convergence"
 subtitle: "Two systems. Two priorities. One secure path to convergence."
-description: "IT vs OT explained for manufacturing in 2026: the key differences, security risks, and how to securely converge the two."
+description: "IT vs OT explained: what operational technology is, how it differs from IT, OT cybersecurity risks, and how to converge them securely."
 date: 2025-09-08
 lastUpdated: 2025-12-19
 authors: ["sumit-shinde"]
 video: gA-zR1XbBDI
-image: /blog/2025/09/images/it-vs-ot-difference-between-information-technology-and-operational-technology.png
 keywords: it vs ot, difference between it and ot, what is ot vs it, it versus ot, it vs ot definition, it vs ot meaning, difference between ot and it, what is the difference between it and ot, it vs ot systems, what is it vs ot, what's the difference between it and ot, what is difference between it and ot, what is the difference between ot and it, it ot security, it ot convergence, scada systems, plc systems, industrial control systems
 tags:
   - flowfuse
+cta:
+  type: contact
+  title: "Plan Your IT/OT Convergence Securely"
+  description: "FlowFuse is built on Node-RED with role-based access, audit logging, and network isolation. Talk to our team about your architecture."
 meta:
   faq:
   - question: "What is the difference between IT and OT?"
@@ -50,195 +53,56 @@ meta:
     answer: "Network segmentation creates defense-in-depth architecture by separating IT and OT networks with controlled interfaces. Industrial DMZs manage data flow between environments, preventing threats from freely moving between systems. Proper segmentation ensures that even if IT systems are compromised, attackers cannot directly access production control systems."
 ---
 
-IT vs OT is one of the most critical distinctions in modern manufacturing, representing two fundamentally different technology ecosystems: Information Technology (IT) and Operational Technology (OT). Understanding how these systems differ, and how to secure and integrate them, isn’t just a technical necessity. It’s a competitive advantage that prevents downtime, reduces cyber risk, and unlocks operational efficiency.
+**Operational Technology (OT)** is the hardware and software that monitors and controls physical equipment and processes: PLCs, SCADA, DCS, and machinery on the plant floor. **Information Technology (IT)** is the systems that run the business: email, ERP, databases, and cloud applications. IT vs OT comes down to managing information versus controlling physical processes, and that one difference drives everything else: security priorities, update cycles, equipment lifespan, and downtime tolerance.
 
-## What is Information Technology (IT)?
+Connecting the two (IT/OT convergence) is central to Industry 4.0, but it only works once you understand where these systems differ and why.
 
-Information Technology encompasses the systems, software, and infrastructure that manage your business data and enable enterprise operations. IT systems handle everything from [email](/node-red/notification/email/) and [databases](/node-red/database/) to enterprise resource planning (ERP), customer relationship management (CRM), and business intelligence platforms.
+## What is OT (Operational Technology)?
 
-Your IT infrastructure manages data storage and processing, enterprise communications like email and video conferencing, business applications for finance and accounting, and customer and supplier management systems. These systems increasingly rely on cloud services and software-as-a-service applications that enable flexible, scalable operations.
+OT is the umbrella term for the systems that directly run production: [Programmable Logic Controllers (PLCs)](/blog/2025/10/plc-to-mqtt-using-flowfuse/) that execute real-time control logic, [SCADA](/use-cases/scada/) systems that provide centralized monitoring across distributed sites, Distributed Control Systems (DCS) for complex continuous processes, and [Human-Machine Interfaces (HMI)](/blog/2025/11/building-hmi-for-equipment-control/) that give operators visualization and control. Safety Instrumented Systems, Building Management Systems, and [Manufacturing Execution Systems (MES)](/use-cases/mes/) round out the OT landscape. Collectively, these are known as Industrial Control Systems (ICS).
 
-The defining characteristics of IT systems reflect their business-oriented nature. They prioritize data confidentiality and integrity above all else, stay connected to external networks and the internet for collaboration and communication, and receive regular updates and patches on monthly or quarterly cycles. IT systems use standardized protocols like TCP/IP, HTTP, and HTTPS that enable straightforward connectivity. Most IT equipment has a typical lifecycle of three to five years before replacement, designed with flexibility and scalability as core requirements. When IT systems need maintenance, businesses can usually tolerate downtime measured in minutes to hours.
+OT prioritizes safety, availability, and reliability above everything else. These systems were historically air-gapped, receive updates rarely (often only during planned shutdowns), and communicate over industrial protocols like [Modbus](/node-red/protocol/modbus/), Profibus, [OPC-UA](/blog/2025/07/reading-and-writing-plc-data-using-opc-ua/), and [EtherNet/IP](/blog/2025/10/using-ethernet-ip-with-flowfuse/) rather than standard internet protocols. Equipment stays in service for 15-25+ years, runs on millisecond timing, and has essentially zero tolerance for downtime: every stopped minute costs money.
 
-## What is Operational Technology (OT)?
+## What is IT (Information Technology)?
 
-Operational Technology refers to the hardware and software systems that monitor and control physical devices, processes, and infrastructure in industrial environments. OT directly manages your production operations, making it the backbone of manufacturing execution.
+IT covers the systems, software, and infrastructure that manage business data and enable enterprise operations: [email](/node-red/notification/email/) and [databases](/node-red/database/), ERP and CRM platforms, business intelligence, and increasingly cloud and SaaS applications.
 
-OT systems include Industrial Control Systems (ICS), which serve as the umbrella term for all control systems used in industrial operations. Within this category, you'll find [Supervisory Control and Data Acquisition (SCADA)](/use-cases/scada/) systems that provide centralized monitoring and control, [Programmable Logic Controllers (PLCs)](/blog/2025/10/plc-to-mqtt-using-flowfuse/) that execute real-time control logic, and Distributed Control Systems (DCS) that manage complex continuous processes. [Human-Machine Interfaces (HMI)](/blog/2025/11/building-hmi-for-equipment-control/) provide operators with visualization and control capabilities, while Safety Instrumented Systems (SIS) protect people and equipment from hazardous conditions. Building Management Systems (BMS) and [Manufacturing Execution Systems (MES)](/use-cases/mes/) round out the OT ecosystem.
+IT prioritizes data confidentiality and integrity, stays connected to the internet by default, and receives patches on monthly or quarterly cycles over standardized protocols like TCP/IP, HTTP, and HTTPS. Equipment typically cycles out every 3-5 years, and businesses can usually tolerate minutes-to-hours of downtime for maintenance.
 
-The characteristics of OT systems stand in stark contrast to IT. OT prioritizes safety, availability, and reliability above everything else. These systems were historically air-gapped or completely isolated from external networks, receiving infrequent updates, often annually or only when absolutely necessary during planned shutdowns. OT environments rely on proprietary and industrial protocols like [Modbus](/node-red/protocol/modbus/), Profibus, [OPC-UA](/blog/2025/07/reading-and-writing-plc-data-using-opc-ua/), [EtherNet/IP](/blog/2025/10/using-ethernet-ip-with-flowfuse/), and DeviceNet rather than standard internet protocols. Equipment lifecycles stretch fifteen to twenty-five years in operation, designed for stability and deterministic performance rather than flexibility. In OT, downtime tolerance is essentially zero because every minute of stopped production directly costs money. Real-time processing happens in milliseconds, where timing precision can mean the difference between safe operation and catastrophic failure.
+## IT vs OT: Key Differences
 
-## IT vs OT: Understanding the Real Differences
-
-Information Technology (IT) and Operational Technology (OT) are often discussed together, but they were created to solve very different problems. Before connecting these systems, it’s critical to understand where they differ and why those differences matter in real-world manufacturing environments.
-
-Simply put, **IT manages information**, while **OT controls physical processes**. IT systems support business operations such as finance, planning, communication, and analytics. OT systems directly run machines, production lines, and safety-critical infrastructure. Because OT interacts with the physical world, its requirements for reliability, timing, and safety are far stricter than those of IT systems.
-
-The table below summarizes the most important distinctions between IT and OT.
-
-## IT vs OT: Side-by-Side Comparison
+IT manages information; OT controls physical processes. IT systems support finance, planning, and analytics, while OT systems directly run machines, production lines, and safety-critical infrastructure. Because OT interacts with the physical world, its requirements for reliability, timing, and safety are far stricter than IT's.
 
 | Dimension                      | Information Technology (IT)                         | Operational Technology (OT)                         |
-| ------------------------------ | --------------------------------------------------- | --------------------------------------------------- |
+| ------------------------------- | --------------------------------------------------- | --------------------------------------------------- |
 | **Primary Role**               | Manage business data and digital workflows          | Control and monitor physical equipment              |
 | **Main Priority**              | Efficiency, data integrity, and confidentiality     | Safety, availability, and reliability               |
 | **Operating Environment**      | Offices, data centers, cloud platforms              | Factory floors, plants, field locations             |
 | **Typical Systems**            | ERP, CRM, email, databases, cloud apps              | PLCs, SCADA, DCS, HMIs, SIS, MES                    |
-| **What Is Controlled**         | Information and processes                           | Machines and industrial operations                  |
 | **Impact of Downtime**         | Reduced productivity and service disruption         | Production stoppage and safety risk                 |
 | **Downtime Tolerance**         | Minutes to hours                                    | Near zero                                           |
 | **Response Time Requirements** | Seconds to minutes                                  | Milliseconds to seconds                             |
-| **System Lifecycle**           | 3–5 years                                           | 15–25+ years                                        |
+| **System Lifecycle**           | 3-5 years                                           | 15-25+ years                                        |
 | **Patch & Update Frequency**   | Regular and frequent                                | Rare and carefully scheduled                        |
 | **Connectivity Model**         | Internet and cloud by default                       | Historically isolated, now selectively connected    |
 | **Protocols Used**             | TCP/IP, HTTP/HTTPS, REST, SQL                       | Modbus, OPC-UA, Profibus, EtherNet/IP               |
 | **Security Priority Model**    | **CIA**: Confidentiality → Integrity → Availability | **AIC**: Availability → Integrity → Confidentiality |
-| **Security Approach**          | Patching, endpoint security, zero trust             | Segmentation, monitoring, minimal disruption        |
-| **Change Management Style**    | Fast and iterative                                  | Slow, controlled, and risk-averse                   |
 | **Failure Consequences**       | Data loss or system outage                          | Equipment damage, safety incidents                  |
 | **Regulatory Emphasis**        | Data protection and compliance                      | Safety and critical infrastructure protection       |
 | **Typical Skill Sets**         | IT, networking, cybersecurity                       | Automation, electrical, mechanical engineering      |
 
-## The Growing Convergence of IT and OT
+## IT/OT Convergence
 
-Historically, IT and OT operated in complete isolation. Your factory floor systems never touched corporate networks, and your business systems had no visibility into production processes. This separation provided natural security but created information silos that limited operational intelligence and prevented data-driven decision making.
+Historically, IT and OT operated in complete isolation: factory floor systems never touched the corporate network, and business systems had no visibility into production. Industry 4.0, the Industrial Internet of Things (IIoT), and smart manufacturing are now driving IT/OT convergence: connecting production equipment to business systems for real-time monitoring, predictive maintenance, quality feedback loops, energy optimization, and automated supply chain integration.
 
-Today, Industry 4.0, the Industrial Internet of Things (IIoT), and smart manufacturing initiatives are driving unprecedented IT/OT convergence. Manufacturers are connecting production equipment to business systems to enable real-time production monitoring and analytics, predictive maintenance based on equipment data, automated supply chain integration, quality management with immediate feedback loops, and energy optimization across operations. Remote monitoring and control capabilities that were once impossible are now becoming standard expectations.
+Done well, convergence delivers concrete results: real-time dashboards instead of end-of-shift reports, condition-based maintenance that catches failures before they happen, immediate quality feedback that cuts scrap and rework, and inventory and logistics systems that react to actual consumption instead of forecasts.
 
-This convergence is driven by shared goals that benefit from integration. Both IT and OT teams want operational efficiency and cost reduction, data-driven decision making, improved asset utilization, and enhanced quality control. Regulatory compliance and reporting requirements increasingly demand integrated data from both environments. Perhaps most compellingly, competitive advantage now flows from digital transformation that breaks down the walls between business and operational systems.
+Making it work takes more than connectivity, though. Start with clear business objectives and a handful of high-ROI use cases rather than a big-bang integration project. Design security in from the start (see below), and don't skip the organizational side: IT teams are used to iterating fast and patching often, while OT teams prioritize stability and uptime above all else, so successful projects build cross-functional teams and shared goals rather than treating convergence as a pure IT initiative. The most common failure mode is treating convergence as a technology project instead of a business one: without clear objectives, executive sponsorship, and OT involvement from day one, projects deliver connectivity without value.
 
-Despite their differences, IT and OT systems share more similarities than many realize. Both require robust access controls and authentication mechanisms. Both generate valuable data for business insights when properly captured and analyzed. Both face increasing cybersecurity threats that demand attention. Both benefit from modern technologies like artificial intelligence, machine learning, and cloud computing. Both require skilled personnel for effective management and maintenance. And both are absolutely critical to business continuity, failure in either domain can cripple operations.
+## OT Cybersecurity
 
-## The Critical Challenge: Cybersecurity in IT/OT Convergence
+Connecting OT to business networks, and potentially the internet, exposes production systems to threats they were never designed to withstand. Traditional IT security assumptions break down in OT environments for a few structural reasons: OT systems often can't be patched without a production stoppage, and some legacy equipment can't be patched at all; OT flips the IT security priority model from confidentiality-first (**CIA**) to availability-first (**AIC**), since stopping a line can cost more, and be more dangerous, than the threat it prevents; and OT's millisecond timing requirements mean standard IT tools like network scanners can crash a PLC that was never built to handle that traffic.
 
-While IT/OT convergence delivers substantial benefits, it also creates significant cybersecurity risks. When you connect production systems to business networks, and potentially to the internet, you expose critical operational infrastructure to cyber threats that were previously impossible. Understanding these risks and implementing appropriate security measures isn't optional. It's essential for protecting your operations, your people, and your business.
+The threats are real and growing: ransomware that specifically targets manufacturers because downtime pressure makes them more likely to pay, nation-state actors probing critical infrastructure, insider access being misused, compromised vendor and supply-chain access, and, ironically, well-meaning IT security scans that take down OT equipment by accident.
 
-### Why OT Security Differs Fundamentally from IT Security
-
-Traditional IT security assumptions simply don't apply in OT environments, creating dangerous gaps when IT security approaches are applied without modification. IT security relies heavily on regular patching and updates to address vulnerabilities. OT systems often can't be updated without production downtime, and some legacy equipment literally cannot be patched because vendors no longer support decades-old systems or the equipment lacks the computing resources for security updates.
-
-The availability versus confidentiality trade-off creates fundamental conflicts between IT and OT security priorities. IT security teams will gladly take systems offline to patch critical vulnerabilities or investigate potential breaches. OT security must prioritize system availability and safety above all else, a security measure that stops production or creates safety risks is worse than the threat it prevents. This isn't about OT teams being lax about security. It's about the reality that stopping a production line costs thousands of dollars per minute, and certain security measures could literally endanger human lives.
-
-System lifespan differences compound security challenges. IT equipment is replaced every few years, ensuring relatively current security capabilities. OT systems run for decades, meaning manufacturing facilities commonly operate equipment from the 1990s or early 2000s that was never designed with cybersecurity in mind. This equipment predates modern security threats and often lacks basic capabilities like encryption, authentication logging, or network security features.
-
-Real-time requirements in OT systems prevent the use of many standard IT security tools and techniques. OT systems control physical processes with millisecond timing requirements where deterministic behavior is critical. Security measures that introduce latency, even small amounts, can cause safety issues or production failures. Network scans, intrusion detection systems, and other IT security tools that work perfectly in business networks can inadvertently crash industrial controllers or disrupt critical timing.
-
-Legacy equipment presents perhaps the most intractable security challenge. Manufacturing facilities contain equipment from dozens of vendors spanning multiple decades. Much of this equipment was designed when industrial networks were completely isolated, so it has no security features whatsoever. Usernames and passwords might be hardcoded and unchangeable. Communications happen in cleartext with no encryption. These systems were built to last and they do their jobs perfectly, they just can't be secured using modern security practices.
-
-### Understanding Real Cybersecurity Threats to OT Systems
-
-The threat landscape for OT environments is serious and growing. Ransomware attacks increasingly target manufacturing facilities because cybercriminals understand that production downtime pressure makes companies more likely to pay ransoms. A single ransomware attack can cost millions in downtime and recovery, even if no ransom is paid. Manufacturing targets are attractive because unlike IT systems where data can be restored from backups, stopping production creates immediate financial pain.
-
-Nation-state attacks represent sophisticated threats to critical infrastructure and manufacturing capabilities. State-sponsored actors seek to disrupt operations, steal intellectual property, or establish persistent access for future attacks. These attacks are often discovered only after months or years of presence in target networks, during which time attackers map systems, exfiltrate data, and position themselves for maximum impact.
-
-Insider threats from disgruntled employees or contractors with access to OT systems can cause significant damage through malicious action or negligent behavior. Someone with legitimate access and knowledge of industrial systems can bypass security controls that would stop external attackers. The damage can range from sabotage of production systems to theft of proprietary processes and formulations.
-
-Supply chain compromises introduce vulnerabilities through third-party equipment, software, or vendor access. When a vendor's remote access credentials are compromised, attackers gain legitimate pathways into OT environments. Equipment may ship with malware pre-installed or contain undisclosed backdoors. Software updates from trusted vendors can be compromised to distribute malware to multiple customers simultaneously.
-
-Perhaps ironically, unintentional disruptions from well-meaning IT actions cause frequent problems. IT security scans or updates applied to OT networks can inadvertently crash industrial systems that can't handle the traffic patterns or protocol variations. A network scan that's routine for IT systems might overwhelm a PLC that was never designed to handle that volume or type of network traffic.
-
-### Implementing Effective OT/IT Security
-
-Network segmentation provides the foundational defense for converged IT/OT environments. Implementing defense-in-depth architecture with clear separation between IT and OT networks prevents threats from freely moving between environments. Industrial DMZs (demilitarized zones) control data flow between environments through strictly managed interfaces. The cardinal rule: never allow direct connectivity from the internet to OT networks, regardless of business pressure or convenience arguments.
-
-Asset inventory and visibility seem basic but prove surprisingly challenging in practice. Maintaining comprehensive inventories of all OT assets including hardware specifications, software versions, communication protocols, and system dependencies requires ongoing effort. Shadow IT in OT, unauthorized equipment connected to industrial networks, creates unknown vulnerabilities. You cannot secure what you don't know exists, making discovery and inventory continuous processes rather than one-time projects.
-
-Access control and authentication require careful implementation that balances security with operational requirements. Role-based access controls with the principle of least privilege ensure people can do their jobs but nothing more. Multi-factor authentication for remote access adds protection without adding excessive friction for legitimate users. Regular reviews of access permissions catch orphaned accounts and excessive privileges that accumulate over time.
-
-Industrial security monitoring deploys OT-specific security tools that understand industrial protocols and can detect anomalous behavior without disrupting operations. Traditional IT security tools often aren't appropriate for OT environments because they don't understand industrial protocols, introduce unacceptable latency, or generate false positives that create alert fatigue. Purpose-built industrial security platforms can monitor traffic, detect threats, and alert security teams while respecting OT's unique requirements.
-
-Vendor and third-party management controls one of the largest attack surfaces in OT environments. Carefully controlling vendor access to OT systems through jump servers, time-limited credentials, and continuous monitoring protects against both malicious actors and accidental damage. Every remote access session should be logged and auditable. Vendors should access only the specific systems they need, not entire network segments.
-
-Backup and recovery planning takes on special importance in OT environments. Maintaining offline backups of critical OT configurations, PLC programs, HMI setups, and system documentation enables recovery when systems are compromised or fail. Testing recovery procedures regularly ensures they work when needed, because restoring OT systems is fundamentally different from IT recovery. You can't simply restore from last night's backup if that backup is months old or doesn't include the custom programming that makes your production line run.
-
-Security awareness training must address the unique requirements of converged environments. IT staff need to understand OT constraints including real-time requirements, change management processes, and why their normal security tools can't be used without modification. OT staff need to understand cybersecurity fundamentals including threat landscapes, attack vectors, and security best practices. Building mutual understanding between IT and OT teams prevents dangerous assumptions and enables effective collaboration.
-
-Regulatory compliance provides frameworks and requirements for industrial security. Industry-specific standards like IEC 62443 for industrial automation security, NERC-CIP for critical infrastructure protection, and NIST Cybersecurity Framework guidance for industrial systems establish baseline security practices. Compliance isn't just about checking boxes, these standards codify lessons learned from incidents across industries and provide structured approaches to industrial security.
-
-## Technical Deep Dive: Core OT Technologies
-
-Industrial Control Systems (ICS) serves as the umbrella term for all control systems used in industrial operations. ICS includes SCADA systems, distributed control systems, programmable logic controllers, and related technologies that monitor and control industrial processes across manufacturing, energy production, water treatment, chemical processing, and critical infrastructure sectors. Understanding ICS architecture and components is essential for securing and integrating OT environments.
-
-SCADA systems provide supervisory control and data acquisition for geographically distributed processes. A SCADA system might monitor and control water treatment across an entire city, manage electrical generation and distribution across a region, or coordinate production across multiple manufacturing facilities. SCADA systems collect data from remote locations, provide centralized visualization and control, generate alarms when conditions exceed thresholds, and log historical data for analysis and compliance. Modern SCADA platforms increasingly integrate with IT systems for advanced analytics and business intelligence.
-
-Programmable Logic Controllers (PLCs) execute real-time control logic at the machine and process level. These ruggedized industrial computers run specialized programs that read sensors, make decisions based on programmed logic, and control actuators and equipment. PLCs operate in harsh industrial environments with extreme temperatures, vibration, electrical noise, and contamination that would destroy standard computers. They provide deterministic execution where timing is guaranteed, ensuring safety and process control requirements are met. PLCs use ladder logic, function block diagrams, or structured text programming languages designed for industrial applications rather than general-purpose computing.
-
-Distributed Control Systems (DCS) manage complex continuous processes like chemical production, oil refining, or power generation. Unlike SCADA systems that supervise distributed operations, DCS provides integrated control of processes within a single facility. DCS architecture distributes control functions across multiple controllers for redundancy and performance, integrates control, operator interfaces, and engineering tools in unified platforms, and manages complex regulatory control strategies for maintaining product quality and process efficiency. DCS platforms represent significant investments with lifecycles often exceeding twenty years.
-
-Human-Machine Interfaces (HMI) provide the visualization and control capabilities that operators use to monitor and manage industrial processes. Modern HMIs display real-time process data through graphics, trends, and alarms, enable operators to adjust setpoints and control equipment, provide historical trending and reporting capabilities, and increasingly support mobile access for remote monitoring. HMI design significantly affects operator effectiveness and safety, making usability and information clarity critical considerations.
-
-## Industrial Protocols: The Languages of OT
-
-Industrial protocols enable communication between OT devices but differ fundamentally from standard IT protocols. Modbus, developed in 1979, remains widely used for connecting industrial electronic devices. This simple, robust protocol enables PLCs, sensors, and other devices to communicate over serial connections or Ethernet networks. Modbus's age means it has no built-in security features, all communications are unencrypted and unauthenticated, but its ubiquity and simplicity ensure it will remain deployed for decades.
-
-Profibus and Profinet serve as standard protocols in European manufacturing and are particularly common in automotive and process industries. Profibus operates over serial connections while Profinet runs on standard Ethernet, providing faster communications and more features. These Siemens-developed protocols dominate in certain industries and regions, creating integration challenges when connecting equipment from different vendors.
-
-OPC-UA (OLE for Process Control - Unified Architecture) represents a modern, secure, and platform-independent protocol designed for industrial interoperability. Unlike older protocols, OPC-UA includes built-in security features including encryption, authentication, and authorization. It enables semantic modeling of industrial data so systems understand not just values but their meaning and relationships. OPC-UA is increasingly adopted as the standard for Industry 4.0 and IIoT applications because it addresses both connectivity and security requirements.
-
-EtherNet/IP adapts standard Ethernet and TCP/IP protocols for industrial automation, particularly in North American manufacturing. This protocol is common in discrete manufacturing, packaging, and material handling applications. DeviceNet provides a low-cost network for connecting simple industrial devices like sensors, motor starters, and actuators to PLCs and controllers.
-
-The diversity of industrial protocols creates significant integration challenges. A single manufacturing facility might use half a dozen different protocols across equipment from various vendors and vintages. Protocol converters, gateways, and translation tools are often necessary to achieve connectivity, adding complexity and potential points of failure. This protocol fragmentation makes unified [IT/OT integration](/use-cases/it-ot-middleware/) technically challenging and expensive.
-
-## The Organizational Challenge: Bridging IT and OT Teams
-
-Technical integration challenges are matched by organizational and cultural differences between IT and OT teams. These groups often have fundamentally different priorities, training, and approaches to problems, creating friction that can derail integration projects if not addressed thoughtfully.
-
-IT teams focus on keeping business systems running, securing data, enabling collaboration, and adopting new technologies to improve business processes. They're accustomed to regular change, view updates and patches as routine and necessary, prioritize cybersecurity and data protection, and measure success through system availability, user satisfaction, and cost efficiency. IT professionals typically have formal education in computer science or information systems and hold certifications like CISSP, CISM, or various vendor credentials.
-
-OT teams focus on keeping production running safely and efficiently, maintaining equipment reliability, preventing unplanned downtime, and preserving process knowledge that might span decades. They're accustomed to stability and view changes with skepticism until proven necessary, prioritize safety and availability over all other concerns, and measure success through production uptime, quality metrics, and safety records. OT professionals often come from engineering backgrounds in electrical, mechanical, or chemical engineering, holding certifications like PE licenses or vendor-specific industrial automation credentials.
-
-These different backgrounds create predictable conflicts. When IT suggests network upgrades or security improvements, OT worries about production disruption and unproven technology in critical systems. When OT wants to keep running proven systems unchanged, IT worries about security vulnerabilities and inability to integrate with modern business systems. Both perspectives are valid and rooted in real concerns shaped by each team's responsibilities and past experiences.
-
-Successful IT/OT convergence requires building bridges between these cultures. Creating cross-functional teams that include both IT and OT expertise ensures projects consider all relevant concerns from the beginning. Establishing shared goals and metrics that both teams contribute to helps align priorities. Developing mutual respect through education about each domain's challenges and constraints builds understanding. And perhaps most importantly, ensuring executive leadership understands and supports convergence efforts provides the authority and resources necessary to overcome organizational inertia.
-
-## Making IT/OT Convergence Work: Strategic Implementation
-
-Successful IT/OT convergence requires a strategic, methodical approach rather than ad-hoc connectivity projects. Start by establishing clear business objectives that justify the effort and investment. What specific problems are you trying to solve? What measurable outcomes define success? IT/OT convergence is a means to an end, not an end in itself, so clarity about the desired outcomes guides all subsequent decisions.
-
-Prioritize use cases with measurable return on investment to build momentum and prove value. Rather than attempting comprehensive integration all at once, identify specific high-value opportunities where connectivity delivers clear benefits. Predictive maintenance that prevents unplanned downtime, real-time quality monitoring that reduces scrap, or energy optimization that lowers utility costs provide concrete value propositions. Success with focused use cases builds organizational confidence and provides lessons for broader implementation.
-
-Design robust security architectures from the beginning rather than adding security as an afterthought. The security model must respect OT constraints while providing effective protection. This typically involves network segmentation with industrial DMZs, defense-in-depth strategies with multiple security layers, OT-specific security monitoring and threat detection, and carefully managed interfaces between IT and OT environments. Security architecture decisions made early are difficult and expensive to change later.
-
-Foster collaboration between IT and OT teams through shared projects, cross-training, and integrated planning. The technical integration cannot succeed without organizational integration. Create forums for regular communication between teams, establish joint governance for converged systems, and develop shared understanding of each domain's requirements and constraints. Successful convergence projects consistently cite strong IT/OT collaboration as a critical success factor.
-
-Plan for long-term evolution rather than one-time projects. IT/OT convergence is an ongoing journey as technology, business requirements, and threat landscapes evolve. Build flexible architectures that can adapt to changing needs, establish processes for continuous improvement, and plan for lifecycle management of integrated systems. The goal isn't reaching a finished state but rather creating capabilities for continuous adaptation and improvement.
-
-## Real-World Benefits of IT/OT Integration
-
-When implemented thoughtfully, IT/OT convergence delivers substantial operational and business benefits. Production visibility transforms from lagging indicators based on end-of-shift reports to real-time dashboards that show current performance, immediate quality metrics, and live equipment status. This visibility enables faster problem identification and response, data-driven decision making at all organizational levels, and immediate understanding of production impacts from changes.
-
-Predictive maintenance shifts maintenance strategies from reactive repairs or time-based schedules to condition-based maintenance driven by actual equipment health. Sensors and analytics identify early warning signs of impending failures, allowing maintenance during planned downtime rather than crisis response to breakdowns. This reduces unplanned downtime, extends equipment life through optimal maintenance timing, and lowers maintenance costs through better resource allocation.
-
-Quality management improves through immediate feedback loops that connect production processes with quality results. Rather than discovering defects in finished goods or during sampling, integrated systems can detect quality excursions in real-time and automatically adjust processes or alert operators. This reduces scrap and rework, improves first-pass yield, and enables faster root cause analysis when issues occur.
-
-Energy optimization becomes possible when business systems can analyze energy consumption patterns across production operations. Identifying energy-intensive processes, optimizing production schedules to leverage time-of-use rates, and detecting energy waste from inefficient equipment operation deliver measurable cost reductions. Many manufacturers discover that previously invisible energy waste represents significant savings opportunities.
-
-Supply chain integration becomes more dynamic and responsive when production systems can communicate directly with inventory, purchasing, and logistics systems. Automated reordering triggered by actual consumption rather than forecasts, real-time visibility of production status for customer order management, and immediate coordination of material delivery with production schedules reduce inventory carrying costs while improving delivery performance.
-
-## Common Pitfalls to Avoid
-
-Understanding common implementation failures helps organizations avoid costly mistakes. The single biggest pitfall is treating IT/OT convergence purely as a technology project rather than a strategic business initiative. Without clear business objectives and executive sponsorship, projects devolve into technical exercises that may achieve connectivity but deliver limited business value. Secure executive commitment to desired business outcomes before beginning significant integration work.
-
-Underestimating security requirements leads to vulnerable implementations that expose critical operations to cyber threats. Organizations sometimes focus on achieving connectivity while treating security as something to address later. In IT/OT convergence, security must be architectural rather than bolted on afterward. The cost and complexity of retrofitting security after deployment far exceeds incorporating it from the beginning.
-
-Ignoring legacy equipment challenges causes projects to stall when teams encounter the reality of decades-old systems that can't be integrated using modern approaches. Assess the actual state of existing equipment early in planning, identify systems that will require special handling or replacement, and budget accordingly. Many legacy systems can be integrated through edge devices or protocol converters, but this requires planning and investment.
-
-Failing to involve OT teams in planning and implementation creates resistance and risks disrupting production. IT-led initiatives that treat OT as simply another network to be managed often fail because they don't account for OT's unique requirements and constraints. Successful projects include OT expertise from the beginning and respect the primacy of production operations.
-
-Attempting too much too quickly overwhelms organizations and dilutes resources across multiple initiatives. Better to achieve significant success with focused use cases than superficial progress across broad initiatives. Build momentum through early wins rather than comprehensive transformation attempts.
-
-## Your Path Forward with FlowFuse
-
-Navigating IT/OT convergence requires tools that understand both worlds. FlowFuse is built on [Node-RED](/node-red/), an open-source platform that has become the de facto standard for industrial integration, with over [5,000 pre-built](/integrations/) nodes connecting to industrial protocols, databases, cloud platforms, and business systems. This extensive library means you can integrate Modbus devices with your ERP system, connect OPC-UA machines to cloud analytics, or bridge SCADA systems with business intelligence tools, all without extensive custom programming.
-
-The visual, drag-and-drop interface enables your engineers and technicians to build integration workflows directly. People who understand your processes and equipment can implement solutions themselves, reducing dependency on external developers and speeding project delivery. This democratization of integration development means OT teams aren't dependent on IT resources for every connection or modification.
-
-FlowFuse adds enterprise capabilities including team collaboration, version control, and secure deployment to the Node-RED foundation. These features make Node-RED suitable for production manufacturing environments where change management, security, and reliability are non-negotiable. Projects can be developed in test environments, reviewed by stakeholders, and deployed to production with confidence.
-
-Security features built into FlowFuse protect your integration projects and the systems they connect. Role-based access controls ensure people can access only appropriate projects and deployments. Audit logging provides visibility into changes and activities. Network isolation options enable proper segmentation between IT and OT environments even within your integration platform.
-
-The open-source foundation means you're never locked into proprietary technology or single-vendor solutions. Node-RED's active community continuously develops new protocol support, integration capabilities, and functionality. When you need to connect to new equipment or systems, chances are someone has already created the necessary integration components.
-
-Manufacturing operations worldwide rely on FlowFuse for IT/OT convergence projects ranging from simple data collection to sophisticated predictive maintenance, quality management, and energy optimization initiatives. The platform scales from proof-of-concept projects to enterprise deployments managing thousands of devices and processes.
-
-***[Book a demo today](/book-demo/) to see how FlowFuse can help you navigate IT/OT convergence securely and effectively, using proven open-source technology that respects both IT and OT requirements.***
+Effective OT security centers on a handful of practices: network segmentation with industrial DMZs (never connect OT directly to the internet), full asset inventories (you can't secure equipment you don't know exists), role-based access with multi-factor authentication for remote sessions, OT-specific monitoring tools that understand industrial protocols instead of generating false positives, tightly scoped and logged vendor access, tested offline backups of PLC and HMI configurations, and cross-training so IT and OT teams understand each other's constraints. Standards like IEC 62443 and NERC-CIP provide a structured baseline to build against.

--- a/src/blog/2025/09/poka-yoke-mistake-proofing.md
+++ b/src/blog/2025/09/poka-yoke-mistake-proofing.md
@@ -1,15 +1,18 @@
 ---
-metaTitle: "Poka Yoke Explained: Definition, Examples, Types"
-title: "Poka Yoke (Poke Yoke, Bokayoke) Explained: Definition, Examples, Types (2026)"
+metaTitle: "Poka-Yoke (Mistake-Proofing): Definition, Types & Examples"
+title: "Poka-Yoke (Mistake-Proofing): Definition, Types & Examples"
 subtitle: "How to mistake-proof your manufacturing processes"
-description: "Learn how poka yoke prevents manufacturing defects before they happen, and the four types of mistake-proofing you can use."
+description: "Poka-yoke (mistake-proofing) stops defects before they happen. See the types, real Toyota examples, and a 6-step process to implement it."
 date: 2025-09-11
 lastUpdated: 2025-12-30
 authors: ["sumit-shinde"]
-image: /blog/2025/09/images/what-is-poka-yoke.png
 keywords: poka yoke, mistake proofing, poka yoke examples, lean manufacturing, poka yoke manufacturing, mistake proofing poka yoke, poka yoke in lean manufacturing, lean six sigma poka yoke, kaizen poka yoke, poka yoke technique, poka yoke method, poka yoke system, poka-yoke, quality control, defect prevention, manufacturing quality
 tags:
   - flowfuse
+cta:
+  type: contact
+  title: "Automate Your Mistake-Proofing Checks"
+  description: "FlowFuse connects sensors and quality systems to trigger real-time alerts the moment a defect condition occurs, no custom programming required."
 meta:
   faq:
   - question: "What does poka yoke mean in English?"
@@ -43,13 +46,11 @@ meta:
     answer: "Key skills include strong observation, creative problem-solving, deep process knowledge, and empathy for human limitations. While formal training in lean manufacturing and root cause analysis helps, the most effective poka yoke solutions often come from operators who understand the work firsthand."
 ---
 
-Every day, skilled operators make mistakes that cost thousands. A component installed backwards. A critical step skipped during rush orders. A measurement misread at shift's end. 
+Every day, skilled operators make small mistakes: a component installed backwards, a step skipped during a rush order, a measurement misread at the end of a shift. The usual response is more training, more warning signs, more reminders to slow down and pay attention. It rarely works for long, because the mistake was never really a training problem.
 
 <!--more-->
 
-The shocking truth? Human errors account for nearly 23% of manufacturing defects worldwide, costing businesses billions annually. But here's what's different: companies implementing poka yoke have reduced defects by up to 50% and increased production efficiency by 30%.
-
-What if the problem isn't your people, but your processes?
+Poka yoke is the alternative: instead of asking people to be perfect, you design the process so the mistake becomes physically impossible, or impossible to miss the moment it happens. Toyota built this into its production system decades ago, and manufacturers that adopt it consistently cut defect rates without adding inspection headcount.
 
 ## What Does Poka Yoke (Often Misspelled as Bokayoke or Poke Yoke) Mean and Where Did It Come From?
 
@@ -57,11 +58,11 @@ Poka yoke (pronounced "POH-kah YOH-kay") is a Japanese term that means "mistake-
 
 In 1961, a Japanese electronics plant faced a staggering 25% defect rate. Workers kept missing tiny springs in switch assemblies, not due to carelessness, but because the repetitive handling of microscopic components made mistakes inevitable.
 
-Toyota engineer [Shigeo Shingo](https://en.wikipedia.org/wiki/Shigeo_Shingo) introduced a simple but revolutionary solution: a fixture holding exactly two springs for each assembly. Workers had to remove both springs before starting their task, instantly highlighting any incomplete assembly. As a result, defects dropped to zero overnight, without additional training.
+Toyota engineer [Shigeo Shingo](https://en.wikipedia.org/wiki/Shigeo_Shingo) introduced a simple but revolutionary solution: a fixture holding exactly two springs for each assembly. Workers had to remove both springs before starting their task, instantly highlighting any incomplete assembly. As a result, defects dropped to zero overnight, without additional training, a case Shingo later documented himself in [*Zero Quality Control: Source Inspection and the Poka-Yoke System*](https://www.routledge.com/Zero-Quality-Control-Source-Inspection-and-the-Poka-Yoke-System/Shingo/p/book/9780915299072) (Productivity Press, 1986).
 
 Originally called **"baka-yoke" (idiot-proofing)**, the technique was renamed **poka yoke** after a worker objected, emphasizing that human errors are natural, not a reflection of intelligence.
 
-Shingo made a key distinction between human mistakes and production defects. Mistakes happen, they're part of being human. Defects occur when those mistakes reach the customer. Poka yoke focuses on designing processes so mistakes are immediately detected and corrected, eliminating defects at the source. This philosophy shifts manufacturing focus: rather than trying to perfect human behavior, perfect the systems in which humans work.
+Shingo made a key distinction between human mistakes and production defects. Mistakes happen, they're part of being human. Defects occur when those mistakes reach the customer. Poka yoke focuses on designing processes so mistakes are immediately detected and corrected, eliminating defects at the source. This philosophy, which Toyota traces in its own account of the system, [*Toyota Production System: Beyond Large-Scale Production*](https://www.routledge.com/Toyota-Production-System-Beyond-Large-Scale-Production/Ohno/p/book/9780915299140) (Productivity Press, 1988), and which Jeffrey Liker later analyzed in [*The Toyota Way*](https://en.wikipedia.org/wiki/The_Toyota_Way) (McGraw-Hill, 2004), shifts manufacturing focus: rather than trying to perfect human behavior, perfect the systems in which humans work.
 
 ## Poka Yoke Definition?
 
@@ -70,13 +71,9 @@ Poka yoke is a systematic approach that uses automatic devices or methods to eit
 ::cta-image{src="/images/cta/arch-systems-book-demo.png" alt="Arch Systems scales automation across complex manufacturing environments with FlowFuse - book a demo" cta="demo"}
 ::
 
-The poka yoke meaning extends beyond simple error prevention. Rather than treating errors as moral failures or training deficiencies, it treats them as design problems. This lean manufacturing approach recognizes that even the most skilled workers experience moments of distraction, fatigue, or cognitive overload.
+The poka yoke meaning extends beyond simple error prevention. Rather than treating errors as moral failures or training deficiencies, it treats them as design problems, the lean manufacturing approach James Womack and Daniel Jones frame in [*Lean Thinking*](https://www.lean.org/store/book/lean-thinking-2nd-edition/) (Free Press, 2003), which recognizes that even the most skilled workers experience moments of distraction, fatigue, or cognitive overload.
 
-Traditional quality control detects defects after they occur, requiring inspection, rework, and often scrapping of materials. The poka yoke approach prevents defects during production by making errors physically impossible or immediately visible. This prevention-first approach creates a cascading effect: quality control teams focus on complex issues rather than basic errors, workers gain confidence in their processes, customer satisfaction improves through consistent product quality, and excellence becomes the natural outcome rather than a heroic achievement.
-
-If you prefer a video format, watch this short and clear video explaining what poka yoke is:
-
-<lite-youtube videoid="JTI_-xwIIg8" params="rel=0" style="margin-top: 20px; margin-bottom: 20px; width: 100%; height: 480px;" title="YouTube video player"></lite-youtube>
+Traditional quality control detects defects after they occur, requiring inspection, rework, and often scrapping of materials, the approach outlined in the [ASQ's *Certified Quality Engineer Handbook*](https://asq.org/quality-press) (American Society for Quality, 2013). The poka yoke approach instead prevents defects during production by making errors physically impossible or immediately visible. This prevention-first approach creates a cascading effect: quality control teams focus on complex issues rather than basic errors, workers gain confidence in their processes, customer satisfaction improves through consistent product quality, and excellence becomes the natural outcome rather than a heroic achievement.
 
 ## Why Is Poka Yoke Important for Manufacturers?
 
@@ -84,9 +81,7 @@ The impact of mistake-proofing extends far beyond just catching errors. By desig
 
 Errors in manual assembly lead to increased scrap rates, rework, and delays, all contributing to higher production costs. By eliminating errors at the source, the cost of mistakes within a company is reduced significantly. Companies implementing poka yoke techniques saw a 25% increase in productivity, with time previously spent correcting errors now available for value-added activities.
 
-Mistake-proofing creates safer processes by eliminating conditions that lead to accidents. When errors can literally mean life or death (as in pharmaceutical manufacturing), poka yoke becomes mission-critical. Workers experience less frustration from rework and greater confidence in their processes, leading to improved morale. Successful implementation leads to a 20% improvement in customer satisfaction through consistent product quality and reliability.
-
-The benefits of poka yoke in manufacturing deliver measurable business outcomes: defect elimination achieving near-zero defects, waste reduction across the eight forms identified in lean manufacturing, process simplification turning complex procedures into straightforward steps, real-time correction catching mistakes immediately rather than weeks later, scalable quality built into the system rather than dependent on individual heroics, and continuous improvement creating a foundation for ongoing kaizen activities.
+Mistake-proofing creates safer processes by eliminating conditions that lead to accidents. When errors can literally mean life or death (as in pharmaceutical manufacturing), poka yoke becomes mission-critical. Workers experience less frustration from rework and greater confidence in their processes, leading to improved morale and a 20% improvement in customer satisfaction through consistent product quality.
 
 ## Poka Yoke Types?
 
@@ -98,17 +93,17 @@ The **contact method** identifies product defects by testing the product's shape
 
 **Motion-step methods** focus on ensuring operators perform the right steps in the correct sequence. These force the correct sequence of operations. Lockout/tagout systems prevent equipment access until safety steps are complete. CNC machines require tool verification before program execution. Assembly stations physically prevent advancement until the current step is finished, sequential interlocks ensure proper startup and shutdown procedures, and guided work instructions must be completed in order. These turn complex procedures into foolproof, step-by-step processes.
 
-Beyond these three detection methods, poka yoke systems function in two fundamental ways: control-based and warning-based. Control poka yoke actually prevents the mistake from being made, making it mechanically or electronically impossible for errors to occur. Think of a car transmission requiring "Park" or "Neutral" to start, or computer forms that won't submit until all required fields are filled. Use this when errors must be prevented entirely, especially for safety-critical operations. Warning-based poka yoke alerts operators to occurring or soon-to-occur defects, relying on human intervention to stop and correct errors. Examples include backup sensors beeping when you're too close to an obstacle, warning lights indicating missing components, or Outlook reminding you about missing attachments. The key difference: control systems stop the process automatically; warning systems rely on human response.
+These detection principles aren't limited to physical manufacturing either, Harry Robinson documented the same techniques applied to early defect detection in software testing, in his paper ["Using Poka-Yoke Techniques for Early Defect Detection"](https://www.semanticscholar.org/paper/Using-Poka-Yoke-Techniques-for-Early-Defect-Robinson/606988be74e39106b4ef3ed30472045bdc2b25b4) presented at the Sixth International Conference on Software Testing, Analysis and Review (STAR'97). Beyond these three detection methods, poka yoke systems function in two fundamental ways: control-based and warning-based. Control poka yoke actually prevents the mistake from being made, making it mechanically or electronically impossible for errors to occur. Think of a car transmission requiring "Park" or "Neutral" to start, or computer forms that won't submit until all required fields are filled. Use this when errors must be prevented entirely, especially for safety-critical operations. Warning-based poka yoke alerts operators to occurring or soon-to-occur defects, relying on human intervention to stop and correct errors. Examples include backup sensors beeping when you're too close to an obstacle, warning lights indicating missing components, or Outlook reminding you about missing attachments. The key difference: control systems stop the process automatically; warning systems rely on human response.
 
 ## What Are the 6 Steps of Poka Yoke Mistake-Proofing?
 
 Implementing poka yoke follows a systematic six-step process that ensures effective error prevention.
 
-**Step 1: Identify the Problem.** Create a detailed process flowchart mapping every operation, no matter how small. Review each step to determine where human errors are likely to occur, which can involve using the 5 Whys technique. Where do defects occur most frequently? Which errors have the highest impact? What causes operators the most difficulty? Use tools like Pareto analysis to prioritize, typically 80% of defects come from 20% of causes. Before implementing any mistake-proofing tools or poka yoke devices, you need to identify your most frequent quality problems. A Pareto chart analysis helps you prioritize which defects cause 80% of your quality issues, ensuring you focus your poka yoke efforts where they'll have maximum impact. [Learn how to create effective Pareto charts for quality analysis](/blog/2025/09/creating-pareto-chart/)
+**Step 1: Identify the Problem.** Create a detailed process flowchart mapping every operation, no matter how small. Review each step to determine where human errors are likely to occur, which can involve using the 5 Whys technique. Where do defects occur most frequently? Which errors have the highest impact? Use a [Pareto chart](/blog/2025/08/pareto-chart-manufacturing-guide/) to prioritize, typically 80% of defects come from 20% of causes, so you focus your poka yoke efforts where they'll have maximum impact.
 
 **Step 2: Analyze Root Causes.** Once every potential error is found, work through the process to find the root cause. Don't just identify when errors occur, understand why they happen. Use techniques like 5 Whys analysis, fishbone diagrams, process mapping, Failure Mode and Effects Analysis (FMEA), and gemba walks (go see where work happens). Understanding root causes prevents implementing complex solutions for simple problems.
 
-**Step 3: Design the Solution.** Design solutions in the process to eliminate the risk of the error ever happening, which can include eliminating the step or replacing it with a mistake-proof step. The solution hierarchy from most to least effective includes elimination (remove the error-prone step entirely), replacement (substitute with an error-proof alternative), facilitation (make correct actions significantly easier than errors), detection (identify errors immediately when they occur), and mitigation (minimize effects if errors reach this point). The four key principles are elimination, prevention, detection, and mitigation.
+**Step 3: Design the Solution.** Design solutions in the process to eliminate the risk of the error ever happening, which can include eliminating the step or replacing it with a mistake-proof step. The solution hierarchy from most to least effective, detailed in Thomas Pyzdek and Paul Keller's [*The Six Sigma Handbook*](https://accessengineeringlibrary.com/browse/six-sigma-handbook-fourth-edition) (McGraw-Hill Education, 2014), includes elimination (remove the error-prone step entirely), replacement (substitute with an error-proof alternative), facilitation (make correct actions significantly easier than errors), detection (identify errors immediately when they occur), and mitigation (minimize effects if errors reach this point). The four key principles are elimination, prevention, detection, and mitigation.
 
 **Step 4: Choose the Implementation Method.** Select the appropriate mistake-proofing technique based on your specific situation. Consider inspection methods like source inspection (checks before the process step occurs), self-inspection (workers check their own work immediately), or successive inspection (next worker verifies previous step). Choose setting functions such as contact/physical checks, fixed-value counting or weighing, motion-step sequence verification, or information enhancement for visibility. Decide on regulatory functions including warning signals (lights, buzzers, colors) or control mechanisms (preventing advancement).
 
@@ -134,15 +129,7 @@ However, poka yoke isn't always the answer. For truly unique, one-off custom wor
 
 The key question: Are errors systematic or random? If the same mistakes happen repeatedly, poka yoke is your solution. If every error is unique and unpredictable, focus on training and skill development instead.
 
-## How to Implement Poka Yoke in Your Manufacturing Processes
-
-Successful poka yoke implementation begins with systematic error pattern analysis through root cause investigation and detailed process mapping. Understanding why errors occur, rather than just when they occur, enables targeted mistake-proofing techniques that address underlying causes rather than symptoms. This analytical foundation prevents the common mistake of implementing complex solutions for simple problems.
-
-Employee involvement throughout the design process proves crucial for successful adoption. Operators who participate in solution development understand the reasoning behind changes and can provide valuable insights about practical implementation challenges. Their buy-in transforms potential resistance into enthusiastic support for quality improvement initiatives aligned with poka yoke principles.
-
-Testing and refinement cycles validate system effectiveness before full-scale deployment. Pilot implementations reveal unexpected challenges and opportunities for improvement while building confidence in proposed solutions. This iterative approach prevents costly mistakes and ensures solutions work effectively in real production environments.
-
-Start simple by focusing on obvious, high-impact problems using basic mistake-proofing examples before tackling complex issues. Prioritize cost-effective solutions and devices that deliver measurable results. Include operators in design for better adoption rates, following kanban poka yoke and kaizen principles. Build mistake-proofing into standard operating procedures and integrate it with Six Sigma methodologies. Conduct regular reviews and enhancements of existing systems for continuous improvement.
+Getting this right in practice comes down to two things the six steps above don't fully capture: involve the operators who'll use the system while you're still designing it, since their buy-in is what turns a new mistake-proofing device from resistance into adoption; and start with your highest-impact, simplest problem rather than your most complex one, so you build confidence and momentum before tackling harder cases.
 
 ## Modern Digital Poka Yoke: Engineering Mistake-Proof Systems
 
@@ -150,7 +137,7 @@ The future of poka yoke increasingly incorporates Industry 4.0 technologies that
 
 Modern smart manufacturing systems integrate digital work instructions that guide operators through complex procedures step-by-step, ensuring consistency while accommodating process variations. Adaptive tooling automatically adjusts parameters based on real-time measurements, preventing specification deviations while maintaining production efficiency.
 
-FlowFuse enables sophisticated poka yoke implementations by connecting IoT sensors, machine data, and quality control systems in real-time workflows. Manufacturing teams can build automated solutions that trigger immediate alerts, stop processes when deviations occur, and guide operators through corrective actions, all without complex programming or expensive custom solutions. To learn more or see it in action, you can [book a demo](/book-demo/) or [get in touch](/contact-us/) with the team.
+FlowFuse enables sophisticated poka yoke implementations by connecting IoT sensors, machine data, and quality control systems in real-time workflows. Manufacturing teams can build automated solutions that trigger immediate alerts, stop processes when deviations occur, and guide operators through corrective actions, all without complex programming or expensive custom solutions.
 
 ## Conclusion
 
@@ -159,13 +146,3 @@ The poka yoke technique represents more than a quality improvement method, it em
 The method's enduring relevance in an era of smart manufacturing demonstrates that the most powerful solutions often combine simple principles with sophisticated execution. Whether you're implementing basic mistake-proofing devices or advanced IoT-enabled systems, the core philosophy remains unchanged: make errors impossible, or make them immediately obvious.
 
 The question isn't whether poka yoke works, decades of success across industries prove it does. The question is: which errors in your process are you ready to eliminate forever?
-
-## References
-
-1. Shingo, Shigeo. "Zero Quality Control: Source Inspection and the Poka-Yoke System." Productivity Press, 1986.
-2. Liker, Jeffrey K. "The Toyota Way: 14 Management Principles from the World's Greatest Manufacturer." McGraw-Hill Education, 2004.
-3. Robinson, Harry. "Using Poka Yoke Techniques for Early Defect Detection." International Conference on Software Testing, 1999.
-4. Womack, James P., Jones, Daniel T. "Lean Thinking: Banish Waste and Create Wealth in Your Corporation." Free Press, 2003.
-5. ASQ Quality Press. "The Certified Quality Engineer Handbook, Fourth Edition." American Society for Quality, 2013.
-6. Toyota Motor Corporation. "Toyota Production System: Beyond Large-Scale Production." Productivity Press, 1988.
-7. Pyzdek, Thomas, Keller, Paul. "The Six Sigma Handbook: A Complete Guide for Green Belts, Black Belts, and Managers." McGraw-Hill Education, 2014.

--- a/src/blog/2025/09/what-is-takt-time.md
+++ b/src/blog/2025/09/what-is-takt-time.md
@@ -1,16 +1,19 @@
 ---
-metaTitle: "Takt Time: Definition, Formula & Examples"
-title: "Takt Time: Definition, Formula, How to Calculate with Examples & More [2026 Edition]"
-subtitle: "Master takt time to synchronize production with customer demand using lean manufacturing principles"
-description: "A complete guide to takt time in manufacturing: the formula, calculation methods, implementation strategies, and examples."
+metaTitle: "Takt Time: Definition, Formula & Calculation"
+title: "Takt Time: Definition, Formula & How to Calculate It"
+subtitle: "How to calculate takt time and align production pace with real customer demand"
+description: "Takt time explained: the formula, how to calculate it step by step, and how it differs from cycle time, with real manufacturing examples."
 date: 2025-09-25
 lastUpdated: 2025-12-26
 keywords: takt time, takt time formula, takt time defination, takt time calculation, what is takt time
 video: G8eYPuHQgk0
 authors: ["sumit-shinde"]
-image: /blog/2025/09/images/takt-time-flowfuse.png
 tags:
   - flowfuse
+cta:
+  type: contact
+  title: "Monitor Takt Time in Real Time"
+  description: "FlowFuse connects your production data to live dashboards so takt time updates automatically instead of on a spreadsheet."
 meta:
   faq:
     - question: "How often should you check takt time during production?"
@@ -38,200 +41,112 @@ meta:
       answer: "Takt time should be recalculated whenever customer demand changes significantly or when available production time is modified. In modern digital factories, this recalculation can happen automatically in real time."
 ---
 
-Takt time is one of the most fundamental, and most misunderstood, concepts in lean manufacturing. Despite being widely referenced in textbooks, audits, and production meetings, many factories still calculate takt time incorrectly or treat it as a theoretical number rather than an operational control. The result is familiar: overproduction during low demand, missed deliveries during peak demand, unstable lines, and constant firefighting on the shop floor.
+Most factories that struggle with takt time aren't failing at the math, they're treating it as a theoretical number instead of an operational control. The result is the same either way: overproduction during low demand, missed deliveries during peak demand, and constant firefighting on the shop floor.
 
 <!--more-->
 
-In reality, **takt time is not a KPI, it is a design constraint**. It defines the exact pace at which a production system must operate to meet real customer demand using the available working time. When applied correctly, takt time becomes the backbone of flow, line balancing, capacity planning, and continuous improvement. When applied incorrectly, it creates false confidence, hidden bottlenecks, and chronic inefficiencies.
+**Takt time is not a KPI, it's a design constraint.** It defines the exact pace at which a production system must operate to meet real customer demand using the available working time. Applied correctly, it becomes the backbone of flow, line balancing, capacity planning, and continuous improvement. Applied incorrectly, it creates false confidence and hidden bottlenecks.
 
-This guide is written from a **practical, factory-floor perspective**, not just a theoretical lean framework. It reflects how takt time is actually used in modern manufacturing environments, automotive plants, electronics assembly lines, FMCG production, and digitally connected factories running real-time systems. Every definition, formula, and example in this article is grounded in how takt time is applied by production engineers, operations managers, and lean practitioners to solve real problems.
-
-In this 2026 edition, you’ll learn:
-
-- The correct definition of takt time and what it truly represents operationally
-- How to calculate takt time accurately, including what time must be excluded (and why)
-- The difference between takt time, cycle time, and lead time, and how confusing them leads to bad decisions
-- Real-world examples showing how takt time exposes bottlenecks and capacity gaps
-- How modern digital tools calculate and monitor takt time in real time, not spreadsheets
-
-Whether you are designing a new production line, stabilizing an existing process, or transitioning toward lean and Industry 4.0 practices, this guide gives you a complete, trustworthy, and experience-backed explanation of takt time, from first principles to real-world execution.
+This guide covers the correct definition of takt time, how to calculate it (including what time to exclude and why), how it differs from cycle time and lead time, real-world examples, and how modern digital tools monitor it in real time instead of on spreadsheets.
 
 ## What is Takt Time?
 
-**Takt time** is the maximum allowable time to produce one unit of product to meet customer demand. It acts as the "heartbeat" of your production line, establishing the rhythm at which work must flow to satisfy customer orders without overproducing or falling behind.
+**Takt time** is the maximum allowable time to produce one unit of product to meet customer demand. It sets the pace at which work must flow through your production line to satisfy customer orders without overproducing or falling behind.
 
-The word "takt" derives from the German word "taktzeit," which translates to "cycle time" or "beat." This linguistic origin reflects the concept's European manufacturing heritage, though it's important to recognize that takt time and cycle time represent fundamentally different metrics. We'll examine this critical distinction in detail later in this guide.
+The word "takt" comes from the German "taktzeit," meaning "cycle time" or "beat." Despite the linguistic overlap, takt time and cycle time are fundamentally different metrics, a distinction we cover in detail below.
 
-### Formal Definition of Takt Time
+Formally, takt time is **the available production time divided by customer demand**. It's a customer-driven metric calculated from actual demand rather than production capability, and it functions as:
 
-The **definition of takt time** is: the available production time divided by customer demand. This establishes the pace at which your production line must operate to meet customer requirements. It's a customer-driven metric calculated from actual demand rather than production capability.
-
-Takt time serves as both a planning tool and a mechanism for waste elimination, providing a common reference point for distributing work evenly across production stations.
-
-### Meaning of Takt Time
-
-The **meaning of takt time** goes deeper than just a calculation, it represents your production heartbeat. It's the pulse that synchronizes all production activities with real customer demand.
-
-The operational meaning of takt time functions as:
 - A planning target that prevents overproduction and underproduction
 - A balancing tool that distributes work evenly across workstations
 - A performance metric that reveals bottlenecks and capacity constraints
 - A continuous improvement baseline that quantifies the gap between current and required performance
-
-When you properly understand what takt time means, you transform it from a simple formula into a powerful operational philosophy that drives lean manufacturing excellence.
 
 ## Takt Time Formula
 
 ![Takt Time Formula](./images/takt-time-formula.png){data-zoomable}
 _The fundamental takt time formula_
 
-The **takt time formula** is deceptively simple, yet its application transforms manufacturing operations:
-
 **Takt Time = Available Production Time ÷ Customer Demand**
 
-This **formula of takt time** contains two critical components that require careful definition. Let's break down each element to understand how to calculate takt time accurately.
+Two components need careful definition to calculate this accurately.
 
 ### Available Production Time
 
 ::cta-image{src="/images/cta/arch-systems-book-demo.png" alt="Arch Systems scales automation across complex manufacturing environments with FlowFuse - book a demo" cta="demo"}
 ::
 
-This is the net time available for production during your planning period (typically one shift or one day). When applying the takt formula, available production time includes only planned production time. It excludes planned breaks, meetings, shift changes, and scheduled maintenance, but does not include unplanned downtime such as breakdowns or minor stoppages. It excludes scheduled breaks and lunch periods, shift changeovers, planned maintenance windows, and scheduled meetings or training.
+This is the net time available for production during your planning period (typically one shift or day). It includes only planned production time, excluding scheduled breaks, lunch, shift changeovers, planned maintenance, and meetings, but not unplanned downtime like breakdowns.
 
-Consider an example calculation of takt time. An eight-hour shift equals 480 minutes. Subtract a 10-minute break to yield 470 minutes. Subtract a 20-minute lunch to yield 450 minutes. Subtract a 30-minute planned changeover to yield 420 minutes. The available production time equals 420 minutes.
+For example: an eight-hour shift equals 480 minutes. Subtract a 10-minute break (470), a 20-minute lunch (450), and a 30-minute planned changeover (420). Available production time equals 420 minutes.
 
-The distinction between included and excluded time proves critical for accurate takt time calculation. Organizations frequently overestimate available time by failing to account for all legitimate non-production activities, then face persistent schedule shortfalls when reality proves less generous than planning assumptions.
+Organizations frequently overestimate available time by failing to account for all legitimate non-production activities, then face persistent schedule shortfalls when reality proves less generous than planning assumptions.
 
 ### Customer Demand
 
-When you calculate takt time, customer demand represents the number of units customers require during your planning period. This figure can derive from actual customer orders, forecasted demand, production targets based on inventory levels, or averaged demand over longer periods such as weeks or months.
+Customer demand is the number of units customers require during your planning period, drawn from actual orders, forecasted demand, inventory-based production targets, or an average over weeks or months.
 
-The choice of demand figure affects the meaning of takt time stability and operational practicality. Using daily order quantities creates takt times that vary day-to-day, potentially requiring frequent line rebalancing. Averaging demand over weekly or monthly periods creates more stable takt times but may result in temporary overproduction or underproduction as actual daily demand fluctuates around the average.
+Using daily order quantities creates takt times that vary day to day, potentially requiring frequent line rebalancing. Averaging demand over longer periods creates more stable takt times but risks temporary overproduction or underproduction as actual demand fluctuates around the average. Most manufacturers use a hybrid: averaged demand for line design, with periodic adjustments for actual order patterns.
 
-Most manufacturers employ hybrid approaches, using averaged demand for line design and capacity planning while adjusting targets periodically to reflect actual order patterns. The appropriate averaging period depends on demand volatility, product mix complexity, and production flexibility.
+### Step-by-Step Example
 
-### Calculating Takt Time: A Step-by-Step Example
-
-Using our example numbers where available production time equals 420 minutes and customer demand equals 210 units, let's apply the takt time formula:
+Using available production time of 420 minutes and customer demand of 210 units:
 
 **Takt Time = 420 minutes ÷ 210 units = 2.0 minutes per unit**
 
-This result means your production line must complete one unit every 2 minutes to meet customer demand. When you define takt time this way, the calculation establishes a maximum allowable cycle time, any operation taking longer than 2 minutes per unit will prevent the line from meeting demand unless compensated by faster cycle times elsewhere or by adding capacity.
+Your production line must complete one unit every 2 minutes to meet demand. This establishes a maximum allowable cycle time: any operation taking longer than 2 minutes per unit will prevent the line from meeting demand unless compensated elsewhere or by added capacity.
 
 ## Real-World Examples of Takt Time
 
-Examining several real-world examples demonstrates how to calculate takt time across different manufacturing contexts. These examples show the practical application of the takt time formula in diverse scenarios.
-
 ### Example 1: Automotive Parts Manufacturing
 
-An automotive parts manufacturer produces brake assemblies during an eight-hour shift. The shift includes a 30-minute lunch period and two 10-minute breaks totaling 20 minutes. A planned changeover consumes 10 minutes. Customer orders require 120 brake assemblies per shift.
+An automotive parts manufacturer produces brake assemblies during an eight-hour shift that includes a 30-minute lunch, 20 minutes of breaks, and a 10-minute changeover. Customer orders require 120 assemblies per shift.
 
-To calculate takt time, first determine available production time. Start with 480 minutes for the eight-hour shift. Subtract 30 minutes for lunch, 20 minutes for breaks, and 10 minutes for changeover. The available production time equals 420 minutes.
+Available production time: 480 − 30 − 20 − 10 = 420 minutes. Takt time: 420 ÷ 120 = **3.5 minutes per unit**.
 
-Now apply the takt time formula. Divide 420 minutes by 120 units to yield 3.5 minutes per unit.
-
-Understanding the meaning of takt time in this result shows the production line must complete one brake assembly every 3.5 minutes to meet customer demand. If actual cycle time equals 5 minutes per unit, production will fall short by approximately 30 percent, completing only 84 units instead of the required 120 units. If actual cycle time equals 3 minutes per unit, the line produces 140 units, creating 20 units of excess inventory and risking overproduction waste.
-
-This example illustrates why defining takt time correctly matters for matching cycle time to customer demand. Cycle times significantly exceeding takt time reveal capacity shortfalls requiring immediate attention. Cycle times falling well below takt time suggest excess capacity that might be redeployed elsewhere or indicate risk of overproduction if production control systems fail to prevent excess output.
+The line must complete one brake assembly every 3.5 minutes. At a 5-minute actual cycle time, production falls about 30% short (84 units instead of 120). At 3 minutes per unit, the line overproduces by 20 units, creating excess inventory. Cycle times significantly above takt time reveal capacity shortfalls; cycle times well below it suggest redeployable capacity or overproduction risk.
 
 ### Example 2: Electronics Assembly (Multiple Shifts)
 
-An electronics manufacturer operates two shifts producing circuit boards, with weekly demand of 2,400 units across five operating days. Each eight-hour shift allocates 40 minutes for breaks and 20 minutes for changeovers.
+An electronics manufacturer runs two shifts producing circuit boards, with weekly demand of 2,400 units across five days. Each 8-hour shift allocates 40 minutes for breaks and 20 minutes for changeovers.
 
-When you calculate takt time for multiple shifts, first determine available time per shift: 480 minutes minus 40 minutes for breaks minus 20 minutes for changeovers equals 420 minutes per shift.
+Available time per shift: 480 − 40 − 20 = 420 minutes. Weekly available time: 420 × 2 × 5 = 4,200 minutes. Takt time: 4,200 ÷ 2,400 = **1.75 minutes per unit**.
 
-Calculate total available time per week: 420 minutes multiplied by 2 shifts multiplied by 5 days equals 4,200 minutes per week.
-
-Apply the takt formula: 4,200 minutes divided by 2,400 units equals 1.75 minutes per unit.
-
-An alternative approach to calculate takt time uses per-shift demand. Daily demand equals 2,400 units divided by 5 days, or 480 units per day. Demand per shift equals 480 units divided by 2 shifts, or 240 units per shift. Using the takt time formula: 420 minutes divided by 240 units equals 1.75 minutes per unit, the same result.
-
-This example demonstrates that the takt time calculation can proceed from different time horizons and still yield consistent results. Whether calculating weekly, daily, or per-shift takt time using the takt formula, the fundamental relationship between available time and required output remains constant. Organizations typically choose calculation periods matching their planning cycles and demand visibility horizons.
+Calculating per-shift instead (240 units/shift ÷ 420 minutes) yields the same 1.75 minutes per unit, showing the calculation holds regardless of the time horizon you choose, as long as it matches your planning cycle.
 
 ### Example 3: Variable Product Mix
 
-A manufacturer produces three different models on the same production line with 450 minutes of available time. Model A requires 100 units at 2 minutes per unit, Model B requires 50 units at 3 minutes per unit, and Model C requires 30 units at 4 minutes per unit.
-
-To define takt time for mixed-model production, calculate weighted average takt time by summing total demand: 100 plus 50 plus 30 equals 180 units. Using the takt time formula, average takt time equals 450 minutes divided by 180 units, or 2.5 minutes per unit.
-
-Individual product takt times can also be calculated using the formula of takt time. Model A would receive 4.5 minutes per unit (450 divided by 100), though its actual process time is only 2 minutes. Model B would receive 9.0 minutes per unit, and Model C would receive 15.0 minutes per unit. In mixed-model production, manufacturers typically employ level loading techniques to smooth production across the shift rather than producing in large batches.
-
-Level loading for this scenario might sequence production as A-A-B-A-A-C-A-A-B-A-A-C, distributing the three models proportionally throughout available time. This sequence maintains steadier overall pace than producing all Model A units first, then all Model B units, then all Model C units. Understanding the meaning of takt time in this context shows how steady pace reduces work-in-process buildup, makes quality problems visible sooner, and creates more predictable material consumption patterns.
+For lines running multiple models, takt time is calculated as a weighted average: total available time divided by total unit demand across all models. A line with 450 minutes available and combined demand of 180 units (across three models) has an average takt time of 2.5 minutes per unit. Manufacturers typically use level loading, sequencing models proportionally (e.g., A-A-B-A-A-C) rather than running large batches, to keep pace steady and surface quality issues sooner.
 
 ## Takt Time vs. Cycle Time vs. Lead Time: Comparison Matrix
 
-You might have heard the terms takt time, cycle time, and lead time, but they're not the same. Let's define takt time and these related metrics to understand their distinct meanings.
-
 | Feature | **Takt Time** | **Cycle Time** | **Lead Time** |
 | --- | --- | --- | --- |
-| **Fundamental Meaning** | The "Heartbeat." The pace required to satisfy the customer. | The "Actual Speed." The time it takes to perform the work. | The "Wait Time." The total duration a part spends in the system. |
+| **Fundamental Meaning** | The "Target Pace." The rate required to satisfy the customer. | The "Actual Speed." The time it takes to perform the work. | The "Wait Time." The total duration a part spends in the system. |
 | **Formula** | **Available Production Time ÷ Customer Demand** | **Time to complete one unit of work** | **Order completion time – Order placement time** |
 | **What it Includes** | Only net available production time (no breaks). | Loading, processing, unloading, and reset time. | Processing time + Queue time + Shipping + Delays. |
 | **Operational Focus** | **Planning:** How many people or machines do we need? | **Efficiency:** How can we make this specific task faster? | **Responsiveness:** How quickly can we turn an order into cash? |
 | **Management Signal** | If this changes, you must rebalance your production line. | If this is too high, you have a bottleneck at that station. | If this is too high, your inventory levels are likely bloated. |
 
-### The "Ideal State" Relationship
-
-In a perfect Lean environment, the relationship between these three metrics follows a hierarchy that maximizes ROI and eliminates waste. When you properly calculate takt time and understand its meaning, the ideal relationships emerge:
-
-1. **Cycle Time ≤ Takt Time:** Your actual work speed should be roughly **90–95% of Takt Time**, providing a small buffer for minor interruptions without failing to meet customer demand.
-2. **Minimized Lead Time:** Lead Time should be as close as possible to the sum of your Cycle Times. For example, if total Cycle Time is 1 hour but Lead Time is 10 days, **99% of the product's time is idle**, representing pure waste.
+In an ideal lean environment: **Cycle Time should sit at roughly 90–95% of Takt Time**, leaving a small buffer for minor interruptions without missing demand. **Lead Time** should stay as close as possible to the sum of your cycle times; if total cycle time is 1 hour but lead time is 10 days, 99% of the product's time in the system is pure waste.
 
 ## Why Takt Time Matters in Manufacturing
 
-Understanding the definition of takt time and applying the takt formula functions as more than a calculation exercise. It represents a fundamental operating principle that transforms manufacturing execution from reactive scheduling to demand-synchronized production.
+**Synchronizing production with demand.** Without takt time, production systems tend to run at maximum achievable speed regardless of actual demand, generating inventory during slow periods and shortages when demand rises. Calculating takt time correctly aligns production pace directly with order rate: when demand changes, takt time changes proportionally, triggering controlled adjustments instead of guesswork. This also caps overproduction: any output beyond the takt-time-derived rate is inventory the customer hasn't ordered yet, which is why pull-based systems use takt time as their replenishment signal.
 
-### Synchronization with Customer Demand
+**Line balancing and capacity planning.** Workstations with mismatched cycle times create bottlenecks: slow stations cause downstream waiting, fast ones cause upstream waiting, and both build up work-in-process that hides quality problems. Takt time gives every station the same target to balance against. For example, on a three-station line where Station 2's 3.5-minute cycle time bottlenecks Stations 1 (1.5 min) and 3 (2.0 min), rebalancing to a 2.5-minute takt time redistributes work so each station lands close to 2.3–2.4 minutes, and the bottleneck largely disappears. The same gap between current cycle time and takt time also quantifies staffing needs, equipment investment cases, and capacity expansion decisions.
 
-Production systems operating without understanding what takt time means typically run at maximum achievable speed, independent of actual demand signals. This approach generates inventory during periods of low demand and creates capacity shortages when demand increases. The disconnect between production pace and order rate leads to resource misallocation and suboptimal working capital deployment.
-
-When you define takt time and apply it correctly, you establish direct alignment between order rate and production pace. When demand changes, the calculated takt time changes proportionally using the takt time formula, triggering controlled adjustments to production resources. This synchronization maintains lean inventory levels while meeting delivery commitments.
-
-### Elimination of Overproduction
-
-Overproduction amplifies other forms of manufacturing waste. Excess production requires additional handling, consumes storage capacity, ties up working capital, and increases the inventory at risk from quality issues or obsolescence. Organizations often underestimate the compounding effect of overproduction on total manufacturing cost.
-
-The meaning of takt time in waste elimination establishes a maximum production rate derived from actual demand. Production exceeding the rate calculated using the takt formula generates inventory that customer orders have not yet justified. Pull-based production systems use takt time as the foundation for inventory replenishment signals, preventing unauthorized production while maintaining buffer stock at calculated levels.
-
-### Line Balancing and Flow
-
-Manufacturing lines develop bottlenecks when workstation cycle times vary significantly. Slow stations create waiting at downstream operations, fast stations create waiting at upstream operations, and both conditions generate work-in-process inventory that obscures quality issues and extends lead time.
-
-When you calculate takt time and apply it to each workstation, you provide a common target for balancing workload across all stations. When each station operates near the calculated takt time, flow improves and waiting decreases. Line balancing efforts use the takt time formula as the reference point for redistributing work elements across stations.
-
-Consider a three-station line before balancing. Station 1 completes work in 1.5 minutes, Station 2 requires 3.5 minutes, and Station 3 completes in 2.0 minutes. The bottleneck at Station 2 limits throughput while Stations 1 and 3 accumulate idle time. After balancing to a 2.5-minute takt time (calculated using the takt formula), Station 1 performs work totaling 2.3 minutes, Station 2 completes 2.4 minutes of work, and Station 3 handles 2.3 minutes. Flow improves and bottleneck waiting largely disappears.
-
-### Resource Planning and Capacity Analysis
-
-The takt time formula quantifies the relationship between demand and required capacity. When cycle time exceeds the calculated takt time, analysis immediately reveals whether additional operators, additional shifts, faster equipment, or process improvement can close the gap. When cycle time falls well below takt time, excess capacity becomes visible and can be redeployed.
-
-Staffing requirements derive from the comparison between takt time and cycle time. Equipment investment decisions gain quantitative support when takt time analysis demonstrates that current equipment cannot achieve required cycle times. Capacity planning validates whether demand projections require facility expansion or whether existing assets suffice.
-
-### Continuous Improvement Framework
-
-When you define takt time clearly, it establishes a baseline for improvement initiatives. The gap between current cycle time and required takt time (calculated using the takt time formula) quantifies the improvement target. Kaizen events and process optimization efforts use this gap to prioritize activities and measure progress.
-
-The improvement cycle follows a standard pattern. Measure current cycle time and compare to calculated takt time. Identify root causes for the gap. Implement improvements addressing these causes. Validate the new cycle time against the takt formula results. Document the process and repeat. This structured approach replaces ad hoc improvement with systematic capability building.
-
-### Quality and Safety Considerations
-
-Operating at sustainable pace rather than maximum speed affects both quality outcomes and safety performance. Production systems pushed to maximum throughput often sacrifice quality checks, proper technique, and ergonomic considerations. The pressure to maintain speed creates conditions where errors multiply and injuries occur.
-
-Understanding the true meaning of takt time shows it's about sustainable pace. Takt time–based production (properly calculated using the takt formula) operates at a pace that supports proper work methods, allows time for quality verification at each station, and reduces the physical stress associated with rushing. Manufacturing operations report substantial reductions in defects when transitioning from maximum-speed production to takt time–based production. Similarly, safety incident rates decline when operators work at a sustainable pace rather than pushing to maximum achievable speed.
+**Continuous improvement and safety.** The gap between current cycle time and takt time gives kaizen and process-improvement efforts a concrete target: measure, find root causes, implement fixes, re-measure against takt time, repeat. It also protects quality and safety: production pushed to maximum speed rather than a sustainable, demand-matched pace tends to sacrifice quality checks and proper technique, and manufacturers moving to takt-time-based pacing typically see fewer defects and safety incidents as a result.
 
 ## Implementing Takt Time Monitoring with FlowFuse
 
-While understanding the theory behind the definition of takt time is important, putting it into practice requires the right tools and approach. [FlowFuse](/) provides an industrial automation platform that connects to your existing systems, whether that's [PLCs](/blog/2025/10/plc-to-mqtt-using-flowfuse/), [databases](/node-red/database/), or ERP software, to automatically calculate takt time in real-time using the takt time formula.
-
-Instead of manually calculating takt time on spreadsheets or relying on static reports, you can build a dynamic monitoring system that updates continuously as customer orders and production conditions change. Let's see how to calculate takt time automatically, but before we begin, make sure you have a FlowFuse instance running. You can [create an account here](https://app.flowfuse.com/account/create) and get it set up quickly.
+Understanding takt time in theory is one thing; putting it into practice requires the right tools. [FlowFuse](/) connects to your existing systems, whether [PLCs](/blog/2025/10/plc-to-mqtt-using-flowfuse/), [databases](/node-red/database/), or ERP software, to calculate takt time automatically in real time instead of on static spreadsheets. Before starting, [create a FlowFuse account](https://app.flowfuse.com/account/create) if you don't already have one.
 
 ### Step 1: Connect to Your Data Sources
 
-The foundation of accurate takt time calculation is reliable data. FlowFuse supports connections to virtually any industrial system through its extensive library of [protocol](/node-red/protocol/) and [database](/node-red/database/) nodes.
+FlowFuse supports connections to industrial systems through its library of [protocol](/node-red/protocol/) and [database](/node-red/database/) nodes, pulling customer orders from your [ERP system](/blog/2025/06/connect-shop-floor-to-odoo-erp-flowfuse/), production schedules from MES, and real-time counts from PLCs.
 
-In a real implementation where you define takt time based on actual operations, you would pull customer order data from your ERP system, gather production schedules from manufacturing execution systems, connect to PLCs for real-time production counts, and integrate with quality systems for good parts tracking. You can [pull customer order data from your ERP system](/blog/2025/06/connect-shop-floor-to-odoo-erp-flowfuse/) using FlowFuse's integration capabilities.
-
-For this demonstration of how to calculate takt time, we'll simulate customer orders using an Inject node:
+For this demo, simulate customer orders with an Inject node:
 
 1. Add an Inject node
 2. Configure the payload with this JSONata expression:
@@ -240,11 +155,9 @@ For this demonstration of how to calculate takt time, we'll simulate customer or
 ```
 3. Set it to trigger every 5 seconds
 
-This simulates variability in customer demand between 50 and 100 units, demonstrating how the takt time formula responds to changing demand.
+This simulates demand varying between 50 and 100 units.
 
 ### Step 2: Calculate Available Production Time
-
-Next, establish the available production time for your shift, a critical component when you calculate takt time. This typically equals your total shift hours minus planned downtime for breaks, maintenance, and changeovers.
 
 1. Add a Change node
 2. Use the following JSONata expression:
@@ -252,11 +165,9 @@ Next, establish the available production time for your shift, a critical compone
    (8 * 60) - 60
 ```
 
-This represents an 8-hour shift (480 minutes) minus 1 hour (60 minutes) for breaks and changeovers, giving 420 minutes of available production time, the numerator in the takt time formula.
+This represents an 8-hour shift (480 minutes) minus 60 minutes for breaks and changeovers, leaving 420 minutes of available production time, the numerator in the formula.
 
 ### Step 3: Automate Takt Time Calculation
-
-Now, apply the takt formula to calculate takt time based on customer demand and available time.
 
 1. Add another Change node
 2. Configure it with this JSONata expression:
@@ -264,21 +175,19 @@ Now, apply the takt formula to calculate takt time based on customer demand and 
    $round(($number(msg.payload.availableTime) / $number(msg.payload.customer_order)) * 100)/100
 ```
 
-This implements the takt time formula automatically: Available Production Time ÷ Customer Demand. The calculation ensures takt time updates dynamically with each new order and produces clean, readable numbers for operators and managers.
+This applies the formula automatically, recalculating takt time with every new order.
 
 ### Step 4: Create Real-Time Dashboards
 
-Data is most valuable when operators can interpret the meaning of takt time instantly on the shop floor. FlowFuse's dashboard lets you create real-time displays showing calculated takt time using the same intuitive drag-and-drop interface.
-
 1. Install the [FlowFuse Dashboard](/platform/dashboard/) package via the Palette Manager (`@flowfuse/node-red-dashboard`)
-2. For basic displays, use text widgets to show current takt time values calculated using the takt formula. For more sophisticated interfaces, the Template widget allows you to create custom components. With [FlowFuse AI](/blog/2025/07/flowfuse-ai-assistant-better-node-red-manufacturing/), you can describe your desired interface in plain English and let the AI generate the appropriate code
-3. Connect the output of the Inject node to the input of the Change node that calculates available production time. Next, connect the output of this Change node to the input of the Change node that calculates takt time using the formula. Finally, connect the output of the takt time Change node to the input of the UI Template node
-4. Next, deploy the flow and open the dashboard to see real-time takt time updates
+2. Use text widgets for a simple readout, or the Template widget for a custom display; [FlowFuse AI](/blog/2025/07/flowfuse-ai-assistant-better-node-red-manufacturing/) can generate the code from a plain-English description
+3. Wire the Inject node into the available-time Change node, that into the takt-time Change node, and that into the UI Template node
+4. Deploy the flow and open the dashboard
 
 <video autoplay loop muted playsinline aria-label="Simple takt time display dashboard built with FlowFuse" width="558" height="546" preload="none"><source src="/blog/2025/09/images/takt-time-flowfuse.webm" type="video/webm" /></video>
-*Real-time takt time monitoring dashboard in FlowFuse showing the takt formula in action*
+*Real-time takt time monitoring dashboard in FlowFuse*
 
-Here's the complete flow we built for automated takt time calculation and visualization with FlowFuse, demonstrating how to calculate takt time in real-time.
+Here's the complete flow:
 
 ::render-flow{:height="300"}
 ```json
@@ -288,30 +197,14 @@ Here's the complete flow we built for automated takt time calculation and visual
 
 ## Best Practices for Takt Time Implementation
 
-When you understand how to define takt time and apply the takt time formula correctly, implementation success depends on following proven best practices. The meaning of takt time only translates to operational excellence when these principles guide your approach:
-
-- **Accurate Data:** Base your takt time calculation on actual production time, including breaks, changeovers, maintenance, and realistic downtime. Use real customer demand when applying the takt formula and update regularly to maintain accuracy.
-
-- **Leadership Commitment:** Leaders must support implementation visibly, allocate resources, participate in training, and communicate the benefits clearly. Understanding the takt time starts at the top.
-
-- **Gradual Deployment:** Start with a pilot line where you can define takt time clearly, train operators thoroughly, stabilize each phase, and expand gradually. Avoid implementing the takt time across all lines at once.
-
-- **Lean Integration:** Combine takt time (calculated using the proper formula) with value stream mapping, standardized work, and 5S to reduce waste and improve process capability. The meaning of takt time is amplified when integrated with other lean tools.
-
-- **Visual Management:** Use intuitive, visible displays that show calculated takt time and production status at a glance, enabling quick operator action when cycle times exceed the takt time.
-
-- **Problem Response:** Establish escalation procedures, maintain critical spares, station maintenance nearby, and train operators in basic troubleshooting. Quick response preserves the production pace defined by takt time.
-
-- **Continuous Refinement:** Review takt time calculations regularly, analyze performance trends against calculated takt time, and share lessons learned to improve future deployments.
+- **Accurate Data:** Base calculations on actual production time, including breaks, changeovers, and realistic downtime, using real customer demand, and update regularly.
+- **Leadership Commitment:** Leaders must support implementation visibly, allocate resources, and communicate the benefits clearly.
+- **Gradual Deployment:** Start with a pilot line, train operators thoroughly, stabilize, and expand gradually rather than rolling out across all lines at once.
+- **Lean Integration:** Combine takt time with value stream mapping, standardized work, and 5S to reduce waste and improve process capability.
+- **Visual Management:** Use visible displays showing calculated takt time and production status at a glance so operators can react quickly.
+- **Problem Response:** Establish escalation procedures, keep critical spares and maintenance nearby, and train operators in basic troubleshooting.
+- **Continuous Refinement:** Review takt time regularly, track performance against it, and share lessons learned across deployments.
 
 ## Conclusion
 
-The true meaning of takt time goes far beyond a simple calculation, it's the essential "heartbeat" of lean manufacturing that transforms volatile customer demand into a precise, manageable production rhythm. When you properly define takt time and apply the takt time formula consistently, you expose bottlenecks, balance workloads, and create predictable flow that maximizes resource utilization.
-
-While the **takt formula** (Takt Time = Available Production Time ÷ Customer Demand) is mathematically simple, its implementation is what separates world-class operations from those plagued by overproduction and constant firefighting. Understanding how to calculate takt time accurately and what the definition of takt time truly means operationally allows you to synchronize your production pace with the market.
-
-By learning to define takt time properly and applying the takt time formula in the right contexts, you expose bottlenecks, balance workloads, and create a predictable flow that maximizes resource utilization. However, manual tracking often leads to lagging data and missed opportunities. Modern industrial platforms like **FlowFuse** bridge this gap, providing the real-time visibility needed to monitor Takt Time, Cycle Time, and Lead Time automatically across your entire value stream.
-
-Mastering takt time isn't about working faster, it's about working at the right pace. When production is synchronized with demand, every minute on the shop floor creates customer value instead of waste. When you truly understand what it means to define takt time and calculate takt time correctly using the proper formula, you unlock the foundation of lean manufacturing excellence.
-
-**[Book your demo](/book-demo/) today to see how FlowFuse can automate your production metrics and help you eliminate waste through real-time data visibility.**
+Takt time turns volatile customer demand into a precise, manageable production rhythm. The formula is simple (Available Production Time ÷ Customer Demand), but consistently applying it is what separates world-class operations from those stuck firefighting overproduction and missed deadlines. Manual tracking on spreadsheets tends to lag reality; platforms like FlowFuse give you the real-time visibility to monitor takt time, cycle time, and lead time automatically across your value stream.

--- a/src/blog/2025/12/five-whys-root-cause-analysis-definition-examples.md
+++ b/src/blog/2025/12/five-whys-root-cause-analysis-definition-examples.md
@@ -1,15 +1,18 @@
 ---
-metaTitle: "Five Whys Root Cause Analysis: Steps & Examples"
-title: "Five Whys Root Cause Analysis: Definition, Steps & Examples (2026)"
-subtitle: "A proven root cause analysis technique for solving recurring problems in manufacturing, operations, and continuous improvement."
-description: "Learn the Five Whys root cause analysis method: step-by-step process, real Toyota examples, templates, and best practices."
+metaTitle: "5 Whys Root Cause Analysis: Steps, Template & Example"
+title: "5 Whys Root Cause Analysis: Steps, Template & Example"
+subtitle: "The Toyota technique for finding what actually caused a problem, not just its symptom."
+description: "The 5 Whys root cause analysis method: a step-by-step template, the original Toyota example, and mistakes to avoid."
 date: 2025-12-22
 lastUpdated: 2025-12-23
 authors: ["sumit-shinde"]
-image: /blog/2025/12/images/five-whys-analysis.png
 keywords: 
 tags:
   - flowfuse
+cta:
+  type: contact
+  title: "Prove Your Fixes Are Actually Working"
+  description: "FlowFuse connects your PLCs, SCADA, and quality systems so you can track whether a corrective action is holding, in real time, not just assume it is."
 meta:
   faq:
   - question: "How many times should I actually ask 'why' in a Five Whys analysis?"
@@ -31,42 +34,32 @@ meta:
 tldr: "The Five Whys is a root cause analysis technique from Toyota: keep asking why a problem happened, typically five times, until you reach a systemic cause rather than a symptom. It is fast, needs no statistical training, and forces one causal chain to its end so the failure doesn't recur."
 ---
 
-The Five Whys is a root cause analysis technique where you ask "why" repeatedly, typically five times, until you identify the underlying systemic cause instead of just symptoms.
+The 5 Whys is a root cause analysis technique where you ask "why" repeatedly, typically five times, until you identify the underlying systemic cause instead of just symptoms.
 
 <!--more-->
 
-Your equipment fails on Tuesday. The maintenance team fixes it. It fails again on Friday. They fix it again. Three weeks later, same failure. This cycle continues because everyone treats the symptom, the broken part, instead of asking why it broke.
+Your equipment fails on Tuesday. The maintenance team fixes it. It fails again on Friday. Three weeks later, same failure. This cycle continues because everyone treats the symptom, the broken part, instead of asking why it broke.
 
-The Five Whys breaks this pattern. Developed by Sakichi Toyoda at Toyota in the 1930s, it's become the standard root cause analysis method across manufacturing, healthcare, software development, and anywhere recurring problems drain productivity. The technique works through systematic questioning that strips away symptoms to expose fixable failures in your systems, the process gaps, training deficiencies, and procedural weaknesses that allow problems to persist. When applied correctly, it takes under an hour and prevents problems from returning.
+The 5 Whys breaks this pattern. Developed by Sakichi Toyoda at Toyota in the 1930s, it's the standard root cause analysis method across manufacturing, healthcare, and software development. Systematic questioning strips away symptoms to expose the process gaps, training deficiencies, and procedural weaknesses that let problems persist. Applied correctly, it takes under an hour.
 
-## What Is the Five Whys Root Cause Analysis Method?
+## What Is the 5 Whys Root Cause Analysis Method?
 
-The Five Whys root cause analysis is a questioning technique where you ask "why" a problem occurred, then ask "why" that condition existed, then keep asking until you hit something you can actually fix at a systemic level. It was developed by Sakichi Toyoda in the 1930s and became a core tool in the Toyota Production System. Today it's used across manufacturing, healthcare, software development, and anywhere else people need to solve recurring problems.
+The 5 Whys is a questioning technique: ask "why" a problem occurred, ask "why" that condition existed, and keep going until you hit something fixable at a systemic level, not just a symptom.
 
-The technique is deceptively simple. You start with a specific problem. You ask why it happened. You take that answer and ask why again. You keep going until asking "why" one more time would just be splitting hairs or rehashing what you already know. Usually that takes about five iterations, the number comes from the observation that five whys is typically sufficient to reveal the root cause, but I've seen effective analyses that stopped at three and others that went to eight.
+The technique is deceptively simple. Start with a specific problem, ask why it happened, then take that answer and ask why again. Keep going until asking "why" one more time would just be splitting hairs. That usually takes about five iterations, hence the name, but effective analyses sometimes stop at three and others run to eight.
 
-Watch this video if you prefer video format:
+## Why the 5 Whys Works When Other Methods Don't
 
-<lite-youtube videoid="-_nN_YTDsuk" params="rel=0" style="margin-top: 20px; margin-bottom: 20px; width: 100%; height: 480px;" title="YouTube video player"></lite-youtube>
+Organizations often spend weeks on elaborate root cause analyses using [fault trees](https://en.wikipedia.org/wiki/Fault_tree_analysis), [fishbone diagrams](/blog/2026/07/ishikawa-fishbone-diagram/), and [statistical process control charts](/blog/2025/07/quality-control-automation-spc-charts), only to implement solutions that don't stick. The 5 Whys succeeds where these often fail, for three reasons.
 
-## Why the Five Whys Works When Other Methods Don't
-
-Organizations often spend weeks on elaborate root cause analyses using [fault trees](https://en.wikipedia.org/wiki/Fault_tree_analysis), [fishbone diagrams](/blog/2026/07/ishikawa-fishbone-diagram/), and [statistical process control charts](/blog/2025/07/quality-control-automation-spc-charts), only to implement solutions that don't stick. The Five Whys succeeds where these methods often fail for three reasons.
-
-First, it's fast. You can complete a thorough analysis in under an hour. That speed matters because problems are freshest when they just happened. Witnesses remember details. Physical evidence hasn't been cleaned up or moved. The sense of urgency is still there. Wait two weeks to schedule your analysis meeting, and you're working from memory and assumptions.
-
-Second, it's accessible. The machine operator who saw the problem doesn't need training in statistical methods or failure mode analysis. They just need to answer questions honestly about what they observed. This democratization of problem-solving means you're not waiting for specialists to free up their calendars. The people closest to the work can solve problems themselves.
-
-Third, it forces you to follow a single causal chain all the way down. Other methods encourage you to map out every possible contributing factor simultaneously. That comprehensiveness sounds good in theory, but in practice it often leads to analysis paralysis. You've identified seventeen potential causes, and now you're trying to fix all of them at once. The Five Whys makes you pick the most likely path and follow it to the end. You can always come back and explore alternative explanations if your first solution doesn't work.
+It's fast: a thorough analysis takes under an hour, while problems are still fresh and evidence hasn't been cleaned up. It's accessible: the operator who saw the problem doesn't need statistical training, just honest answers about what they observed. And it forces a single causal chain all the way down, instead of the analysis-paralysis that comes from mapping every possible contributing factor at once. You can always circle back and explore alternatives if your first path doesn't hold up.
 
 ::cta-image{src="/images/cta/arch-systems-book-demo.png" alt="Arch Systems scales automation across complex manufacturing environments with FlowFuse - book a demo" cta="demo"}
 ::
 
-## The Five Whys Checklist: What You Need Before You Start
+## The 5 Whys Checklist: What You Need Before You Start
 
-Most failed Five Whys sessions fail before they even begin because people skip the setup. You need four things in place before you ask the first question.
-
-Before you ask the first question, you need four things:
+Most failed 5 Whys sessions fail before they even begin because people skip the setup. You need four things in place before you ask the first question:
 
 - **A specific problem statement.** "Quality issues in Department B" won't work. "Thirty-seven units failed final inspection on December 18th due to incomplete welds" will. Specificity disciplines your thinking and keeps the analysis focused.
 
@@ -76,90 +69,53 @@ Before you ask the first question, you need four things:
 
 - **Commitment to honest answers.** If the real reason your new hires keep making mistakes is that your training program is inadequate, you need people willing to say that out loud. If your preventive maintenance schedule was designed fifteen years ago and never updated, someone needs to acknowledge it. The Five Whys only works if people tell the truth about what they see.
 
-## How to Complete a Five Whys Root Cause Analysis
+## 5 Whys Template: How to Complete the Analysis
 
-The mechanics of the method are straightforward, but execution requires more care than most people expect.
+The mechanics are straightforward, but execution requires more care than most people expect.
 
 ![Five Whys funnel diagram from problem to root cause](./images/5-Why-Funnel.jpg)
 _Five Whys funnel diagram from problem to root cause_
 
-Start by stating the problem as precisely as you can. Write it down where everyone can see it. If you're working through this at the gemba, write it on a whiteboard or a large sheet of paper. If you're remote, put it in a shared document. The problem statement anchors everything that follows, so take the time to get it right. Include what happened, when it happened, where it happened, and how you know it happened. Measurements matter here. "Production was slow" is too vague. "Line 3 produced 847 units against a target of 1,000 units during the first shift on December 20th" gives you something concrete to investigate.
+Use this simple template to run the analysis, filling in each line with a verified fact, not a guess:
 
-Ask your first why: Why did this specific problem occur? The answer should be factual, not speculative. "I think maybe the bearings were worn" isn't good enough. "The motor seized, and when we disassembled it, we found metal shavings in the bearing housing" is what you're after. If you don't know the answer with certainty, stop and gather evidence before continuing.
+- **Problem:** What happened, where, when, and how you know it. ("Line 3 produced 847 units against a target of 1,000 during first shift on Dec 20th," not "production was slow.")
+- **Why 1:** Why did this specific problem occur?
+- **Why 2:** Why did *that* condition exist?
+- **Why 3–5 (as needed):** Keep asking why of the previous answer.
+- **Root cause:** The systemic gap you can actually fix.
+- **Corrective action:** The specific fix, owner, and deadline.
 
-Take that answer and ask why again. Why did the motor bearings fail? Because the lubrication system wasn't delivering oil to that bearing. How do you know? Because we checked the oil flow and found the feed line was clogged. This is where many analyses go wrong. People start speculating instead of observing. They say things like "probably the operator forgot to check it" when what they actually know is that the line was clogged. Stick to what you can verify.
+Each answer should be something you can verify: a physical observation, sensor data, a log, or direct testimony, not speculation. "Probably the operator forgot" isn't an answer; "the feed line was clogged, confirmed by checking oil flow" is. Stop once you reach a process failure or systemic gap you can fix with a clear corrective action, revising a maintenance procedure or adding a training step, rather than "operator error" or "equipment failure," which are symptoms, not causes.
 
-Continue this pattern. Each answer becomes the subject of the next question. Why was the feed line clogged? Because particulate from the oil reservoir got into the line. Why was there particulate in the reservoir? Because we're not filtering the oil when we top off the reservoir. Why aren't we filtering it? Because the maintenance procedure doesn't specify using a filter when adding oil.
+The number of whys is a guideline, not a rule. Some analyses reach the root cause in three questions; others need eight. What matters is reaching something you can actually fix.
 
-Stop when you've identified a process failure or systemic gap. In this case, the inadequate maintenance procedure is your root cause. It's something you can fix with a clear corrective action: revise the maintenance procedure to require filtered oil and provide the appropriate filtering equipment. That's different from "operator error" or "equipment failure," which are symptoms, not causes.
+## When to Use the 5 Whys (and When Not To)
 
-Notice that this example took exactly five questions, but that's coincidental. Effective analyses sometimes reach the root cause in three questions and other times need eight. The number doesn't matter. What matters is reaching the point where you've identified something you can actually fix.
+The 5 Whys is most effective for problems with one dominant causal chain: equipment failures, quality defects, process bottlenecks, safety incidents, and customer complaints. Ask it here and you'll typically reach the fix quickly.
 
-## When and Where Should You Use the Five Whys?
+It's less effective for complex problems with multiple simultaneous, interacting causes, like a major product recall spanning design, materials, and distribution, where fishbone or fault tree analysis lets you map several pathways at once. It also struggles with deep organizational or cultural roots: if people don't report problems for fear of retaliation, asking "why" five times might surface that fact, but fixing it needs change management, not a questioning technique.
 
-The Five Whys is particularly effective for problems with a dominant causal chain. If your problem has one primary cause with some contributing factors, this method will find it quickly. It works well for equipment failures, quality defects, process bottlenecks, safety incidents, and customer complaints where you're trying to understand what broke down in your systems.
+## The Toyota Origin of the 5 Whys
 
-It's less effective for complex problems with multiple simultaneous causes that interact with each other. If you're investigating a major product recall with contributing factors spanning design, materials, manufacturing, and distribution, the Five Whys will feel inadequate. You're better off with something like fishbone analysis or fault tree analysis that lets you map multiple causal pathways simultaneously.
+[Sakichi Toyoda](https://en.wikipedia.org/wiki/Sakichi_Toyoda) developed the 5 Whys in the 1930s as part of what became the [Toyota Production System](https://en.wikipedia.org/wiki/Toyota_Production_System), insisting that problems were symptoms of deeper issues that could be identified and eliminated rather than accepted as inevitable. His son [Kiichiro Toyoda](https://en.wikipedia.org/wiki/Kiichiro_Toyoda) and engineer [Taiichi Ohno](https://en.wikipedia.org/wiki/Taiichi_Ohno) refined it in the decades after World War II, formalizing the practice of observing problems firsthand at the [gemba](https://en.wikipedia.org/wiki/Gemba) and asking why until reaching something systemic.
 
-The method also struggles with problems that have deep organizational or cultural roots. If your real issue is that nobody wants to report problems because they fear retaliation, asking "why" five times might surface that fact, but fixing it requires organizational change management that's well beyond what a questioning technique can address. The Five Whys can identify the issue, but you'll need other tools to solve it.
+The method spread beyond automotive manufacturing in the 1970s-80s as Western companies studied Toyota's success, though often without the cultural foundation that made it work: it only survives in an environment where people feel safe identifying systemic problems and management is committed to fixing them, not one that shoots the messenger.
 
-The method works well for equipment failures and maintenance issues, quality problems that recur despite corrections, process bottlenecks that resist obvious solutions, safety incidents requiring rapid investigation, and customer complaints where you need to fix internal processes. It struggles with problems that have multiple independent causes, new product development scenarios where you're trying to prevent future failures, strategic planning issues, and situations where participants don't have sufficient knowledge to answer accurately.
+## 5 Whys Best Practices
 
-## The Toyota Five Whys: Where This Method Came From
+- **Focus on processes, not people.** If your analysis points to an individual's mistake, keep going: why didn't training or a verification step catch it? A well-designed process assumes people will make mistakes and builds in safeguards.
+- **Verify every answer.** The 5 Whys fails when it becomes brainstorming instead of investigation. Each answer needs evidence, a log, a measurement, a witness, not a guess.
+- **Stay on one causal chain at a time.** Resist branching into every contributing factor at once; follow the most likely path to the end first, then circle back if it doesn't hold up.
+- **Keep questions neutral.** "Why wasn't the pressure checked?" surfaces procedural gaps; "why did the operator forget?" just points toward blame.
+- **Know when to stop.** You're done when the answer is something fixable through a procedural, training, or design change, not a philosophical statement about culture or budget.
 
-[Sakichi Toyoda](https://en.wikipedia.org/wiki/Sakichi_Toyoda) developed the Five Whys in the 1930s as part of the manufacturing methodology that would eventually become the [Toyota Production System](https://en.wikipedia.org/wiki/Toyota_Production_System). Toyoda, who founded what would become Toyota Industries, was obsessed with understanding why things failed. His approach was radical for its time: instead of accepting problems as inevitable, he insisted they were symptoms of deeper issues that could be identified and eliminated.
+## Common 5 Whys Mistakes
 
-His son [Kiichiro Toyoda](https://en.wikipedia.org/wiki/Kiichiro_Toyoda) and engineer [Taiichi Ohno](https://en.wikipedia.org/wiki/Taiichi_Ohno) refined the method as they developed Toyota's production system in the decades after World War II. They formalized the practice of going to the gemba to observe problems firsthand and asking why until you hit something systemic rather than symptomatic.
+The most frequent mistake is stopping at a symptom: a part fails, the team replaces it, logs "component failure," and moves on without asking why it failed. Close behind is accepting "human error" as the root cause, when the real question is why that error was possible and why existing safeguards didn't catch it. Teams also rush through the questions when they're uncomfortable, quickly blaming an operator instead of investigating, or branch off into several causal chains at once and never follow any of them to a concrete root cause. Each of these produces an analysis that looks complete but changes nothing.
 
-Toyota's success with this approach attracted attention in the 1970s and 1980s when Western manufacturers were trying to understand why Japanese companies were outcompeting them. The Five Whys spread beyond automotive manufacturing into other industries, though often without the cultural foundation that made it effective at Toyota. Many companies adopted the technique as a standalone tool without understanding that it only works in an environment where people feel safe identifying systemic problems and where management is committed to fixing them.
+## 5 Whys Example: The Original Toyota Case
 
-That context matters when you're implementing the Five Whys in your organization. The technique itself is simple, but it won't survive in a culture that shoots the messenger or treats problem identification as complaining rather than continuous improvement.
-
-## Best Practices From Experienced Root Cause Analysis
-
-Focus on processes and systems, not people. When your analysis points to an individual who made a mistake, don't stop there. Ask why that mistake was possible. Why didn't training cover this situation? Why didn't the procedure include a verification step? Why wasn't there a physical or administrative control that would have caught the error? Robust processes assume people will make mistakes and build in safeguards. If your process allows one person's mistake to cause a significant problem, your process is inadequate.
-
-Verify every answer before moving to the next question. The Five Whys fails when it becomes an exercise in brainstorming rather than investigation. Each answer should be based on evidence you can point to: physical observations, data from sensors or logs, documents, measurements, or direct testimony from witnesses. If your team is guessing, stop and gather facts.
-
-Stay on one causal chain at a time. Real problems often have multiple contributing causes, and your team will want to explore all of them simultaneously. Resist this. Follow the most likely path all the way to the end first. If the corrective actions you implement don't solve the problem, you can come back and explore alternative paths. Trying to investigate everything at once creates confusion and dilutes your focus.
-
-Keep your questions neutral. "Why did the operator forget to check the pressure?" assumes forgetfulness and points toward blame. "Why wasn't the pressure checked?" opens up multiple possibilities including procedural gaps, time pressure, distraction, inadequate training, or unclear responsibility. How you phrase the question shapes what answers you'll get.
-
-Know when to stop. You've found your root cause when the answer identifies something you can fix through a procedural change, a training modification, a design improvement, or another corrective action that addresses the systemic level. If you keep asking why beyond that point, you'll end up with philosophical answers about organizational culture or budget constraints that aren't actionable in the context of this specific problem.
-
-## Common Mistakes That Undermine Five Whys Analysis
-
-The most frequent mistake is stopping at symptoms. A part fails, and the team replaces it, logs "component failure" as the root cause, and moves on. That's not root cause analysis. That's just describing what happened. The root cause is why the component failed: inadequate maintenance, incorrect installation, design limitation, contamination, or some other systemic issue that made the failure possible.
-
-Another common failure is accepting "human error" as a root cause. People make mistakes. This is not new information. If your analysis concludes that someone made a mistake, ask why that mistake was possible and why existing safeguards didn't prevent or catch it. Human error is a symptom, not a cause.
-
-Teams sometimes rush through the analysis because they're uncomfortable with the questions. Someone asks why a procedure wasn't followed, and instead of actually investigating, the team quickly blames the operator and moves on. This happens in organizations where problem-solving has become a blame-finding exercise. If your culture doesn't support honest answers, the Five Whys won't work regardless of how well you understand the technique.
-
-Some teams branch off into multiple causal chains without finishing any of them. They ask the first why, get an answer, then immediately see three more potential causes and start investigating all of them. Before long, they've filled a whiteboard with possibilities but haven't followed any single path to a concrete root cause. Discipline yourself to investigate one chain completely before exploring alternatives.
-
-## Tools and Software for Five Whys Analysis
-
-You don't need specialized software to conduct a Five Whys analysis. A whiteboard, a notepad, or a simple word processing document works fine. The tool matters far less than the discipline with which you apply the method.
-
-That said, organizations that conduct frequent root cause analyses often find value in standardized digital tools. Quality management systems like ETQ, MasterControl, or Sparta Systems include Five Whys templates integrated with corrective action tracking. This integration helps ensure that the actions identified during analysis actually get completed and verified.
-
-Project management platforms can be adapted for Five Whys documentation if you configure custom workflows. The advantage here is that corrective actions automatically flow into your existing task management processes rather than living in a separate system that nobody checks.
-
-Some organizations prefer physical tools. I've worked in plants that keep Five Whys templates on clipboards at each production line. When a problem occurs, the shift supervisor conducts the analysis right there, documents it on the physical form, and posts it on a problem-solving board where everyone can see it. This visibility reinforces the importance of root cause analysis and shares lessons learned across shifts.
-
-The best tool is the one your team will actually use consistently. If your organization already has a quality management system, use that. If you're just starting out, begin with the simplest thing that works: a shared document template and a commitment to complete one analysis per week.
-
-## What Is the 5 Problem-Solving Steps Process?
-
-The 5 problem-solving steps is a broader framework that incorporates the Five Whys as one component. The steps are: define the problem, analyze the root cause, develop solutions, implement corrective actions, and verify effectiveness. The Five Whys specifically addresses the second step, root cause analysis.
-
-This framework matters because root cause analysis by itself doesn't solve problems. You also need clear problem definition up front, solution development after you identify the cause, disciplined implementation, and verification that your corrective actions actually worked. Organizations sometimes do excellent Five Whys analyses but never implement the corrective actions they identify. The analysis becomes an end in itself rather than a means to improvement.
-
-Effective problem-solving requires all five steps in sequence. Rushing to solutions before you understand root causes leads to wasted effort fixing the wrong things. Identifying root causes but failing to implement solutions means nothing changes. Implementing solutions without verification means you never know if they actually worked or if the problem just hasn't recurred yet by chance.
-
-## Example of a 5 Why Question in Practice
-
-What does an effective Five Whys question actually sound like? Here's the classic example from Taiichi Ohno, one of the architects of the Toyota Production System, documented in his book "Toyota Production System: Beyond Large-Scale Production" (1988, p. 17).
+Here's the classic example from Taiichi Ohno, one of the architects of the Toyota Production System, documented in his book "Toyota Production System: Beyond Large-Scale Production" (1988, p. 17).
 
 **The problem:** A machine stopped functioning on the factory floor.
 
@@ -184,64 +140,14 @@ What does an effective Five Whys question actually sound like? Here's the classi
 
 This example demonstrates the fundamental questioning pattern. Modern Five Whys analyses typically include more detailed evidence documentation at each step (inspection reports, sensor data, maintenance logs), but the core approach of following a single causal chain to reach a systemic issue remains unchanged. Notice how the analysis moved from a symptom (blown fuse) through intermediate causes (overload, insufficient lubrication, worn shaft) to arrive at a fixable process gap (missing strainer).
 
-## Implementing the Five Whys in Your Organization
+## Implementing the 5 Whys in Your Organization
 
-If you want to implement the Five Whys effectively, start with a pilot program rather than a company-wide rollout. Select one department or one type of problem as your initial focus. Train a small group of people thoroughly rather than providing superficial training to everyone. Conduct your first few analyses with experienced facilitation, ideally from someone who has used the method successfully in another organization.
+Start with a pilot program, one department or one type of problem, rather than a company-wide rollout, and train a small group thoroughly rather than everyone superficially. Expect the first few analyses to feel awkward: people will want to skip to solutions or struggle to phrase neutral questions. That's normal and improves with practice. After each analysis, debrief on the process itself (did we gather evidence or speculate? follow one chain or branch off?), and track whether corrective actions actually get completed, since root cause analysis without follow-through is worse than no analysis at all. Give it six months before judging whether it's working; a shortfall by then is usually an implementation problem, not a flaw in the method.
 
-Expect the first several analyses to feel awkward. People will struggle with phrasing neutral questions. They'll want to skip ahead to solutions before finishing the analysis. They'll be uncomfortable when the questioning reveals gaps in procedures or training. This is normal. The skill develops with practice.
+## Measuring Whether the 5 Whys Is Working
 
-After each analysis, conduct a brief debrief focused on the process itself. What went well? Where did we struggle? Did we gather evidence before answering, or did we speculate? Did we follow one causal chain to the end, or did we branch off into multiple paths? This reflection builds capability faster than simply conducting more analyses.
+Four metrics tell the story: **problem recurrence** (do issues that used to recur monthly or quarterly stop appearing?), **cycle time** from problem to implemented fix (this should shrink with practice), **quality of corrective actions** (systemic fixes, not "be more careful" reminders), and **staff engagement** (are frontline staff bringing problems forward and suggesting causes on their own?).
 
-Track your corrective action completion rate. If actions identified during Five Whys analyses aren't being implemented, you have an organizational problem that needs attention. Root cause analysis without follow-through is worse than no analysis at all because it creates the illusion of improvement while nothing actually changes.
+## 5 Whys Limitations
 
-Give it six months before evaluating whether the method is working for your organization. You should see a reduction in recurring problems, faster resolution of new problems, and increasing confidence among frontline staff in their ability to identify and solve issues. If you're not seeing these outcomes, the problem is usually implementation rather than the method itself.
-
-## Measuring Whether the Five Whys Is Working
-
-How do you know if the Five Whys is actually improving your operations? Four metrics tell the story:
-
-**Problem recurrence rates.** If you're conducting thorough root cause analyses and implementing effective corrective actions, the same problems should stop reappearing. Pull your incident data from six months before you started using the Five Whys and compare it to six months after. Look for problems that used to recur monthly or quarterly that have stopped appearing.
-
-**Cycle time from problem to solution.** As your team gets more practiced with the method, this should decrease. Early on, you might take two weeks to complete an analysis and implement corrections. After several months of practice, you should be conducting same-day or next-day analyses with corrective actions implemented within a week.
-
-**Quality of corrective actions.** Are you implementing procedural changes, training improvements, and system modifications? Or are you repeatedly concluding that operators need to "be more careful" and issuing reminders? High-quality corrective actions address systemic issues. Low-quality corrective actions ask people to try harder without changing anything about the system they work in.
-
-**Staff engagement.** Are frontline staff bringing problems forward more readily? Are they participating actively in analyses? Are they suggesting root causes and corrective actions? Increasing engagement signals that the method is building problem-solving capability across your organization rather than remaining a management-only activity.
-
-## The Limitations Nobody Talks About
-
-The Five Whys has limitations that don't get discussed much in the literature promoting it. Understanding these limitations helps you apply the method appropriately rather than treating it as a universal solution.
-
-First, the method assumes a relatively linear cause-and-effect relationship. Many real-world problems involve complex interactions between multiple systems where causes and effects aren't clearly distinguishable. Equipment failures in modern automated systems often result from software interactions, sensor drift, mechanical wear, and operator actions all contributing simultaneously. The Five Whys struggles with this kind of complexity because it forces you to follow a single thread.
-
-Second, the technique depends entirely on the knowledge and honesty of the people answering the questions. If they don't actually know why something happened, they'll speculate. If they're afraid of identifying systemic issues that might reflect poorly on management, they'll stop at superficial answers. The Five Whys doesn't magically generate insight. It structures questioning, but the quality of answers depends on the people providing them.
-
-Third, the method can lead to what statisticians call "confirmation bias." If your team already suspects the cause of a problem, the questions will unconsciously steer toward confirming that hypothesis rather than genuinely exploring alternatives. A facilitator aware of this bias can counteract it, but it requires conscious effort.
-
-Finally, the Five Whys doesn't help you prioritize which problems to investigate. If you have twenty recurring issues, it doesn't tell you which five deserve immediate root cause analysis and which can wait. You need a separate prioritization framework based on safety risk, financial impact, frequency, or strategic importance.
-
-These limitations don't make the method useless. They just mean you need to recognize when you're facing a problem that requires a different or additional approach.
-
-## What Happens After the Analysis
-
-The Five Whys analysis is the easy part. Implementation is where most organizations struggle. You've identified that your preventive maintenance schedule is inadequate, or your training program has gaps, or your procedures haven't been updated to match your current equipment. Now you have to actually fix these things, which requires resources, time, and organizational commitment.
-
-Effective implementation requires clear ownership. Someone needs to be specifically responsible for each corrective action, with a realistic deadline and the authority to make the necessary changes. "The maintenance department will handle it" doesn't work. "James will revise the PM schedule by December 15th and review it with the maintenance manager before implementation" does.
-
-Build verification into your corrective actions. How will you know if the changes you implemented actually solved the problem? In some cases, verification is straightforward: if the problem was equipment failures, track whether failures stop occurring. In other cases, you need to actively test: if you revised a procedure, observe someone following the new procedure to ensure it's clear and complete.
-
-Communicate the results. When a Five Whys analysis leads to improvements, tell people about it. Post the analysis and the corrective actions where staff can see them. Mention it in team meetings. This visibility serves two purposes: it demonstrates that problem-solving leads to real changes, and it shares lessons learned across your organization so other areas can benefit from what you discovered.
-
-Don't declare victory too soon. Some corrective actions take time to show results, and some problems are intermittent enough that you need several months of data to confirm they're truly resolved. Plan a follow-up review three to six months after implementation to verify effectiveness and make adjustments if needed.
-
-The Five Whys is a tool for getting to root causes. But getting to root causes only matters if you do something about them. The analysis takes thirty minutes. The real work comes after.
-
-## Monitor Your Corrective Actions Across All Systems
-
-You've identified the root cause and implemented fixes. Now you need to verify they're working, across IT systems, OT equipment, quality databases, and maintenance platforms.
-
-[FlowFuse](/) connects them all. Whether it's legacy PLCs or modern IoT sensors, ERP systems or SCADA networks, FlowFuse brings your data together in one place. Build dashboards that track the metrics proving your solutions worked: reduced equipment failures, lower defect rates, improved maintenance compliance, or whatever KPIs matter for your specific corrective actions.
-
-Catch warning signs before problems recur. See trends that reveal whether your fixes are holding or degrading over time. Turn root cause analysis into continuous improvement with real-time monitoring.
-
-[Start connecting your systems with FlowFuse](https://app.flowfuse.com) and prove your Five Whys analyses deliver lasting results.
+The method assumes a roughly linear cause-and-effect chain, so it struggles with modern failures that result from several systems interacting at once (software, sensors, mechanical wear) rather than one dominant path. It also depends entirely on the honesty and knowledge of whoever answers: people who don't know will speculate, and people worried about blame will stop at a superficial answer. It's prone to confirmation bias if the team already suspects a cause, and it won't tell you which of twenty recurring problems to tackle first, that needs a separate prioritization framework based on risk, cost, or frequency. None of this makes the method useless, but it does mean recognizing when a problem needs a different or additional approach.

--- a/src/blog/2025/12/mttf-vs-mtbf-vs-mttr.md
+++ b/src/blog/2025/12/mttf-vs-mtbf-vs-mttr.md
@@ -10,8 +10,8 @@ tags:
     - flowfuse
 cta:
   type: contact
-  title: "Automate MTTF Tracking Across Your Fleet"
-  description: "FlowFuse connects to PLCs, SCADA, and your CMMS to calculate MTTF from real operating data instead of manual logs."
+  title: "Automate MTTF, MTBF & MTTR Tracking Across Your Fleet"
+  description: "FlowFuse connects to PLCs, SCADA, and your CMMS to calculate MTTF, MTBF, and MTTR from real operating data instead of manual logs."
 meta:
   faq:
   - question: "What does MTTF stand for?"
@@ -37,15 +37,47 @@ meta:
 tldr: "Mean Time to Failure (MTTF) is the average operating lifetime of non-repairable components, such as bulbs, batteries, and electronic modules, that get replaced rather than repaired. Divide total operating time by the number of failures. MTTF differs from MTBF, which covers repairable systems, and MTTR, which measures repair time."
 ---
 
-A motor bearing assembly rated for a year fails after six months. Was that bad luck, a bad batch, or has this part always run hot in your facility? Without a number to compare against, there's no way to tell.
+A motor bearing assembly rated for a year fails after six months. Is that an MTTF problem, an MTBF problem, or something you should be tracking as MTTR instead? Attach the wrong metric to the wrong type of equipment, and your maintenance planning is built on a number that was never meant to apply.
 
 <!--more-->
 
-Mean Time to Failure (MTTF) is that number. It measures the average operational lifetime of non-repairable components before permanent failure, and it's what turns "that failed early" into a data-driven decision about replacement timing, spare parts inventory, and component selection.
+MTTF, MTBF, and MTTR all measure reliability, but they answer different questions. MTTF (Mean Time to Failure) tracks how long a non-repairable part lasts before it's replaced. MTBF (Mean Time Between Failures) tracks how long a repairable system runs between fixes. MTTR (Mean Time to Repair) tracks how long those fixes take. Confuse the three and you end up comparing numbers that were never meant to be compared, and basing replacement schedules, spare parts inventory, and supplier decisions on the wrong one.
 
-MTTF emerged as a core reliability engineering metric in the 1950s during the development of military and aerospace reliability theory. Today, it remains essential across industries where component reliability determines operational success, from semiconductor manufacturing to data centers to industrial automation.
+These metrics emerged as core reliability engineering concepts in the 1950s during the development of military and aerospace reliability theory, and remain essential across industries where component and system reliability determine operational success, from semiconductor manufacturing to data centers to industrial automation.
 
-This guide explains what MTTF measures, how to calculate it correctly with real examples, how it differs from related metrics, and how to use MTTF data for strategic maintenance planning.
+This guide breaks down what each metric measures and when to use which one, then dives into how to calculate MTTF correctly with real examples and how to use that data for strategic maintenance planning.
+
+## MTTF vs MTBF vs MTTR: What's the Difference?
+
+These three acronyms measure fundamentally different aspects of reliability.
+
+### What is MTBF (Mean Time Between Failures)?
+
+MTBF is the average operating time between failures for a **repairable** system, one that gets fixed and returned to service rather than discarded. It's the metric to use for motors, pumps, HVAC units, and vehicles.
+
+```
+MTBF = Total Operating Time / Number of Repair Events (excluding repair time)
+```
+
+### What is MTTR (Mean Time to Repair)?
+
+MTTR is the average time it takes to complete a repair once a failure happens, covering diagnosis, parts sourcing, and the fix itself. It applies to any equipment that gets repaired rather than replaced.
+
+```
+MTTR = Total Repair Time / Number of Repairs
+```
+
+### MTTF vs MTBF vs MTTR at a glance
+
+| Metric | What It Measures | Use For | Example |
+|--------|-----------------|---------|---------|
+| **MTTF** | Average time until permanent failure | Non-repairable items replaced when they fail | Light bulbs, batteries, hard drives, sealed bearings |
+| **MTBF** | Average time between repair events | Repairable systems fixed and returned to service | Motors, pumps, HVAC systems, vehicles |
+| **MTTR** | Average time to complete repairs | Any equipment requiring repair | All repairable systems |
+
+**The key distinction**: MTTF applies when you discard and replace it. MTBF applies when you fix it and keep using it. MTTR tells you how long the fixing takes.
+
+A facility might track MTTF for LED bulbs in their fixtures (replace when burned out) while tracking MTBF for the fixtures themselves (repair when they fail). Both metrics serve different planning purposes.
 
 ## What is Mean Time to Failure (MTTF)?
 
@@ -127,38 +159,6 @@ One of the most common mistakes when calculating MTTF is confusing calendar time
 Small sample sizes also lead to misleading results. Calculating MTTF from just a few failures can produce numbers that fluctuate widely and don’t reflect real performance. In practice, at least 20 to 30 failures are needed to produce meaningful averages, with larger datasets providing more reliable insight. Operating conditions are another major source of error. The same component can have very different lifespans depending on factors like temperature, dust, vibration, and load, so MTTF values should always be compared under similar conditions.
 
 Finally, MTTF is often misunderstood as a guaranteed lifespan. It is only an average. Some components will fail much earlier than the MTTF value, while others will last significantly longer. Maintenance planning should account for this natural variation instead of treating MTTF as a minimum life expectancy.
-
-## MTTF vs MTBF vs MTTR: What's the Difference?
-
-These three acronyms measure fundamentally different aspects of reliability.
-
-### What is MTBF (Mean Time Between Failures)?
-
-MTBF is the average operating time between failures for a **repairable** system, one that gets fixed and returned to service rather than discarded. It's the metric to use for motors, pumps, HVAC units, and vehicles.
-
-```
-MTBF = Total Operating Time / Number of Repair Events (excluding repair time)
-```
-
-### What is MTTR (Mean Time to Repair)?
-
-MTTR is the average time it takes to complete a repair once a failure happens, covering diagnosis, parts sourcing, and the fix itself. It applies to any equipment that gets repaired rather than replaced.
-
-```
-MTTR = Total Repair Time / Number of Repairs
-```
-
-### MTTF vs MTBF vs MTTR at a glance
-
-| Metric | What It Measures | Use For | Example |
-|--------|-----------------|---------|---------|
-| **MTTF** | Average time until permanent failure | Non-repairable items replaced when they fail | Light bulbs, batteries, hard drives, sealed bearings |
-| **MTBF** | Average time between repair events | Repairable systems fixed and returned to service | Motors, pumps, HVAC systems, vehicles |
-| **MTTR** | Average time to complete repairs | Any equipment requiring repair | All repairable systems |
-
-**The key distinction**: MTTF applies when you discard and replace it. MTBF applies when you fix it and keep using it. MTTR tells you how long the fixing takes.
-
-A facility might track MTTF for LED bulbs in their fixtures (replace when burned out) while tracking MTBF for the fixtures themselves (repair when they fail). Both metrics serve different planning purposes.
 
 ## Where to Find Reliable MTTF Data
 

--- a/src/blog/2025/12/what-is-mttf.md
+++ b/src/blog/2025/12/what-is-mttf.md
@@ -1,14 +1,17 @@
 ---
-metaTitle: "Mean Time to Failure (MTTF): Formula & Calc"
-title: "Mean Time to Failure (MTTF): Formula, Calculation, MTTF vs MTBF vs MTTR, and More"
+metaTitle: "MTTF vs MTBF vs MTTR: Formulas & Differences"
+title: "MTTF vs MTBF vs MTTR: Formulas, Calculations & Key Differences"
 subtitle: "Understanding equipment reliability and predicting failure patterns"
-description: "Learn what Mean Time to Failure (MTTF) means, how to calculate it with real examples, and how it improves maintenance planning."
+description: "MTTF vs MTBF vs MTTR explained: formulas, real calculation examples, and how to pick the right reliability metric for maintenance planning."
 date: 2025-12-29
 authors: ["sumit-shinde"]
-image: /blog/2025/12/images/what-is-mttf.png
 keywords: MTTF, mean time to failure, MTTF formula, MTTF calculation, how to calculate MTTF, MTTF vs MTBF, MTTF vs MTTR, equipment reliability, failure prediction, reliability metrics, asset management
 tags:
     - flowfuse
+cta:
+  type: contact
+  title: "Automate MTTF Tracking Across Your Fleet"
+  description: "FlowFuse connects to PLCs, SCADA, and your CMMS to calculate MTTF from real operating data instead of manual logs."
 meta:
   faq:
   - question: "What does MTTF stand for?"
@@ -34,11 +37,11 @@ meta:
 tldr: "Mean Time to Failure (MTTF) is the average operating lifetime of non-repairable components, such as bulbs, batteries, and electronic modules, that get replaced rather than repaired. Divide total operating time by the number of failures. MTTF differs from MTBF, which covers repairable systems, and MTTR, which measures repair time."
 ---
 
-When a critical motor bearing assembly fails after just 6 months, half its rated lifespan, maintenance teams face a fundamental question: "How long should this component actually last?"
+A motor bearing assembly rated for a year fails after six months. Was that bad luck, a bad batch, or has this part always run hot in your facility? Without a number to compare against, there's no way to tell.
 
 <!--more-->
 
-Mean Time to Failure (MTTF) provides the answer. It measures the average operational lifetime of non-repairable components before permanent failure, enabling data-driven decisions about replacement timing, spare parts inventory, and component selection.
+Mean Time to Failure (MTTF) is that number. It measures the average operational lifetime of non-repairable components before permanent failure, and it's what turns "that failed early" into a data-driven decision about replacement timing, spare parts inventory, and component selection.
 
 MTTF emerged as a core reliability engineering metric in the 1950s during the development of military and aerospace reliability theory. Today, it remains essential across industries where component reliability determines operational success, from semiconductor manufacturing to data centers to industrial automation.
 
@@ -74,10 +77,6 @@ You have 50 light bulbs. Ten bulbs burn out after 8,000 hours (that's 80,000 tot
 MTTF = 530,000 / 50 = **10,600 hours**
 
 This means on average, each bulb lasts 10,600 hours before it fails.
-
-### Quick Shortcuts
-
-If all your components run the same amount of time before the test ends, you can use this shortcut: multiply the number of units by hours run, then divide by failures observed.
 
 The failure rate is simply the inverse of MTTF. If MTTF is 10,000 hours, your failure rate is 0.0001 failures per hour, which means you expect 1 failure every 10,000 hours.
 
@@ -129,9 +128,27 @@ Small sample sizes also lead to misleading results. Calculating MTTF from just a
 
 Finally, MTTF is often misunderstood as a guaranteed lifespan. It is only an average. Some components will fail much earlier than the MTTF value, while others will last significantly longer. Maintenance planning should account for this natural variation instead of treating MTTF as a minimum life expectancy.
 
-## Difference Between MTTF, MTBF, and MTTR
+## MTTF vs MTBF vs MTTR: What's the Difference?
 
-These three acronyms measure fundamentally different aspects of reliability:
+These three acronyms measure fundamentally different aspects of reliability.
+
+### What is MTBF (Mean Time Between Failures)?
+
+MTBF is the average operating time between failures for a **repairable** system, one that gets fixed and returned to service rather than discarded. It's the metric to use for motors, pumps, HVAC units, and vehicles.
+
+```
+MTBF = Total Operating Time / Number of Repair Events (excluding repair time)
+```
+
+### What is MTTR (Mean Time to Repair)?
+
+MTTR is the average time it takes to complete a repair once a failure happens, covering diagnosis, parts sourcing, and the fix itself. It applies to any equipment that gets repaired rather than replaced.
+
+```
+MTTR = Total Repair Time / Number of Repairs
+```
+
+### MTTF vs MTBF vs MTTR at a glance
 
 | Metric | What It Measures | Use For | Example |
 |--------|-----------------|---------|---------|
@@ -141,31 +158,19 @@ These three acronyms measure fundamentally different aspects of reliability:
 
 **The key distinction**: MTTF applies when you discard and replace it. MTBF applies when you fix it and keep using it. MTTR tells you how long the fixing takes.
 
-### Calculation Formulas
-
-- **MTTF** = Total operating time ÷ Number of permanent failures
-- **MTBF** = Total operating time ÷ Number of repair events (excluding repair time)
-- **MTTR** = Total repair time ÷ Number of repairs
-
 A facility might track MTTF for LED bulbs in their fixtures (replace when burned out) while tracking MTBF for the fixtures themselves (repair when they fail). Both metrics serve different planning purposes.
 
 ## Where to Find Reliable MTTF Data
 
-Manufacturer datasheets are a useful starting point, but they should not be treated as definitive. Published MTTF values are usually measured under controlled laboratory conditions with clean environments, ideal installation, stable temperatures, and moderate loads. Real operating environments are rarely this consistent, so actual component life in the field is often shorter or more variable than datasheet values suggest.
+Manufacturer datasheets are a useful starting point, but they're measured under controlled lab conditions, so real-world component life is often shorter or more variable. Industry databases like [ISO 14224](https://www.iso.org/standard/64076.html) offer more realistic benchmarks compiled across many facilities, but still won't fully match your specific environment.
 
-Industry reliability databases provide more realistic benchmarks. Standards such as [ISO 14224](https://www.iso.org/standard/64076.html) compile failure and maintenance data from hundreds of similar facilities, offering reference values that reflect real-world operating conditions rather than ideal test scenarios. These benchmarks are helpful for comparison, but they still represent averages across many sites and may not fully match your specific environment.
-
-The most reliable MTTF data comes from your own facility. By tracking installation dates and failure times, you can build site-specific reliability data that reflects your actual loads, temperatures, maintenance practices, and environmental conditions. After collecting data from 20 to 30 failures, your internal MTTF values will often be more accurate and actionable than any external source.
+The most reliable MTTF data comes from your own facility. Track installation dates and failure times, and after 20-30 failures your internal MTTF numbers will typically be more accurate and actionable than any external source.
 
 ## Using MTTF for Better Maintenance Planning
 
-MTTF delivers the most value when it supports proactive maintenance decisions rather than reactive repairs. When using MTTF for maintenance planning, the objective is to replace components before failures disrupt production. For example, if a component typically fails around 20,000 operating hours, scheduling replacement at 15,000 hours during planned maintenance windows can prevent unexpected breakdowns and emergency interventions. Replacing parts slightly early is often far less costly than absorbing unplanned downtime.
+MTTF delivers the most value when it drives proactive replacement rather than reactive repair. If a component typically fails around 20,000 operating hours, scheduling replacement at 15,000 hours during a planned maintenance window prevents the unexpected breakdown, and replacing parts slightly early is almost always cheaper than absorbing unplanned downtime.
 
-MTTF also plays a critical role in spare parts optimization, particularly in manufacturing and industrial automation environments where many identical components operate continuously across multiple machines. By estimating expected failures per year based on operating hours and installed quantities, maintenance teams can stock enough spares to meet short-term demand without tying up excessive working capital. Even modest improvements in MTTF-based inventory planning can significantly reduce both downtime risk and excess inventory.
-
-Supplier selection becomes more objective when MTTF data is used instead of relying solely on datasheet claims. In real-world maintenance planning scenarios, teams can compare components based on total cost per operating hour rather than purchase price alone. A higher-priced component with a longer operating life may ultimately be more economical once labor costs, downtime impact, and replacement frequency are considered.
-
-Finally, MTTF helps reveal the true cost drivers within maintenance budgets across manufacturing and industrial automation systems. By combining replacement costs, downtime impact, and failure frequency, teams can identify which components contribute most to annual maintenance spend. Incremental improvements in component reliability often translate into substantial cost savings while also improving overall equipment availability.
+It also sharpens spare parts planning and supplier selection. Estimating expected failures per year from operating hours and installed quantity tells you how many spares to stock without tying up excess working capital, and comparing components by total cost per operating hour, rather than purchase price alone, often favors a pricier part with a longer MTTF once labor and downtime are factored in.
 
 ## When MTTF Isn't the Right Metric
 
@@ -178,12 +183,8 @@ MTTF has limitations. Don't use it when:
 
 ## Bottom Line
 
-Stop guessing when parts will fail. Start tracking installation dates and failure times today. After 20-30 failures, you'll have better data than any manufacturer spec sheet, data that reflects your actual operating conditions, not laboratory ideals.
+Stop guessing when parts will fail. Track installation dates and failure times, and after 20-30 failures you'll have data that beats any manufacturer spec sheet, because it reflects your actual operating conditions rather than laboratory ideals.
 
-Use that data to schedule replacements during planned downtime rather than waiting for 2am emergency breakdowns. Stock the right number of spares, not too many tying up working capital, not too few forcing expedited shipping and production delays. Compare suppliers based on actual performance in your facility, not who's cheapest on paper.
-
-The math is straightforward: unplanned breakdowns cost 3-5x more than scheduled replacements when you factor in overtime labor, rush parts shipping, and lost production. MTTF transforms reactive firefighting into predictable maintenance.
-
-Your facility is unique. Your conditions, loads, and environment create a reliability profile unlike any other operation. The only MTTF numbers that truly matter are the ones you measure yourself.
+Use that data to schedule replacements during planned downtime instead of waiting for a 2am breakdown. Unplanned failures typically cost 3-5x more than scheduled replacements once overtime labor, rush shipping, and lost production are factored in, so the only MTTF numbers that really matter are the ones you measure yourself.
 
 As your equipment base grows, manual tracking becomes cumbersome. [FlowFuse](/) automates this by connecting to [PLCs](/blog/2025/12/what-is-plc/), [SCADA](/use-cases/scada/) systems, [MES](/use-cases/mes/) platforms, and your CMMS, pulling operating hours directly from equipment through industrial protocols like [Modbus](/node-red/protocol/modbus/), [OPC UA](/blog/2025/07/reading-and-writing-plc-data-using-opc-ua/), and [EtherNet/IP](/blog/2025/10/using-ethernet-ip-with-flowfuse/), then capturing failure events to recalculate MTTF in real-time across your entire facility.

--- a/src/blog/2026/02/getting-started-with-canbus.md
+++ b/src/blog/2026/02/getting-started-with-canbus.md
@@ -1,13 +1,12 @@
 ---
-metaTitle: "CAN Bus Tutorial: Connect to Dashboards"
-title: "CAN Bus Tutorial: Connect to Dashboards, Cloud, and Industrial Systems"
-subtitle: "Build vehicle and industrial automation systems without low-level drivers or proprietary tools"
-description: "Learn how to set up SocketCAN on Linux, configure CAN interfaces, and build CAN bus applications using FlowFuse's visual programming platform."
+metaTitle: "CAN Bus & CAN Network Explained + Tutorial"
+title: "CAN Bus & CAN Network Explained: Protocol, Frames & Setup"
+subtitle: "How the CAN network and protocol actually work, then a hands-on tutorial connecting it to dashboards, cloud, and industrial systems"
+description: "What is CAN bus? How the CAN network and protocol work, frame structure and arbitration explained, plus a hands-on SocketCAN + FlowFuse tutorial."
 lastUpdated: 2026-06-19
 date: 2026-02-13
 keywords: 
 authors: ["sumit-shinde"]
-image: /blog/2026/02/images/canbus-tutorial.png
 tags:
 - flowfuse
 cta:
@@ -39,6 +38,10 @@ meta:
         text: "Add a socketcan-in node in transmit mode, drive it from an inject node whose payload contains canid and data fields, and deploy to send frames onto the bus."
         url: "transmitting-can-frames"
   faq:
+    - question: "What is CAN bus used for?"
+      answer: "CAN bus is the standard in-vehicle network for cars and trucks (it underlies OBD-II diagnostics), and it's equally common in industrial machinery, agricultural and construction equipment, elevators, medical devices, and marine electronics, anywhere multiple controllers and sensors need to share data over one durable, noise-resistant bus."
+    - question: "How does CAN bus arbitration work?"
+      answer: "Every CAN frame's identifier doubles as its priority. When two nodes transmit at the same instant, each bit is dominant (0) or recessive (1); the node sending the lower identifier keeps transmitting while the other silently backs off and retries, so higher-priority messages always win without a collision or a central scheduler."
     - question: "What is SocketCAN?"
       answer: "SocketCAN is a Linux kernel feature that integrates CAN bus support into the networking stack. It exposes CAN hardware as standard network interfaces such as can0 or vcan0, so you can configure and use CAN with familiar Linux networking commands."
     - question: "Can I use CAN bus in FlowFuse without physical hardware?"
@@ -62,9 +65,37 @@ SocketCAN brings CAN bus support directly into the Linux networking stack, treat
 
 In this tutorial, you'll set up SocketCAN on Linux, integrate it with FlowFuse, and learn how to send and receive CAN frames, establishing the foundation for connecting your CAN infrastructure to the broader industrial ecosystem.
 
-## Understanding CAN Bus
+## What Is CAN Bus?
 
-CAN (Controller Area Network) is a robust communication protocol that allows multiple devices, such as sensors, controllers, and actuators, to share data over a two-wire bus. Commonly used in automotive, industrial, and embedded systems, CAN broadcasts all messages to every device on the network, with each message identified by an ID that devices use to filter relevant data.
+**CAN bus** (Controller Area Network) is a message-based communication protocol that lets multiple electronic control units (ECUs), sensors, and actuators exchange data over a single, shared two-wire connection, without a central computer routing every message. Bosch developed it in the 1980s to simplify automotive wiring, and it now runs everything from car dashboards to industrial machines, farm equipment, and medical devices.
+
+## How the CAN Network Works
+
+A CAN network has no master node and no dedicated point-to-point wiring between devices. Every node connects to the same twisted pair of wires (CAN High and CAN Low), and every message broadcasts to every other node at once, each device decides for itself whether a message is relevant based on its identifier, rather than a switch routing traffic to a specific address.
+
+When two nodes transmit at the same instant, the protocol resolves it without a collision: each bit is either dominant (0) or recessive (1), and during arbitration the node sending the lower, higher-priority identifier wins automatically while the other silently backs off and retries. The network prioritizes itself, a safety-critical message like a brake signal always wins arbitration over a routine one like cabin temperature, without any central scheduler.
+
+## CAN Protocol: Frame Structure
+
+Every message on the bus is a **CAN frame**. Its identifier field drives both filtering and arbitration:
+
+- **Identifier**: 11 bits (standard frame) or 29 bits (extended frame), both the message's priority and its "address"; a lower value wins arbitration
+- **DLC (Data Length Code)**: how many data bytes follow, 0-8
+- **Data**: up to 8 bytes of payload
+- **CRC**: a checksum every receiver verifies before acknowledging
+- **ACK**: a single bit any node on the bus can assert to confirm the frame was received without errors
+
+Because every node sees every frame, error-checking is a network-wide guarantee rather than a point-to-point one: if a frame fails its CRC anywhere, every node flags it and the sender automatically retransmits.
+
+## CAN Controllers and Transceivers
+
+Each node reaches the bus through two components: a **CAN controller**, the chip or microcontroller peripheral that handles framing, arbitration, and error detection, and a **CAN transceiver**, which converts the controller's logic-level signals into the differential voltage the bus actually carries. Some microcontrollers include a built-in CAN controller; others pair an add-on controller chip like the MCP2515 with a transceiver like the MCP2551. On Linux, SocketCAN abstracts all of this behind a standard network interface, which is what the rest of this guide uses.
+
+## Where CAN Bus Is Used
+
+CAN bus is the standard in-vehicle network for nearly every car and truck built since the 1990s, it's the physical layer underneath OBD-II diagnostics, but it's just as common outside automotive: industrial machinery and robotics, agricultural and construction equipment, elevators, medical devices, and marine electronics all use CAN to connect controllers, sensors, and actuators over one durable, noise-resistant bus instead of dedicated point-to-point wiring for every signal.
+
+Reading and writing that traffic from software is where SocketCAN and FlowFuse come in.
 
 ## What Is SocketCAN?
 

--- a/src/blog/2026/03/how-to-connect-to-twincat-using-ads.md
+++ b/src/blog/2026/03/how-to-connect-to-twincat-using-ads.md
@@ -1,11 +1,10 @@
 ---
 title: "How to Connect to Beckhoff TwinCAT PLC Using ADS (2026)"
 subtitle: "Read and write TwinCAT PLC variables from FlowFuse using the ADS protocol, no additional licensing required."
-description: "Learn how to connect Beckhoff TwinCAT to FlowFuse using ADS, covering AMS routing and reading and writing PLC variables."
+description: "Connect Beckhoff TwinCAT to FlowFuse over ADS: configure AMS routing, then read, subscribe to, and write PLC variables without extra licensing."
 lastUpdated: 2026-06-19
 date: 2026-03-13
 authors: ["sumit-shinde"]
-image: /blog/2026/03/images/backoff-twincat.png
 tags:
 - flowfuse
 - plc
@@ -55,7 +54,7 @@ meta:
       answer: "The most common cause is that your FlowFuse device and the TwinCAT machine are not on the same network as the interface TwinCAT's AMS Net ID is bound to. Verify the AMS Net ID under About TwinCAT System, confirm the route exists with Flags 0, and enable Allow Half Open if the PLC runtime is slow to initialize."
 ---
 
-Beckhoff TwinCAT is one of the most widely deployed PLC platforms in industrial automation. ADS, its native communication protocol, gives you direct read and write access to PLC variables without additional licensing or middleware, and connecting from FlowFuse means tapping into that same channel TwinCAT uses internally.
+ADS is the protocol TwinCAT uses internally, between its own runtime, its HMI, and its PLC and NC tasks, and Beckhoff exposes it for external tools too. That means connecting to a TwinCAT PLC over ADS gives you direct read and write access to its variables, no additional licensing or middleware required, over the same channel TwinCAT already relies on.
 
 <!--more-->
 
@@ -81,13 +80,9 @@ Before you begin, make sure you have the following in place:
 
 ## What is ADS and Why It Matters
 
-ADS, Automation Device Specification, is not an integration layer Beckhoff added for external tools. It is the internal communication backbone of the TwinCAT runtime itself. The same protocol TwinCAT XAE uses when you go online with a PLC, the same one the HMI uses to read variables, the same one the NC task uses to talk to the PLC task. When you connect from FlowFuse, you are using that same channel.
-
 Every TwinCAT device has an AMS Net ID. It looks like an IP address with two extra octets: `10.68.82.232.1.1`. The first four typically match the device IP, the last two are almost always `1.1` by convention. This is how the ADS router identifies devices on the network, and it is what you will configure in every connection you make from FlowFuse.
 
 Within a device, different TwinCAT components are reachable on different ADS ports. The PLC runtime listens on port `851` by default. If your machine runs multiple PLC tasks, each task gets its own port: the first task is `851`, the second is `852`, and so on. Check with the controls engineer which port corresponds to the task containing your variables.
-
-Three things cause silent failures: wrong AMS Net ID, missing route, blocked port 48898. ADS gives you nothing when any of these are wrong. No error, no timeout message, just silence. That is why we cover routing before touching a single FlowFuse node.
 
 ::cta-image{src="/images/cta/aperia-book-demo.png" alt="Aperia Technologies stopped reprogramming controllers station by station with FlowFuse - book a demo" cta="demo"}
 ::
@@ -180,7 +175,7 @@ Once the installation is complete, a few nodes will appear in the right-hand pal
 
 ![Optional settings tab showing Router Address, Router TCP Port, Local AMS Net ID and Local ADS Port fields](./images/twincat-config-optional-tab.png)
 
-The **Router Address** and **Router TCP Port** allow the ADS client to reach the TwinCAT router over the network. The **Local AMS Net ID** identifies your FlowFuse edge device inside the ADS routing system and must match the route configured in `StaticRoutes.xml`. The **Local ADS Port** defines the local ADS endpoint used by the client and normally does not need to be changed.
+The **Local AMS Net ID** must match the route configured in `StaticRoutes.xml`. **Local ADS Port** normally does not need to be changed.
 
 > **Note:** If your TwinCAT system is in config mode or the PLC runtime takes time to initialize on startup, enable **Allow Half Open** in the connection settings. Without it the client performs a strict system state check on connect and will fail with ADS error 7 even if the router is reachable. With it enabled the client connects regardless and waits for the runtime to become ready.
 
@@ -301,7 +296,7 @@ The PLC is not in Run mode. The TwinCAT system tray icon must be green. A blue i
 
 ## Setting Up a Test PLC
 
-This section is for readers who do not have a real TwinCAT PLC available and want to set up a minimal test environment to follow along with this guide. If you already have a PLC running, you do not need this section.
+For readers without a real TwinCAT PLC available: this sets up a minimal test environment to follow along with. Skip this section if you already have a PLC running.
 
 ### What You Need
 
@@ -378,10 +373,8 @@ Your test PLC is now running. Go back to the [Configuring ADS Routes](#configuri
 
 ## Conclusion
 
-You now have a working ADS connection between FlowFuse and TwinCAT, reading variables on demand, subscribing to live changes, and writing values back to the PLC. But this is just the starting point.
+You now have a working ADS connection between FlowFuse and TwinCAT: reading variables on demand, subscribing to live changes, and writing values back to the PLC. The `node-red-contrib-ads-client` package includes several other nodes worth exploring on your own.
 
-This guide covered the core nodes to get you connected and working. The `node-red-contrib-ads-client` package includes several other nodes worth exploring on your own, and future articles will cover more advanced use cases in depth.
-
-With FlowFuse you can take this further. Build real-time dashboards that visualize live PLC data, connect TwinCAT to other systems like databases, ERP, or cloud platforms, set up alerts when variables go out of range, and create operator interfaces that let your team interact with the machine from anywhere. All of it built on the same connection you just configured, without writing a single line of custom integration code.
+From here, build real-time dashboards on live PLC data, connect TwinCAT to databases, ERP, or cloud platforms, set up alerts when variables go out of range, and give your team operator interfaces they can reach from anywhere, all on the connection you just configured, without custom integration code.
 
 Beckhoff TwinCAT ADS is one of many PLCs FlowFuse connects to the modern industrial stack. For Siemens, Allen-Bradley, Omron, Modbus, OPC UA, and more, see the [FlowFuse PLC integration overview](/landing/plc/).

--- a/src/blog/2026/05/opc-ua-security-attack-vectors.md
+++ b/src/blog/2026/05/opc-ua-security-attack-vectors.md
@@ -1,11 +1,10 @@
 ---
-metaTitle: "OPC UA Security: How Attackers Exploit It"
-title: "OPC UA Security: How Threat Actors Exploit Industrial Protocol Vulnerabilities"
-subtitle: "The attacks that work in the field aren't broken cryptography, they're security that was never switched on"
-description: "Most OPC UA breaches don't crack encryption. Learn how attackers actually exploit disabled trust lists and stale ciphers."
+metaTitle: "OPC UA Security: What Actually Gets Exploited"
+title: "OPC UA Protocol Security: How It's Actually Exploited, and How to Fix It"
+subtitle: "A practical look at OPC UA's built-in security features, where real deployments leave them switched off, and what to check first"
+description: "OPC UA's protocol includes real authentication, signing, and encryption. Here's where real-world deployments leave it switched off, and how to check yours."
 date: 2026-05-29
 authors: ["sumit-shinde"]
-image: /blog/2026/05/images/opcua-security-blog.png
 tags:
     - posts
     - flowfuse
@@ -14,14 +13,22 @@ cta:
   type: contact
   title: "Connect your plant without opening it up"
   description: "FlowFuse helps you move industrial data off exposed, internet-facing servers and into a managed, secure architecture. Talk to our team about your OT connectivity."
-tldr: "OPC UA ships with real authentication, signing, and encryption, but attackers rarely touch it. They exploit the gap between 'built in' and 'turned on': anonymous access, trust lists that don't enforce certificates, deprecated ciphers nobody removed, and internet-exposed servers Shodan finds for free. The protocol gives you the tools to close every vector. The question is whether they're switched on."
+tldr: "OPC UA ships with real authentication, signing, and encryption, but attackers rarely touch it. They exploit the gap between 'built in' and 'turned on': anonymous access, trust lists that don't enforce certificates, deprecated ciphers that were never removed, and internet-exposed servers Shodan finds for free. The protocol gives you the tools to close every vector. The question is whether they're switched on."
 ---
 
-Threat actors don't break OPC UA's cryptography. They walk through the security it left switched off. The attacks that work in the field are disabled trust lists, anonymous logins left on, dead ciphers nobody removed, and servers sitting on the open internet. This post breaks down how attackers actually exploit OPC UA, vector by vector.
+Threat actors don't break OPC UA's cryptography. They walk through the security it left switched off. The attacks that work in the field are disabled trust lists, anonymous logins left on, dead ciphers that were never removed, and servers sitting on the open internet. This post breaks down how attackers actually exploit OPC UA, vector by vector.
 
 <!--more-->
 
 That's the irony. Unlike most industrial protocols, OPC UA ships with real security: authentication, signing, and encryption built into the spec. It's what finally let your Siemens PLC, your Allen-Bradley controller, and your SCADA system speak the same language. But "built in" and "turned on" are different things, and attackers live in that gap.
+
+## What OPC UA is, and why its security is different
+
+OPC UA (OPC Unified Architecture) is the platform-independent protocol that succeeded classic OPC, letting PLCs, SCADA systems, and MES/ERP software from different vendors exchange live process data over a single, standardized interface. It runs over TCP or HTTPS, supports pub/sub as well as client-server communication, and, unlike Modbus, most EtherNet/IP variants, or classic OPC DA, it was designed with security as part of the protocol itself rather than bolted on afterward.
+
+That's what makes OPC UA different from most industrial protocols still running on plant floors: it ships with application authentication (X.509 certificates), user authentication, message signing, and encryption, all defined in the OPC UA specification rather than left to integrators to build themselves. In theory, that should make OPC UA one of the more secure links in the OT stack.
+
+In practice, that security is opt-in at almost every layer, and a lot of real deployments opt out. The rest of this post walks through exactly where that happens, and why the gap between OPC UA's built-in protections and what's actually running in the field is where every real-world attack has landed.
 
 ## Why attackers target OPC UA
 
@@ -75,7 +82,7 @@ His work produced three CVEs, all credited to him in the vendor advisories, and 
 
 Not every attack reads or steals. Some just stop the plant. Flooding or crashing the OPC server kills the SCADA workstation's real-time view and command path.
 
-This is where OPC UA research began. In 2018, [Kaspersky ICS CERT](https://ics-cert.kaspersky.com/publications/reports/2018/05/10/opc-ua-security-analysis/) reported 17 zero-day vulnerabilities in the OPC Foundation's products, spanning denial of service and remote code execution, plus several flaws in commercial applications built on the stack. All were reported and fixed by the end of March 2018. It's worth noting the OPC Foundation's own response: it reviewed the findings and pointed out that eight of the 17 sat in an ANSI-C *sample server application* shipped as example code on GitHub rather than in the production stack, and that many third-party flaws came from developers misusing the stack's API. The researchers also pinned down the realistic threat model in interviews: exploitation usually needs local network access, and they said they had never seen a configuration allowing direct internet attacks. The broader lesson holds regardless: because a single flaw in a shared OPC UA library or sample can propagate into every product built on it, one bug scales across the supply chain.
+This is where OPC UA research began. In 2018, [Kaspersky ICS CERT](https://ics-cert.kaspersky.com/publications/reports/2018/05/10/opc-ua-security-analysis/) reported 17 zero-day vulnerabilities in the OPC Foundation's products, spanning denial of service and remote code execution, plus several flaws in commercial applications built on the stack. All were reported and fixed by the end of March 2018. The OPC Foundation's own response reviewed the findings and pointed out that eight of the 17 sat in an ANSI-C *sample server application* shipped as example code on GitHub rather than in the production stack, and that many third-party flaws came from developers misusing the stack's API. The researchers also pinned down the realistic threat model in interviews: exploitation usually needs local network access, and they said they had never seen a configuration allowing direct internet attacks. The broader lesson holds regardless: because a single flaw in a shared OPC UA library or sample can propagate into every product built on it, one bug scales across the supply chain.
 
 ## Client and gateway exploitation
 


### PR DESCRIPTION
## Description

Data-driven SEO pass on 9 posts. All 9 ranked at decent positions (6–13) but converted impressions to clicks far below expectation for that position, the core problem was title/meta relevance and bloated length, not raw rankings.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

