### PR TITLE
Update homepage subtitle to lead with AI

### DIFF
--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -5,7 +5,7 @@
     "messaging": {
         "tagLine": "The Edge-Native Platform for Industrial Applications",
         "heroTagLine": "The Edge-Native Platform for Industrial IT, OT, and IIOT Applications",
-        "subtitle": "Build, deploy, and govern operational applications across every plant and production line, distributed to the edge and accelerated by AI.",
+        "subtitle": "Build industrial applications in minutes with AI, then deploy and govern them from cloud to edge.",
         "title": "Build workflows and integrations that optimize your industrial operations",
         "keywords": "Node-RED, Application Development, IoT, IIoT, Low-Code, open source, Integration, Workflow, Automation, Data Processing, Data Integration, Data Transformation, Data Visualization, Industrial Automation, Industrial IoT, Industry 4.0"
     },

--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -5,7 +5,7 @@
     "messaging": {
         "tagLine": "The Edge-Native Platform for Industrial Applications",
         "heroTagLine": "The Edge-Native Platform for Industrial IT, OT, and IIOT Applications",
-        "subtitle": "Build industrial applications in minutes with AI, then deploy and govern them from cloud to edge.",
+        "subtitle": "Build industrial applications in minutes with AI, then deploy and govern production from cloud to edge."
         "title": "Build workflows and integrations that optimize your industrial operations",
         "keywords": "Node-RED, Application Development, IoT, IIoT, Low-Code, open source, Integration, Workflow, Automation, Data Processing, Data Integration, Data Transformation, Data Visualization, Industrial Automation, Industrial IoT, Industry 4.0"
     },


### PR DESCRIPTION
## Summary
- Leads the homepage/marketing subtitle with AI as the differentiator and emphasizes ease of building, aligned with the company strategy doc (branch `ZJvandeWeg-patch-9`, `nuxt/content/handbook/company/strategy.md`).
- Old: "Build, deploy, and govern operational applications across every plant and production line, distributed to the edge and accelerated by AI."
- New: "Build industrial applications in minutes with AI, then deploy and govern them from cloud to edge."

Note: `site.messaging.subtitle` is also reused as the default meta description, OG description, JSON-LD description, and the `/about` page description, so this change propagates beyond just the homepage hero.

## Test plan
- [ ] Visually confirm homepage hero subtitle on preview deploy
- [ ] Spot-check `/about` page and a page's `<meta name="description">` for the updated copy