### PR TITLE
Fix sitemap emitting non-canonical URLs missing trailing slashes

### DIFF
--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -153,6 +153,7 @@ export default defineNuxtConfig({
         name: 'FlowFuse',
         description: site.messaging.subtitle,
         defaultLocale: 'en',
+        trailingSlash: true,
     },
 
     // Only covers content already served by Nuxt. The handbook is deliberately excluded

--- a/nuxt/server/api/__sitemap__/content-urls.get.ts
+++ b/nuxt/server/api/__sitemap__/content-urls.get.ts
@@ -104,7 +104,8 @@ export default defineSitemapEventHandler(async (event) => {
                 if (!entry.path || entry.path.endsWith('.navigation')) continue
                 if (source.filter && !source.filter(entry)) continue
 
-                const url: SitemapUrl = { loc: source.rewriteLoc ? source.rewriteLoc(entry.path) : entry.path }
+                const rawLoc = source.rewriteLoc ? source.rewriteLoc(entry.path) : entry.path
+                const url: SitemapUrl = { loc: rawLoc.endsWith('/') ? rawLoc : `${rawLoc}/` }
 
                 const lastmod = source.lastmod
                     ? source.lastmod(entry)


### PR DESCRIPTION
Every Nuxt-native route requires a trailing slash - Netlify 301s the slash-less form - but nuxt-site-config's resolveSitePath() strips trailing slashes from every sitemap URL by default, including ones sources already built correctly. As a result the entire sitemap.xml (986 URLs) redirected on first crawl, which Search Console reports as the "Page with redirect" indexing issue.

Sets site.trailingSlash: true so the sitemap module stops stripping slashes, and hardens content-urls.get.ts to append one directly since it was relying on @nuxt/content's entry.path, which never has one.

## Description

<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

