### PR TITLE
Replace back-links with breadcrumbs, fix truncation and remove duplication

### DIFF
--- a/nuxt/components/Breadcrumbs.vue
+++ b/nuxt/components/Breadcrumbs.vue
@@ -21,7 +21,7 @@ const displayItems = computed(() => props.items.map((item, index) => ({
     ...item,
     ui: {
         ...(item.to ? { link: 'hover:text-indigo-600' } : {}),
-        ...(index < props.items.length - 1 ? { item: 'shrink-0' } : {}),
+        ...(index === 0 && props.items.length > 1 ? { item: 'shrink-0' } : {}),
     },
 })))
 </script>

--- a/nuxt/components/Breadcrumbs.vue
+++ b/nuxt/components/Breadcrumbs.vue
@@ -17,18 +17,18 @@ useSchemaOrg([
     }),
 ])
 
-// The indigo hover only makes sense on crumbs that actually navigate — a plain span
-// (no `to`, e.g. the current page or a non-navigable group label) getting the same
-// hover color as a real link falsely signals it's clickable.
-const items = computed(() => props.items.map(item => ({
+const displayItems = computed(() => props.items.map((item, index) => ({
     ...item,
-    ui: item.to ? { link: 'hover:text-indigo-600' } : undefined,
+    ui: {
+        ...(item.to ? { link: 'hover:text-indigo-600' } : {}),
+        ...(index < props.items.length - 1 ? { item: 'shrink-0' } : {}),
+    },
 })))
 </script>
 
 <template>
   <UBreadcrumb
-    :items="items"
+    :items="displayItems"
     color="neutral"
     class="capitalize"
     :ui="{ link: 'text-sm' }"

--- a/nuxt/pages/blog/[...slug].vue
+++ b/nuxt/pages/blog/[...slug].vue
@@ -160,7 +160,6 @@ if (routeInfo.value.kind === 'post') {
   <div v-else-if="page" class="w-full page post">
     <div class="post-title container m-auto text-center max-lg:px-6 flex mt-6 mb-6 md:max-w-screen-lg md:mt-12">
       <div class="text-left md:pr-32">
-        <Breadcrumbs :items="breadcrumbItems" class="mb-2" />
         <label>Article</label>
         <h1>{{ page.title }}</h1>
         <h4 v-if="page.subtitle">{{ page.subtitle }}</h4>
@@ -213,10 +212,7 @@ if (routeInfo.value.kind === 'post') {
     <div class="blog nohero w-full pb-24">
       <div class="container flex flex-col md:flex-row m-auto text-left max-lg:px-6 md:max-w-screen-lg gap-8 items-stretch">
         <div class="ff-prose min-w-0">
-          <NuxtLink class="group hover:no-underline inline-flex items-center gap-1 mb-4" to="/blog">
-            <UIcon name="i-heroicons-chevron-left" />
-            <span class="group-hover:underline">Back to Blog Posts</span>
-          </NuxtLink>
+          <Breadcrumbs :items="breadcrumbItems" class="mb-4" />
 
           <div class="prose w-full flex-grow">
             <div class="mb-4 hero-img">

--- a/nuxt/pages/changelog/[...slug].vue
+++ b/nuxt/pages/changelog/[...slug].vue
@@ -67,7 +67,6 @@ useSeoMeta({
   <div class="w-full page post">
     <div class="post-title container m-auto text-center max-lg:px-6 flex mt-6 mb-6 md:max-w-screen-lg md:mt-12">
       <div class="text-left md:pr-32">
-        <Breadcrumbs :items="breadcrumbItems" class="mb-2" />
         <label>Changelog</label>
         <h1>{{ page.title }}</h1>
         <h4 v-if="page.subtitle">{{ page.subtitle }}</h4>
@@ -78,10 +77,7 @@ useSeoMeta({
     <div class="blog nohero w-full pb-24">
       <div class="container flex flex-col md:flex-row m-auto text-left max-lg:px-6 md:max-w-screen-lg gap-8 items-stretch">
         <div class="ff-prose flex-grow">
-          <NuxtLink to="/changelog" class="inline-flex items-center gap-1 mb-4">
-            <UIcon name="i-heroicons-chevron-left" />
-            Back to the Changelog
-          </NuxtLink>
+          <Breadcrumbs :items="breadcrumbItems" class="mb-4" />
           <div class="prose">
             <ContentRenderer :value="page" />
           </div>

--- a/nuxt/pages/customer-stories/[slug].vue
+++ b/nuxt/pages/customer-stories/[slug].vue
@@ -101,11 +101,7 @@ useSchemaOrg([
 
     <div class="blog nohero w-full bg-gray-50 pb-24 pt-6">
       <div class="container m-auto flex flex-col items-stretch text-left max-lg:px-6 md:max-w-screen-lg">
-        <Breadcrumbs :items="breadcrumbItems" class="mb-3" />
-        <NuxtLink to="/customer-stories" class="group mb-5 inline-flex items-center gap-1 hover:no-underline md:mb-4">
-          <UIcon name="i-heroicons-chevron-left" />
-          <span class="group-hover:underline">Back to Customer Stories</span>
-        </NuxtLink>
+        <Breadcrumbs :items="breadcrumbItems" class="mb-5 md:mb-4" />
 
         <div class="ff-prose mb-6 flex flex-col-reverse border-b md:flex-row md:gap-8">
           <div class="flex-grow">


### PR DESCRIPTION
## Summary
- The breadcrumb and the "Back to X" link both navigated to the same parent page, dropped the redundant link and moved the breadcrumb into its old position (top of the article body) instead of the hero title block.
- That move also fixes a mobile overflow bug from #5668: a long post title in the breadcrumb, when placed in the hero's `flex` row, pushed the page wider than the viewport (confirmed live on production: 520px rendered in a 375px viewport).
- Fixed `Breadcrumbs.vue` so only the active (last) crumb truncates on overflow, instead of every crumb, including short ones like "Blog",  shrinking evenly.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

