### PR TITLE
blog: keep a scheduled post hidden on its own URL

### DIFF
--- a/nuxt/composables/useBlogList.ts
+++ b/nuxt/composables/useBlogList.ts
@@ -6,10 +6,13 @@ export const BLOG_PAGE_SIZE = 19
 // which of these show as nav buttons; 'tips' has a route but isn't in that button list).
 export const BLOG_TAGS = ['how-to', 'node-red', 'ai', 'uns', 'dashboard', 'flowfuse', 'releases', 'news', 'plc', 'mqtt', 'opcua', 'modbus', 'tips']
 
-// Mirrors .eleventy.js's DEV_MODE_POSTS: future-dated posts are hidden outside production
-// (Netlify sets CONTEXT), so deploy previews and dev can still preview scheduled posts.
+// Mirrors .eleventy.js's DEV_MODE_POSTS: future-dated posts are hidden outside production,
+// so deploy previews and dev can still preview scheduled posts. The flag is baked at build
+// time (see nuxt.config.ts) rather than read from process.env here: a scheduled post gets no
+// prerendered file, so its URL is served by the Netlify function, where process.env.CONTEXT
+// is always undefined. That switched this check off and served the post before its date.
 export function isFuturePost(date: string | Date): boolean {
-    return new Date(date) > new Date() && process.env.CONTEXT === 'production'
+    return new Date(date) > new Date() && useRuntimeConfig().public.isProductionContext
 }
 
 export function useBlogList(tag: string | null, pageNumber: number) {

--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -134,11 +134,14 @@ export default defineNuxtConfig({
     devtools: { enabled: true },
     modules: ['@nuxt/ui', '@nuxt/content', '@nuxtjs/seo', 'nuxt-studio', '@nuxt/image', './modules/docs-source', 'nuxt-llms'],
 
-    // Captured at build time (Netlify sets CONTEXT during the build, not necessarily
-    // in the deployed Function's runtime), then baked into the server bundle via
-    // runtimeConfig so analytics.ts doesn't depend on a process.env read at request time.
+    // Captured at build time (Netlify sets CONTEXT during the build, but passes only URL,
+    // SITE_NAME and SITE_ID to the deployed Function at runtime), then baked in via
+    // runtimeConfig so nothing depends on a process.env read at request time. Under `public`
+    // so the blog's scheduled-post check reads the same value everywhere it runs.
     runtimeConfig: {
-        isProductionContext: process.env.CONTEXT === 'production'
+        public: {
+            isProductionContext: process.env.CONTEXT === 'production'
+        }
     },
 
     css: ['~/assets/css/theme.css'],

--- a/nuxt/server/plugins/analytics.ts
+++ b/nuxt/server/plugins/analytics.ts
@@ -2,7 +2,7 @@ let headHtml: string | null = null
 let bodyHtml: string | null = null
 
 export default defineNitroPlugin((nitroApp) => {
-    if (import.meta.dev || !useRuntimeConfig().isProductionContext) return
+    if (import.meta.dev || !useRuntimeConfig().public.isProductionContext) return
 
     nitroApp.hooks.hook('render:html', async (html) => {
         if (html.bodyAppend.some(s => s.includes('cc.min.js'))) return

--- a/nuxt/server/routes/blog/index.xml.ts
+++ b/nuxt/server/routes/blog/index.xml.ts
@@ -69,8 +69,10 @@ function escapeXml(value: string): string {
         .replace(/>/g, '&gt;')
 }
 
-function isFuturePost(date: string | Date): boolean {
-    return new Date(date) > new Date() && process.env.CONTEXT === 'production'
+// See useBlogList.ts: the production flag is baked at build time, not read from
+// process.env, which is empty of it inside the deployed Netlify function.
+function isFuturePost(date: string | Date, isProductionContext: boolean): boolean {
+    return new Date(date) > new Date() && isProductionContext
 }
 
 // entry.body is a minimark tree: { value: MinimarkNode[] } where a node is
@@ -178,7 +180,8 @@ export default defineEventHandler(async (event) => {
     const people = { ...teamPeople, ...guestPeople }
     // Full post bodies are heavy - cap the feed to the most recent posts rather
     // than shipping the entire multi-megabyte blog archive on every request.
-    const entries = allEntries.filter(entry => !isFuturePost(entry.date)).slice(0, 20)
+    const { isProductionContext } = useRuntimeConfig(event).public
+    const entries = allEntries.filter(entry => !isFuturePost(entry.date, isProductionContext)).slice(0, 20)
 
     // Mirrors useReleaseFeaturePage: splices plan-availability badges and changelog/docs
     // links into a release blog's body, resolved from its `features:` frontmatter.


### PR DESCRIPTION
## Description

A blog post dated in the future is kept out of the blog list, the feed and the sitemap until that date passes. Opening its link directly still served the whole post. This change makes that link return page not found until the date passes, so a scheduled post is unpublished everywhere rather than almost everywhere.

Review flow is unchanged. A scheduled post is still fully visible on a pull request preview and when working locally, which is how it gets read before its date.

| While a post is still dated in the future | Before | After |
|---|---|---|
| In the blog list, tag pages and author page | Hidden | Hidden |
| In the feed and the sitemap | Hidden | Hidden |
| Opening its link directly | Shows the full post | Page not found |
| Preview of the pull request | Shows the full post | Shows the full post |
| Working locally | Shows the full post | Shows the full post |
| First build after the date passes | Live everywhere | Live everywhere |

Only the live site behaves differently, so the change can be confirmed after merge by dating a throwaway post for tomorrow and opening its link.

## Related Issue(s)

None.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))
