### PR TITLE
Put the terminal install commands on the Node-RED page

### DIFF
--- a/src/_includes/components/device-agent-install-commands.njk
+++ b/src/_includes/components/device-agent-install-commands.njk
@@ -1,0 +1,66 @@
+<!--Install commands for the Device Agent installer, shared by /platform/device-agent/
+    and /node-red/. Both commands are byte-identical to docs/device-agent/quickstart.md:
+    get.sh and get.ps1 only download the installer, so the run step is part of the command.
+    Keep them that way, they drifted apart once already.-->
+<div class="ff-blue-card max-md:max-w-md max-md:mx-auto">
+    <h2 class="font-medium w-full text-center md:text-left mb-6">Install on edge, straight from your terminal</h2>
+    <p class="font-medium mb-2">Linux and macOS</p>
+    <div class="ff-command mb-6">
+        <code class="ff-command__text">/bin/bash -c "$(curl -fsSL https://flowfuse.github.io/device-agent/get.sh)" &amp;&amp; ./flowfuse-device-agent-installer</code>
+        <button type="button" class="ff-command__copy" data-copy-command>Copy</button>
+    </div>
+    <p class="font-medium mb-2">Windows (run elevated)</p>
+    <div class="ff-command">
+        <code class="ff-command__text">Set-Location $env:USERPROFILE; powershell -c "irm https://flowfuse.github.io/device-agent/get.ps1 | iex"; .\flowfuse-device-agent-installer.exe</code>
+        <button type="button" class="ff-command__copy" data-copy-command>Copy</button>
+    </div>
+    <p class="font-light mt-6">
+        Installing with npm or Docker instead? The
+        <a href="/docs/device-agent/install/overview/">installation docs</a> cover every route.
+    </p>
+</div>
+
+<script>
+    // Copy buttons for the install commands. The command text is read from the
+    // sibling <code> element so the markup stays the single source of truth.
+    // Delegated from document and guarded, so including this block more than
+    // once on a page cannot bind the same button twice.
+    (function () {
+        if (window.__ffCopyCommandBound) return
+        window.__ffCopyCommandBound = true
+
+        document.addEventListener('click', async function (event) {
+            var button = event.target.closest('[data-copy-command]')
+            if (!button) return
+
+            var code = button.parentElement.querySelector('.ff-command__text')
+            if (!code) return
+            var text = code.textContent.trim()
+            try {
+                if (navigator.clipboard) {
+                    await navigator.clipboard.writeText(text)
+                } else {
+                    // navigator.clipboard is unavailable outside secure contexts
+                    var field = document.createElement('textarea')
+                    field.value = text
+                    field.setAttribute('readonly', '')
+                    field.style.position = 'absolute'
+                    field.style.left = '-9999px'
+                    document.body.appendChild(field)
+                    field.select()
+                    document.execCommand('copy')
+                    document.body.removeChild(field)
+                }
+            } catch (err) {
+                return
+            }
+            var original = button.textContent
+            button.textContent = 'Copied'
+            button.classList.add('ff-command__copy--done')
+            setTimeout(function () {
+                button.textContent = original
+                button.classList.remove('ff-command__copy--done')
+            }, 2000)
+        })
+    })()
+</script>

--- a/src/_includes/components/device-agent-install-commands.njk
+++ b/src/_includes/components/device-agent-install-commands.njk
@@ -1,9 +1,12 @@
 <!--Install commands for the Device Agent installer, shared by /platform/device-agent/
     and /node-red/. Both commands are byte-identical to docs/device-agent/quickstart.md:
     get.sh and get.ps1 only download the installer, so the run step is part of the command.
-    Keep them that way, they drifted apart once already.-->
+    Keep them that way, they drifted apart once already.
+
+    Set installCommandsHeading before including to phrase the heading for the page;
+    /node-red/ uses it to present this as the alternative to signing up.-->
 <div class="ff-blue-card max-md:max-w-md max-md:mx-auto">
-    <h2 class="font-medium w-full text-center md:text-left mb-6">Install on edge, straight from your terminal</h2>
+    <h2 class="font-medium w-full text-center md:text-left mb-6">{{ installCommandsHeading | default("Install on edge, straight from your terminal") }}</h2>
     <p class="font-medium mb-2">Linux and macOS</p>
     <div class="ff-command mb-6">
         <code class="ff-command__text">/bin/bash -c "$(curl -fsSL https://flowfuse.github.io/device-agent/get.sh)" &amp;&amp; ./flowfuse-device-agent-installer</code>

--- a/src/node-red/index.njk
+++ b/src/node-red/index.njk
@@ -36,7 +36,7 @@ meta:
             Node-RED is a visual programming environment that allows you to do a lot without writing a single line of code. An important benefit of Node-RED is that it also allows for developers to write JavaScript and use the NodeJS API to extend the functionality of a node or flow.
         - question: "How can I get started using Node-RED?"
           answer: >
-            FlowFuse Cloud offers the easiest way to get <a href='/blog/2023/01/getting-started-with-node-red/'>started with Node-RED</a>. After signing into FlowFuse Cloud users have immediate access to a Node-RED instance. For those who prefer to install Node-RED themselves, there are many tutorials that help people to get started with Node-RED. A recommended starting point is the Getting Started found on <a href='https://nodered.org/' target='_blank'>nodered.org</a>. Other tutorials from the community include <a href='http://stevesnoderedguide.com/installing-node-red/' target='_blank'>Steve’s Node-RED Guide</a> and <a href='https://projects.raspberrypi.org/en/projects/getting-started-with-node-red/' target="_blank">Raspberry Pi Getting Started with Node-RED.</a>
+            There are three routes. <a href='https://app.flowfuse.com/account/create/'>FlowFuse Cloud</a> needs no installation at all: sign up and you have a Node-RED editor straight away. To run Node-RED on your own machine, a <a href='/node-red/getting-started/install-node-red/'>single command</a> installs Node-RED, sets it up as a service so it restarts on boot, and offers to import flows you already have on that machine. If you would rather install Node-RED by hand, the <a href='https://nodered.org/docs/getting-started/' target='_blank'>Getting Started guide on nodered.org</a> covers every platform.
         - question: "What port number does Node-RED use?"
           answer: >
             Node-RED is accessed via port 1880. You can access the Node-RED editor running locally at http://localhost:1880 or on another computer at http://domain name:1880.
@@ -299,13 +299,19 @@ sitemapPriority: 0.8
             <h2 class="md:text-left max-w-3xl"><span class="text-indigo-600">Flexible Deployment</span> with FlowFuse</h2>
         </div>
         <div class="m-auto max-w-screen-lg">
-            <div class="grid md:px-0 grid-cols-1 md:grid-cols-2 gap-12 md:gap-5 max-w-md md:max-w-none mx-auto">
+            <div class="grid md:px-0 grid-cols-1 md:grid-cols-3 gap-12 md:gap-5 max-w-md md:max-w-none mx-auto">
                 {% set cards = [
                     {
                         "title": "FlowFuse Cloud",
                         "description": "Get started with Node-RED easily! No installation needed – just sign up for instant editor access.",
                         "buttonText": "MORE INFO",
                         "buttonLink": "/pricing/"
+                    },
+                    {
+                        "title": "On your own machine",
+                        "description": "One command installs Node-RED, keeps it running as a service, and connects it to FlowFuse. It imports flows you already have.",
+                        "buttonText": "INSTALL NODE-RED",
+                        "buttonLink": "/node-red/getting-started/install-node-red/"
                     },
                     {
                         "title": "Self managed",

--- a/src/node-red/index.njk
+++ b/src/node-red/index.njk
@@ -52,6 +52,7 @@ meta:
         - question: "How is Node-RED used in IoT?"
           answer: >
             Node-RED is very popular in the manufacturing and industrial automation industries (IIoT) as an edge computing solution. Often deployed on PLCs and IoT gateways, Node-RED supports collecting data from legacy and proprietary systems (Siemens S7, Modbus, OPC-UA, etc), integrating the industrial data with other data sources (weather data, enterprise data), filtering data on the edge, and then sending the data to the cloud. FlowFuse offers remote device deployment to IIoT edge devices. Node-RED is also very popular with DIY home automation enthusiasts, in particular the <a href='https://community.home-assistant.io/t/home-assistant-community-add-on-node-red/55023/' target='_blank'>Home Assistant</a> community. 
+installCommandsHeading: "Or install Node-RED on your own machine"
 description: Node-RED is the low-code programming language of choice for industrial applications. Industrial engineers use Node-RED to collect, transform, and integrate data through visualized dashboards.
 sitemapPriority: 0.8
 ---
@@ -69,21 +70,42 @@ sitemapPriority: 0.8
                 Co-created by Nick O'Leary, CTO of FlowFuse, Node-RED is <span class="font-semibold">the <span class="inline-block">low-code</span> programming language of choice for industrial applications</span>. Industrial engineers use Node-RED to collect, transform, and integrate data through visualized dashboards.
             </p>
             <p><span class="font-semibold">FlowFuse enhances Node-RED with enterprise features</span> to accelerate digitalization and optimize industrial processes.</p>
-            <p class="md:mb-10">Ready to <span class="font-semibold">get started building with Node-RED</span>?</p>
-            <a class="ff-btn ff-btn--primary hidden min-h-[40px] md:inline" href="{% include "sign-up-url.njk" %}" onclick="capture('cta-try-it-now', {'position': 'nodered'})">TRY IT NOW</a>
+            <p class="md:mb-6">Ready to <span class="font-semibold">get started building with Node-RED</span>? There are two ways in.</p>
+            <div class="max-md:hidden md:mb-10">
+                <a class="ff-btn ff-btn--primary min-h-[40px] md:inline" href="{% include "sign-up-url.njk" %}" onclick="capture('cta-try-it-now', {'position': 'nodered'})">TRY IT NOW</a>
+                <p class="font-light mt-3 mb-0">
+                    Nothing to install, you get an editor in the browser. Or
+                    <a href="#install-node-red-from-your-terminal" onclick="capture('cta-install-terminal', {'position': 'nodered-hero'})">install Node-RED on your own machine</a>
+                    with one command.
+                </p>
+            </div>
         </div>
         <div class="max-w-md md:w-1/2 m-auto border-4 border-indigo-200 rounded-xl ff-image-cover">
             {% image "../images/pseudo-editor.png", "Node-RED pseudo UI", [500] %}
         </div>
-        <a class="ff-btn ff-btn--primary flex flex-col w-full md:hidden max-w-md" href="{% include "sign-up-url.njk" %}" onclick="capture('cta-try-it-now', {'position': 'nodered'})">TRY IT NOW</a>
+        <div class="md:hidden w-full max-w-md m-auto">
+            <a class="ff-btn ff-btn--primary flex flex-col w-full" href="{% include "sign-up-url.njk" %}" onclick="capture('cta-try-it-now', {'position': 'nodered'})">TRY IT NOW</a>
+            <p class="font-light mt-3 mb-0 text-center">
+                Nothing to install, you get an editor in the browser. Or
+                <a href="#install-node-red-from-your-terminal" onclick="capture('cta-install-terminal', {'position': 'nodered-hero'})">install Node-RED on your own machine</a>
+                with one command.
+            </p>
+        </div>
     </div>
 </div>
 
-    <!--Install commands, directly under the hero: the fastest way to get Node-RED
-        running on a machine you already have. Shared with /platform/device-agent/.-->
+    <!--Install commands, directly under the hero. This is the second of the two routes
+        the hero names: TRY IT NOW signs you up for a hosted editor, this one runs
+        Node-RED on hardware you already have. Shared with /platform/device-agent/.-->
     <div id="install-node-red-from-your-terminal" class="w-full scroll-mt-24 pb-16">
         <div class="max-w-screen-lg mx-auto px-6">
             {% include "components/device-agent-install-commands.njk" %}
+            <p class="font-light mt-6 max-md:max-w-md max-md:mx-auto">
+                One command installs Node.js, Node-RED and the FlowFuse Device Agent, sets it up as a
+                service so it restarts on boot, and opens your browser to connect it. It creates a
+                FlowFuse account for you if you do not have one. If the machine already runs Node-RED,
+                it offers to import those flows.
+            </p>
         </div>
     </div>
 

--- a/src/node-red/index.njk
+++ b/src/node-red/index.njk
@@ -36,7 +36,7 @@ meta:
             Node-RED is a visual programming environment that allows you to do a lot without writing a single line of code. An important benefit of Node-RED is that it also allows for developers to write JavaScript and use the NodeJS API to extend the functionality of a node or flow.
         - question: "How can I get started using Node-RED?"
           answer: >
-            There are three routes. <a href='https://app.flowfuse.com/account/create/'>FlowFuse Cloud</a> needs no installation at all: sign up and you have a Node-RED editor straight away. To run Node-RED on your own machine, a <a href='/node-red/getting-started/install-node-red/'>single command</a> installs Node-RED, sets it up as a service so it restarts on boot, and offers to import flows you already have on that machine. If you would rather install Node-RED by hand, the <a href='https://nodered.org/docs/getting-started/' target='_blank'>Getting Started guide on nodered.org</a> covers every platform.
+            There are three routes. <a href='https://app.flowfuse.com/account/create/'>FlowFuse Cloud</a> needs no installation at all: sign up and you have a Node-RED editor straight away. To run Node-RED on your own machine, a <a href='#install-node-red-from-your-terminal'>single command</a> installs Node-RED, sets it up as a service so it restarts on boot, and offers to import flows you already have on that machine. If you would rather install Node-RED by hand, the <a href='https://nodered.org/docs/getting-started/' target='_blank'>Getting Started guide on nodered.org</a> covers every platform.
         - question: "What port number does Node-RED use?"
           answer: >
             Node-RED is accessed via port 1880. You can access the Node-RED editor running locally at http://localhost:1880 or on another computer at http://domain name:1880.
@@ -76,10 +76,18 @@ sitemapPriority: 0.8
             {% image "../images/pseudo-editor.png", "Node-RED pseudo UI", [500] %}
         </div>
         <a class="ff-btn ff-btn--primary flex flex-col w-full md:hidden max-w-md" href="{% include "sign-up-url.njk" %}" onclick="capture('cta-try-it-now', {'position': 'nodered'})">TRY IT NOW</a>
-    </div>   
+    </div>
 </div>
 
-    <!-- Power of low-code -->  
+    <!--Install commands, directly under the hero: the fastest way to get Node-RED
+        running on a machine you already have. Shared with /platform/device-agent/.-->
+    <div id="install-node-red-from-your-terminal" class="w-full scroll-mt-24 pb-16">
+        <div class="max-w-screen-lg mx-auto px-6">
+            {% include "components/device-agent-install-commands.njk" %}
+        </div>
+    </div>
+
+    <!-- Power of low-code -->
     <div class="w-full pb-16">
         <div class="max-w-screen-lg mx-auto px-6">
             <div class="w-full grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-8 gap-y-14">
@@ -311,7 +319,7 @@ sitemapPriority: 0.8
                         "title": "On your own machine",
                         "description": "One command installs Node-RED, keeps it running as a service, and connects it to FlowFuse. It imports flows you already have.",
                         "buttonText": "INSTALL NODE-RED",
-                        "buttonLink": "/node-red/getting-started/install-node-red/"
+                        "buttonLink": "#install-node-red-from-your-terminal"
                     },
                     {
                         "title": "Self managed",

--- a/src/platform/device-agent.njk
+++ b/src/platform/device-agent.njk
@@ -56,65 +56,12 @@ meta:
                 </div>
             </div>
 
-            <!--Install commands, full width so nothing is clipped-->
-            <div class="ff-blue-card max-md:max-w-md max-md:mx-auto mt-12 md:mt-16">
-                <h2 class="font-medium w-full text-center md:text-left mb-6">Install on edge, straight from your terminal</h2>
-                <p class="font-medium mb-2">Linux and macOS</p>
-                <div class="ff-command mb-6">
-                    <code class="ff-command__text">/bin/bash -c "$(curl -fsSL https://flowfuse.github.io/device-agent/get.sh)" &amp;&amp; ./flowfuse-device-agent-installer</code>
-                    <button type="button" class="ff-command__copy" data-copy-command>Copy</button>
-                </div>
-                <p class="font-medium mb-2">Windows (run elevated)</p>
-                <div class="ff-command">
-                    <code class="ff-command__text">Set-Location $env:USERPROFILE; powershell -c "irm https://flowfuse.github.io/device-agent/get.ps1 | iex"; .\flowfuse-device-agent-installer.exe</code>
-                    <button type="button" class="ff-command__copy" data-copy-command>Copy</button>
-                </div>
-                <p class="font-light mt-6">
-                    Installing with npm or Docker instead? The
-                    <a href="/docs/device-agent/install/overview/">installation docs</a> cover every route.
-                </p>
+            <!--Install commands, full width so nothing is clipped. Shared with /node-red/.-->
+            <div class="mt-12 md:mt-16">
+                {% include "components/device-agent-install-commands.njk" %}
             </div>
         </div>
     </div>
-
-    <script>
-        // Copy buttons for the install commands. The command text is read from the
-        // sibling <code> element so the markup stays the single source of truth.
-        (function () {
-            document.querySelectorAll('[data-copy-command]').forEach(function (button) {
-                button.addEventListener('click', async function () {
-                    var code = button.parentElement.querySelector('.ff-command__text')
-                    if (!code) return
-                    var text = code.textContent.trim()
-                    try {
-                        if (navigator.clipboard) {
-                            await navigator.clipboard.writeText(text)
-                        } else {
-                            // navigator.clipboard is unavailable outside secure contexts
-                            var field = document.createElement('textarea')
-                            field.value = text
-                            field.setAttribute('readonly', '')
-                            field.style.position = 'absolute'
-                            field.style.left = '-9999px'
-                            document.body.appendChild(field)
-                            field.select()
-                            document.execCommand('copy')
-                            document.body.removeChild(field)
-                        }
-                    } catch (err) {
-                        return
-                    }
-                    var original = button.textContent
-                    button.textContent = 'Copied'
-                    button.classList.add('ff-command__copy--done')
-                    setTimeout(function () {
-                        button.textContent = original
-                        button.classList.remove('ff-command__copy--done')
-                    }, 2000)
-                })
-            })
-        })()
-    </script>
 
     <!-- Seamlessly manage your devices all in one place -->  
     <div class="w-full">


### PR DESCRIPTION
## Description

The "Install on edge, straight from your terminal" block only existed on `/platform/device-agent/`. `/node-red/` is where people arrive asking how to get started with Node-RED, so the block now sits **on that page**, directly under the hero, rather than behind a link.

Three changes:

**The command block is now a shared include.** `src/_includes/components/device-agent-install-commands.njk` holds the card and its copy-button script. `/platform/device-agent/` and `/node-red/` both render it, so there is one copy of the commands. These commands already drifted from the docs once (https://github.com/FlowFuse/website/pull/5662 fixed that), and a second inline copy is how it would happen again. The copy script is now delegated from `document` and guarded with a flag, so the include cannot double-bind if it ever appears twice on a page.

**`/node-red/` gets the block plus a third deployment card.** The Flexible Deployment section offered FlowFuse Cloud and Self managed only, so the page never said you can run Node-RED on a machine you already have. The new middle card jumps to the command block.

**The FAQ answer is rewritten.** "How can I get started using Node-RED?" sent the reader to three third-party tutorials and never mentioned that we ship an installer. It now names the three real routes. Steve's Node-RED Guide and Raspberry Pi Projects are dropped, since sending visitors off-site from our highest-traffic Node-RED page returns nothing. The nodered.org link stays and now points at their Getting Started docs rather than the site root.

Both in-page links target the block's anchor on the same page, so this PR stands on its own and does not need https://github.com/FlowFuse/website/pull/5663.

## Related Issue(s)

None.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

Markup and copy only, so no performance impact and no tests apply. Checked before pushing: both commands in the include decode byte-identical to `docs/device-agent/quickstart.md` lines 39 and 52, `device-agent.njk` retains no command copy of its own, the frontmatter YAML still parses, and the `cards` array is still valid JSON.

Worth confirming on the preview: the block renders under the hero on `/node-red/`, the copy buttons work on **both** pages now that the script moved, and the three deployment cards sit on one row at desktop width.
