### PR TITLE
Add breadcrumbs to blog, changelog, and customer stories

### DIFF
--- a/nuxt/pages/blog/[...slug].vue
+++ b/nuxt/pages/blog/[...slug].vue
@@ -96,6 +96,10 @@ const tldrText = computed(() => typeof page.value?.tldr === 'string' ? page.valu
 
 const pageTitle = computed(() => page.value?.title || 'Blog')
 provide('blogPostTitle', pageTitle)
+const breadcrumbItems = computed(() => [
+    { label: 'Blog', to: '/blog' },
+    { label: pageTitle.value },
+])
 const pageDescription = computed(() => page.value?.description || page.value?.meta?.description || '')
 const seoTitle = computed(() => page.value?.metaTitle || pageTitle.value)
 const canonicalUrl = computed(() => `https://flowfuse.com${route.path}`)
@@ -156,6 +160,7 @@ if (routeInfo.value.kind === 'post') {
   <div v-else-if="page" class="w-full page post">
     <div class="post-title container m-auto text-center max-lg:px-6 flex mt-6 mb-6 md:max-w-screen-lg md:mt-12">
       <div class="text-left md:pr-32">
+        <Breadcrumbs :items="breadcrumbItems" class="mb-2" />
         <label>Article</label>
         <h1>{{ page.title }}</h1>
         <h4 v-if="page.subtitle">{{ page.subtitle }}</h4>

--- a/nuxt/pages/changelog/[...slug].vue
+++ b/nuxt/pages/changelog/[...slug].vue
@@ -38,6 +38,10 @@ function issueLabel(issue: string): string {
 }
 
 const pageTitle = computed(() => page.value?.title || 'Changelog')
+const breadcrumbItems = computed(() => [
+    { label: 'Changelog', to: '/changelog' },
+    { label: pageTitle.value },
+])
 const seoTitle = computed(() => page.value?.metaTitle || pageTitle.value)
 const canonicalUrl = computed(() => `https://flowfuse.com${route.path}`)
 
@@ -63,6 +67,7 @@ useSeoMeta({
   <div class="w-full page post">
     <div class="post-title container m-auto text-center max-lg:px-6 flex mt-6 mb-6 md:max-w-screen-lg md:mt-12">
       <div class="text-left md:pr-32">
+        <Breadcrumbs :items="breadcrumbItems" class="mb-2" />
         <label>Changelog</label>
         <h1>{{ page.title }}</h1>
         <h4 v-if="page.subtitle">{{ page.subtitle }}</h4>

--- a/nuxt/pages/customer-stories/[slug].vue
+++ b/nuxt/pages/customer-stories/[slug].vue
@@ -42,6 +42,10 @@ const productIcons: Record<string, string> = {
 }
 
 const pageTitle = computed(() => page.value?.title ?? 'Customer Story')
+const breadcrumbItems = computed(() => [
+    { label: 'Customer Stories', to: '/customer-stories' },
+    { label: pageTitle.value },
+])
 const fullTitle = computed(() => `${pageTitle.value} • FlowFuse`)
 const canonicalUrl = computed(() => `https://flowfuse.com${route.path}`)
 
@@ -79,6 +83,7 @@ useSeoMeta({
 
     <div class="blog nohero w-full bg-gray-50 pb-24 pt-6">
       <div class="container m-auto flex flex-col items-stretch text-left max-lg:px-6 md:max-w-screen-lg">
+        <Breadcrumbs :items="breadcrumbItems" class="mb-3" />
         <NuxtLink to="/customer-stories" class="group mb-5 inline-flex items-center gap-1 hover:no-underline md:mb-4">
           <UIcon name="i-heroicons-chevron-left" />
           <span class="group-hover:underline">Back to Customer Stories</span>


### PR DESCRIPTION
Docs, handbook, and application-guide already rendered a visual breadcrumb trail with matching BreadcrumbList schema via the shared Breadcrumbs component. Blog, changelog, and customer stories had neither, despite being some of the most active content on the site. Wires all three into the same component for consistent navigation and structured data.

## Description

<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

