### PR TITLE
changelog: use the shared command block for the MCP address

### DIFF
--- a/nuxt/content/feature-catalog.yml
+++ b/nuxt/content/feature-catalog.yml
@@ -59,6 +59,14 @@ sections:
         beta: true
         showOnPricing: false
         tiers: { edge: true, hub: true, fleet: true }
+      - id: third-party-agents
+        title: Connect Your Own AI Agent
+        description: "Point the AI agent your company already uses at FlowFuse, so it can query your teams and instances and build Node-RED applications, with you deciding which teams it reaches and whether it can make changes."
+        docsLink: /docs/user/expert/third-party-agents/
+        changelog:
+          - url: /changelog/2026/08/connect-your-own-ai-agent/
+            release: "3.0"
+        tiers: { edge: true, hub: true, fleet: true }
       - id: mcp-servers
         title: Agentic Operations
         description: "Expose your Node-RED flows as tools an AI agent can call directly, so agents can query the state of the factory or trigger actions without custom integration work."

--- a/src/changelog/2026/08/connect-your-own-ai-agent.md
+++ b/src/changelog/2026/08/connect-your-own-ai-agent.md
@@ -1,0 +1,29 @@
+---
+title: Connect your own AI agent to FlowFuse
+description: The AI agent your team already uses can now work your platform and build Node-RED applications, with you deciding what it may reach.
+date: 2026-08-27 12:00:00
+release: "3.0"
+authors: ["serban-costin"]
+tags:
+- changelog
+issues:
+- https://github.com/FlowFuse/flowfuse/issues/8192
+---
+
+FlowFuse Expert is no longer the only AI that can work your platform. FlowFuse now acts as an MCP server, so the agent your team already uses can query your teams and instances, and build Node-RED applications for you.
+
+Add the FlowFuse address in your agent's connector settings, sign in, and choose which teams the agent may reach and whether it may make changes.
+
+The address is the one to paste into your agent:
+
+:ff-command{command="https://app.flowfuse.com/mcp"}
+
+[Pick your agent on the AI page](/ai/) for where that goes in [Microsoft Copilot](https://copilotstudio.microsoft.com/), [ChatGPT](https://chatgpt.com/), [Claude](https://claude.ai/settings/connectors) or [Gemini](https://gemini.google.com/), and for the three steps in each. A local model works the same way through any MCP client that speaks HTTP, and so do command-line and editor agents.
+
+This matters most where company policy only permits an approved AI agent. Until now that meant no AI on the platform at all, because the only way in was our own. Now the agent your company already sanctioned can do the work.
+
+The access you grant is enforced on every call, so a read-only grant is refused whatever the agent tries. Nothing an agent reaches through FlowFuse can delete an instance, an application, a snapshot or a team, and deploying stays yours. Everything it does lands in the audit log, marked `via MCP`.
+
+Flow building happens on the canvas in front of you. Open the instance, turn on the MCP toggle in the page header, and you watch the agent work.
+
+This is available to all FlowFuse Cloud users and to Enterprise self-hosted installations from v3.0, across FlowFuse Hub, Edge and Fleet. See [connecting your own agent](/docs/user/expert/third-party-agents/) for setup, including what to check on an instance before asking for a flow.


### PR DESCRIPTION
## Description

Stacked on https://github.com/FlowFuse/website/pull/5681. Base is that branch, not `main`.

The changelog entry gets the same copyable command block `/ai` shows, via the `FfCommand` component that PR introduces, instead of restating the MCP address as inline code. This is the thing that was not possible while `/ai` was 11ty and the changelog was Nuxt Content: two renderers, no shared component.

Also carries the changelog entry and feature-catalog entry from https://github.com/FlowFuse/website/pull/5672, so this shows the merged result rather than a fragment.

## Related Issue(s)

https://github.com/FlowFuse/flowfuse/issues/8192

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))
