### PR TITLE
Hardware guides: install the Device Agent with the current installer

### DIFF
--- a/src/_includes/hardware/device-registration.md
+++ b/src/_includes/hardware/device-registration.md
@@ -1,28 +1,25 @@
-### Registering the Device to Connect to FlowFuse
+### Connecting the Device to FlowFuse
 
-Once you have installed the FlowFuse Device Agent, you need to register the hardware to connect it to your FlowFuse team.
+The installer asks whether you are registering a new instance or connecting with a One-Time
+Code.
 
-For instructions on how to register the hardware with your FlowFuse team, follow the documentation: [Register your Remote Instance](/docs/device-agent/register/).
+**Registering a new instance.** Choose this if the device is not yet on your FlowFuse
+platform. The installer gives you a URL to open in your browser. Complete the registration
+there, keep the tab open, and switch back to the terminal. If you do not have a FlowFuse
+account yet, you can create one at this point.
 
-When registering your hardware, you will be presented with a dialog containing a one-time passcode command that the Device Agent uses to retrieve its configuration. **Make sure to copy it.**
+**Connecting with a One-Time Code.** Choose this if you already added the Remote Instance in
+FlowFuse and it gave you a One-Time Code. Enter the code when the installer asks for it.
 
-!["Dialog containing a one-time passcode command that the Device Agent can use to retrieve its configuration"](./images/configuration-dailog-with-one-time-code.png "Dialog containing a one-time passcode command that the Device Agent can use to retrieve its configuration"){data-zoomable}
+For more detail on both paths, see [Register your Remote Instance](/docs/device-agent/register/).
 
-### Connecting Device
+### Checking the Service
 
-Execute the command you have copied with sudo as shown below
+The installer creates a system service named after the port the agent uses, so the default is
+`flowfuse-device-agent-1880`:
 
 ```bash
-sudo flowfuse-device-agent -o <insert-your-three-word-token> https://app.flowfuse.com
+sudo systemctl status flowfuse-device-agent-1880
 ```
 
-Once executed, you should see an output similar to the one below, indicating that the FlowFuse Device Agent has been successfully configured:
-
-```bash
-[AGENT] 3/21/2025 7:09:25 PM [info] Entering Device setup...
-[AGENT] 3/21/2025 7:09:27 PM [info] Device setup was successful
-[AGENT] 3/21/2025 7:09:27 PM [info] To start the Device Agent with the new configuration, run the following command:
-[AGENT] 3/21/2025 7:09:27 PM [info] flowfuse-device-agent
-```
-
-Now, you can check the remote instance in the FlowFuse platform, where its status should be displayed as **"running."**.
+The device should now show as **running** in the FlowFuse platform.

--- a/src/_includes/hardware/system/debian-ff-install.md
+++ b/src/_includes/hardware/system/debian-ff-install.md
@@ -1,25 +1,21 @@
 ### Installing FlowFuse Device Agent
 
-Before we start, it is recommended to update and upgrade your system to ensure all your packages are up to date:
+Before we start, it is recommended to update and upgrade your system to ensure all your
+packages are up to date:
 
 ```bash
 sudo apt update && sudo apt upgrade -y
 ```
 
-Next, let's install the FlowFuse device agent with the following script.
+Next, download and run the FlowFuse Device Agent installer:
 
 ```bash
-bash <(curl -sL https://raw.githubusercontent.com/FlowFuse/device-agent/main/service/raspbian-install-device-agent.sh)
+/bin/bash -c "$(curl -fsSL https://flowfuse.github.io/device-agent/get.sh)" && ./flowfuse-device-agent-installer
 ```
 
-This script installs the Node.js runtime (if not already installed), sets up the FlowFuse device agent, and configures the device to automatically run the FlowFuse agent on boot and restart it in case of a crash.
+The installer sets up a Node.js runtime, installs the FlowFuse Device Agent, and registers
+it as a system service so it starts on boot and restarts after a crash. It then steps you
+through connecting the device to your FlowFuse team.
 
-To verify that the service is running, use the following command:
-
-```bash
-sudo systemctl status flowfuse-device-agent.service
-```
-
-If running, you should see a result similar to the one shown in the image below:
-
-!["Status of the FlowFuse Device Agent systemd service"](./images/systemctl-status.png "Status of the FlowFuse Device Agent systemd service"){data-zoomable}
+If the device already runs Node-RED, the installer finds those flows and offers to import
+them.

--- a/src/node-red/hardware/opto-22-groove-rio-7-mm2001-10.md
+++ b/src/node-red/hardware/opto-22-groove-rio-7-mm2001-10.md
@@ -60,6 +60,8 @@ sudo flowfuse-device-agent -o <insert-your-three-word-token> https://app.flowfus
 
 > **Important:** Be sure to include the --port 1881 flag when running the command. By default, the Opto-22 firewall only allows access to port 1880 (default Node-RED port) by a very restricted list of users, so the Groov Rio R7 requires specifying port 1881 for the Device Agent to start correctly.
 
+> If you would rather use the one-line installer, pass the same port to it: append `--port 1881` to the installer command.
+
 Once executed, you should see an output similar to the one below, indicating that the FlowFuse Device Agent has been successfully configured:
 
 ```bash

--- a/src/node-red/hardware/siemens-iot-2050.md
+++ b/src/node-red/hardware/siemens-iot-2050.md
@@ -26,6 +26,10 @@ Siemens [announced](https://press.siemens.com/global/en/pressrelease/new-siemens
 
 The goal of this documentation is to guide the user through the installation process of getting FlowFuse Device agent installed on an IoT2050. The IoT2050 comes pre-installed with version 12.22.x Node.js on the [IOT2050_Example_Image_V1.3.1](https://support.industry.siemens.com/cs/document/109741799/downloads-for-simatic-iot20x0?dti=0&lc=en-GB) image. A requirement to install FlowFuse Device Agent, Node.js needs to be upgraded to version 18 minimum.  We will be going through that process.
 
+{% note %}
+The FlowFuse Device Agent installer brings its own Node.js runtime, so the Node.js upgrade steps below are only needed if you want a newer Node.js for other software on the device. To skip them, follow [How to Install Node-RED](/node-red/getting-started/install-node-red/) instead.
+{% endnote %}
+
 ## Prerequisites 
 
 We will be working with the IoT2050 Advanced, *6ES7 647-0BA00-1YA2*. The device has been [upgraded](https://support.industry.siemens.com/cs/attachments/109741799/IOT2050_How_To_Firmware_Update_V1.3.pdf) to the latest firmware at the time of writing this article of v1.3.1.  We will be leveraging the IOT2050_Example_Image_V1.3.1.zip image which is a Debian base OS.  To complete this guide, knowledge of Linux-based cli is necessary.  Documentation to complete these requirements can be found [here](https://support.industry.siemens.com/cs/document/109741799/downloads-for-simatic-iot20x0?dti=0&lc=en-GB).


### PR DESCRIPTION
## Description

Targets `main` and contains only this change. The Siemens note links to `/node-red/getting-started/install-node-red/`, which https://github.com/FlowFuse/website/pull/5663 adds, so that one link 404s on this preview until 5663 merges. Everything else here is self-contained.

The four Debian-based hardware guides (Raspberry Pi 4, Raspberry Pi 5, ARMxy BL340, Robustel EG5120) installed the agent by curling `raspbian-install-device-agent.sh` from `raw.githubusercontent.com`. That script sets `MIN_NODEJS=14`, is apt-only, and names the service `flowfuse-device-agent`. The documented floor is Node.js 18, the recommended runtime is 22, and the installer names the service after the port. Three stale facts in one shared include.

**`hardware/system/debian-ff-install.md`** now uses the one-line installer, copied verbatim from `docs/device-agent/quickstart.md`.

**`hardware/device-registration.md`** described the platform-first flow: register in the browser, copy a three-word code, run the agent by hand. The installer asks that question itself now, so this describes its two prompts instead. The service check uses the real name, `flowfuse-device-agent-1880` (`installer/go/cmd/install.go:54`).

**Opto-22 Groov RIO** keeps its own inline registration copy, because that device needs `--port 1881` and does not use these includes. It gains one line saying the installer takes the same flag.

**Siemens IoT2050** gains a note that its manual Node.js upgrade walkthrough is unnecessary on the installer path, since the installer brings its own runtime. Rewriting that guide is separate work and not attempted here.

## Related Issue(s)

None.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

Content-only, so no performance impact and no tests apply. Two shared includes reach four pages, so this is the widest blast radius of the set: worth checking all four on the preview.

## One loose end

`src/node-red/hardware/images/systemctl-status.png` is now unreferenced, since the rewritten include no longer shows it. Left in place rather than deleted, because deleting it is not needed to make this change correct. `configuration-dailog-with-one-time-code.png` is still used by the Opto-22 page and stays.
