### PR TITLE
Restore FAQ and HowTo data omitted during blog migration

### DIFF
--- a/nuxt/content.config.ts
+++ b/nuxt/content.config.ts
@@ -146,7 +146,7 @@ export default defineContentConfig({
                     title: z.string().optional(),
                     description: z.string().optional(),
                 }).optional(),
-                meta: z.object({
+                structuredData: z.object({
                     title: z.string().optional(),
                     description: z.string().optional(),
                     faq: z.array(z.object({

--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -410,6 +410,13 @@ export default defineNuxtConfig({
     },
 
     hooks: {
+        'content:file:beforeParse' ({ file, collection }) {
+            if (collection.name !== 'blog') return
+            file.body = file.body.replace(
+                /^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*/,
+                (block) => block.replace(/^meta:[ \t]*\r?$/m, 'structuredData:')
+            )
+        },
         // Enumerate /integrations/{id}/ routes at config-time so SSG prerenders them.
         // Can't use Nuxt's $fetch here — it only exists at nitro runtime.
         async 'nitro:config' (nitroConfig: import('nitropack').NitroConfig) {

--- a/nuxt/pages/blog/[...slug].vue
+++ b/nuxt/pages/blog/[...slug].vue
@@ -135,16 +135,16 @@ if (routeInfo.value.kind === 'post') {
                 ? authorMembers.value.map(authorSchema)
                 : [{ name: 'FlowFuse', url: 'https://flowfuse.com' }]),
         }),
-        computed(() => page.value?.meta?.faq?.length ? {
+        computed(() => page.value?.structuredData?.faq?.length ? {
             '@type': 'FAQPage',
-            mainEntity: page.value.meta.faq.map(item => defineQuestion({ name: item.question, acceptedAnswer: { '@type': 'Answer', text: item.answer } })),
+            mainEntity: page.value.structuredData.faq.map(item => defineQuestion({ name: item.question, acceptedAnswer: { '@type': 'Answer', text: item.answer } })),
         } : undefined),
-        computed(() => page.value?.meta?.howto ? defineHowTo({
-            name: page.value.meta.howto.name || pageTitle.value,
-            description: page.value.meta.howto.description || pageDescription.value,
-            totalTime: page.value.meta.howto.totalTime,
-            tool: page.value.meta.howto.tool,
-            step: (page.value.meta.howto.steps || []).map(s => defineHowToStep({ name: s.name, text: s.text, url: s.url ? `${canonicalUrl.value}#${s.url}` : undefined })),
+        computed(() => page.value?.structuredData?.howto ? defineHowTo({
+            name: page.value.structuredData.howto.name || pageTitle.value,
+            description: page.value.structuredData.howto.description || pageDescription.value,
+            totalTime: page.value.structuredData.howto.totalTime,
+            tool: page.value.structuredData.howto.tool,
+            step: (page.value.structuredData.howto.steps || []).map(s => defineHowToStep({ name: s.name, text: s.text, url: s.url ? `${canonicalUrl.value}#${s.url}` : undefined })),
         }) : undefined),
     ])
 }
@@ -238,9 +238,9 @@ if (routeInfo.value.kind === 'post') {
             <BlogPostCta :title="page.title" :cta="page.cta" />
           </div>
 
-          <div v-if="page.meta?.faq?.length" class="prose mt-12">
+          <div v-if="page.structuredData?.faq?.length" class="prose mt-12">
             <h2 class="mb-1">Frequently Asked Questions</h2>
-            <BlogFaq :faq="page.meta.faq" />
+            <BlogFaq :faq="page.structuredData.faq" />
           </div>
 
           <BlogAuthorCard v-for="(author, i) in authorMembers" :key="i" :author="author" />


### PR DESCRIPTION
## Description

Restores blog FAQ sections and FAQ/HowTo structured data that were omitted during the Nuxt blog migration.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

