### PR TITLE
Add an Install Node-RED page to the Node-RED getting started section

### DIFF
--- a/src/node-red/getting-started/date-and-time.md
+++ b/src/node-red/getting-started/date-and-time.md
@@ -1,7 +1,7 @@
 ---
 eleventyNavigation:
   key: Date & Time
-  order: 7
+  order: 9
   parent: Getting Started
 meta:
   title: Working with Dates and Times in Node-RED

--- a/src/node-red/getting-started/install-node-red.md
+++ b/src/node-red/getting-started/install-node-red.md
@@ -1,0 +1,85 @@
+---
+eleventyNavigation:
+  key: Install Node-RED
+  order: 2
+  parent: Getting Started
+meta:
+  title: How to Install Node-RED
+  description: Install Node-RED on Linux, macOS, Windows or a Raspberry Pi, either as a managed instance with one command or standalone with npm.
+  keywords: install node-red, node-red installation, install node-red raspberry pi, install node-red windows, node-red setup
+---
+
+# {{ meta.title }}
+
+There are two ways to install Node-RED. Which one you want depends on whether the machine is
+something you will come back to later.
+
+## Option 1: One command, managed
+
+This installs Node-RED as a managed remote instance. One command sets up a Node.js runtime,
+Node-RED, the FlowFuse Device Agent, and a system service that restarts the instance on boot
+and after a crash. The installer then opens your browser so you can register the machine. It
+creates a FlowFuse account for you if you do not have one.
+
+If the machine already runs Node-RED, the installer finds those flows and offers to import
+them, so you can move an existing setup across without rebuilding it.
+
+**Linux and macOS**
+
+```bash
+/bin/bash -c "$(curl -fsSL https://flowfuse.github.io/device-agent/get.sh)" && ./flowfuse-device-agent-installer
+```
+
+**Windows**, in an elevated PowerShell terminal:
+
+```bash
+Set-Location $env:USERPROFILE; powershell -c "irm https://flowfuse.github.io/device-agent/get.ps1 | iex"; .\flowfuse-device-agent-installer.exe
+```
+
+If port 1880 is already in use, the installer stops and tells you. Add `--port 1881` to the
+end of the command to use a different port.
+
+The [Device Agent quick start](/docs/device-agent/quickstart/) walks through each prompt.
+
+## Option 2: Standalone with npm
+
+This gives you plain Node-RED on one machine, with nothing managing it. It is the right
+choice for a quick experiment on your laptop.
+
+Install Node.js 20 or later first, then:
+
+```bash
+npm install -g --unsafe-perm node-red
+```
+
+Start it:
+
+```bash
+node-red
+```
+
+Open `http://localhost:1880` in your browser. The Node-RED project also publishes
+[platform-specific install guides](https://nodered.org/docs/getting-started/) covering
+Docker, Raspberry Pi and Windows.
+
+## Which one should I pick
+
+| | One command, managed | Standalone with npm |
+| --- | --- | --- |
+| Node.js installed for you | Yes | No |
+| Restarts on boot and after a crash | Yes | You set this up |
+| Remote access to the editor | Yes | Local network only |
+| Flow backups and rollback | Yes | You set this up |
+| Deploy the same flows to more machines | Yes | Copy by hand |
+| Needs a FlowFuse account | Yes, created during install | No |
+
+For anything that has to keep running once you walk away from it, take the first option.
+Read [why standalone Node-RED runs into trouble in production](/blog/2025/09/installing-node-red/)
+for the longer version of that argument.
+
+## Next steps
+
+- [Find your way around the editor](/node-red/getting-started/editor/)
+- [Change the port Node-RED runs on](/node-red/getting-started/node-red-port/)
+- [Keep Node-RED up to date](/node-red/getting-started/update-node-red/)
+- [Set Node-RED up on specific hardware](/node-red/hardware/)

--- a/src/node-red/getting-started/library/index.md
+++ b/src/node-red/getting-started/library/index.md
@@ -3,7 +3,7 @@ metaTitle: "Node-RED Library: Curated List of Nodes"
 eleventyNavigation:
   key: Node-RED Library
   parent: Getting Started
-  order: 3
+  order: 5
 meta:
    title: Node-RED Library – A Curated and Actively Maintained List of Nodes
    description: Browse the Node-RED Library for community-built nodes and integrations. FlowFuse's curated catalog offers tested, documented, enterprise-ready solutions with professional support for critical deployments.

--- a/src/node-red/getting-started/node-red-android.md
+++ b/src/node-red/getting-started/node-red-android.md
@@ -1,7 +1,7 @@
 ---
 eleventyNavigation:
   key: Node-RED On Android
-  order: 4
+  order: 6
   parent: Getting Started
 meta:
   title: Installing Node-RED on Android

--- a/src/node-red/getting-started/node-red-messages.md
+++ b/src/node-red/getting-started/node-red-messages.md
@@ -1,7 +1,7 @@
 ---
 eleventyNavigation:
   key: Working with Messages
-  order: 5
+  order: 7
   parent: Getting Started
 meta:
   title: Understanding Node-RED Messages

--- a/src/node-red/getting-started/node-red-port.md
+++ b/src/node-red/getting-started/node-red-port.md
@@ -1,7 +1,7 @@
 ---
 eleventyNavigation:
   key: Port Configuration
-  order: 2
+  order: 3
   parent: Getting Started
 meta:
   title: Node-RED Port (localhost:1880)

--- a/src/node-red/getting-started/programming/index.md
+++ b/src/node-red/getting-started/programming/index.md
@@ -1,7 +1,7 @@
 ---
 eleventyNavigation:
   key: Programming
-  order: 7
+  order: 10
   parent: Getting Started
 meta:
   title: Node-RED Programming

--- a/src/node-red/getting-started/string.md
+++ b/src/node-red/getting-started/string.md
@@ -2,7 +2,7 @@
 metaTitle: "Strings in Node-RED: Convert, Split & Trim"
 eleventyNavigation:
   key: String
-  order: 6
+  order: 8
   parent: Getting Started
 meta:
   title: "Strings in Node-RED: Convert String to Number, Split, Concatenate, Trim, and More"

--- a/src/node-red/getting-started/update-node-red.md
+++ b/src/node-red/getting-started/update-node-red.md
@@ -1,7 +1,7 @@
 ---
 eleventyNavigation:
   key: Update Node-RED
-  order: 3
+  order: 4
   parent: Getting Started
 meta:
   title: How to Update Node-RED


### PR DESCRIPTION
## Description

`/node-red/getting-started/` teaches you to update Node-RED and configure its port, but it has no page on installing it. This adds one, at `/node-red/getting-started/install-node-red/`.

The page presents both routes honestly. The one-line Device Agent installer goes first, because it is the route we support and the only one that survives a reboot. Plain `npm install -g node-red` goes second, with a table saying what each one actually gives you. A page under this URL, ranking for "install node-red", that only offered a FlowFuse route would read as a bait and switch, so the comparison is explicit rather than implied.

Both installer commands are copied verbatim from `docs/device-agent/quickstart.md`, same as https://github.com/FlowFuse/website/pull/5662.

Also renumbers the section nav. `Install Node-RED` takes `order: 2` and the pages after it shift down by one. That clears two pre-existing collisions, `Node-RED Library` against `Update Node-RED` at 3 and `Date & Time` against `Programming` at 7, where the rendered order was depending on file discovery order.

Resulting order: Editor, Install Node-RED, Port Configuration, Update Node-RED, Node-RED Library, Node-RED On Android, Working with Messages, String, Date & Time, Programming.

## Related Issue(s)

None.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

One new content page plus eight one-line frontmatter changes, so no performance impact and no tests apply. Not a blog post, so no Art Request. Worth checking on the preview: the sidebar order above, and that the code blocks get their copy buttons (they come from `eleventy-plugin-code-clipboard` via `layouts/documentation.njk`).
