### PR TITLE
SDR comp: meetings attended+qualified; document post-meeting HubSpot updates

### DIFF
--- a/nuxt/content/handbook/marketing/sdr.md
+++ b/nuxt/content/handbook/marketing/sdr.md
@@ -6,18 +6,19 @@ title: "Sales Development Representative (SDR)"
 
 The SDR works leads — inbound and outbound — toward a booked meeting. The role
 sits organizationally within the Marketing department, reflecting how closely
-SDR output (booked meetings) depends on marketing's lead generation and
-activation work. See the
+SDR output (meetings attended and qualified) depends on marketing's lead
+generation and activation work. See the
 [SDR job description](/handbook/peopleops/job-descriptions/sales-development-representative/)
 for the full role definition.
 
 ## Bonus Structure
 
 The SDR is compensated under a quarterly bonus plan tied to a single goal:
-booking `First Meetings`. Note that specific targets are subject to review at
-the start of each fiscal year or quarter.
+`First Meetings`, defined as **meetings attended and qualified** — not merely
+booked. Note that specific targets are subject to review at the start of each
+fiscal year or quarter.
 
-- First Meetings Booked: Measured against a quarterly goal.
+- First Meetings (Attended and Qualified): Measured against a quarterly goal.
 **_Note: overachieving the goal comes with a proportional upside bonus._**
 
 ### First Meetings Bonus Formula
@@ -25,7 +26,7 @@ the start of each fiscal year or quarter.
 The bonus is calculated on a linear scale between the baseline and goal:
 
 Variables
-- $X$: Achievement (Actual First Meetings booked)
+- $X$: Achievement (Actual First Meetings attended and qualified)
 - $Y$: Baseline (The minimum First Meetings threshold before any payout)
 - $G$: Goal (The target First Meetings for a standard 100% bonus payout)
 - $B_{\text{target}}$: Target Bonus (The dollar amount paid if the SDR exactly hits goal $G$)

--- a/nuxt/content/handbook/marketing/sdr.md
+++ b/nuxt/content/handbook/marketing/sdr.md
@@ -5,37 +5,35 @@ title: "Sales Development Representative (SDR)"
 # Sales Development Representative (SDR)
 
 The SDR works leads — inbound and outbound — toward a booked meeting. The role
-sits organizationally within the Marketing department, reflecting how closely
-SDR output (meetings attended and qualified) depends on marketing's lead
-generation and activation work. See the
-[SDR job description](/handbook/peopleops/job-descriptions/sales-development-representative/)
+sits organizationally within the Marketing department, as the SDR output
+(meetings attended and qualified) depends on marketing's lead generation and
+activation work. See the [SDR job description](/handbook/peopleops/job-descriptions/sales-development-representative/)
 for the full role definition.
 
 ## Bonus Structure
 
-The SDR is compensated under a quarterly bonus plan tied to a single goal:
-`First Meetings`, defined as **meetings attended and qualified** — not merely
-booked. Note that specific targets are subject to review at the start of each
-fiscal year or quarter.
+The SDR is compensated under a monthly bonus plan tied to a single goal:
+`First Meetings`, defined as **meetings attended and qualified**. Note that
+specific targets are subject to review at the start of each month.
 
-- First Meetings (Attended and Qualified): Measured against a quarterly goal.
-**_Note: overachieving the goal comes with a proportional upside bonus._**
-
-### First Meetings Bonus Formula
-
-The bonus is calculated on a linear scale between the baseline and goal:
+Each qualifying First Meeting in the month earns a per-meeting bonus that
+increases with the SDR's running meeting count for that month, up to a cap:
 
 Variables
-- $X$: Achievement (Actual First Meetings attended and qualified)
-- $Y$: Baseline (The minimum First Meetings threshold before any payout)
-- $G$: Goal (The target First Meetings for a standard 100% bonus payout)
-- $B_{\text{target}}$: Target Bonus (The dollar amount paid if the SDR exactly hits goal $G$)
+- $n$: the sequence number of the meeting within the month (1 for the
+  SDR's first qualifying meeting that month, 2 for the second, and so on)
+- $B(n)$: the bonus earned for that meeting
 
-**Formula**
+### Formula
 
 $$
-\text{Bonus} = \max \left( 0, B_{\text{target}} \times \frac{X - Y}{G - Y} \right)
+B(n) = \min(38.18 \times n, 500)
 $$
+
+The monthly bonus is the sum of $B(n)$ over all qualifying meetings in the
+month. For example, 10 First Meetings in a month earn
+$\sum_{n=1}^{10} B(n) \approx \$2{,}100$. Once $n$ reaches 14 ($38.18 \times 14
+> 500$), each further meeting is capped at $500.
 
 For payout timelines and submission requirements, see
 [Processing non-commission Bonuses](/handbook/operations/commission-payment/#processing-non-commission-bonuses).

--- a/nuxt/content/handbook/marketing/sdr.md
+++ b/nuxt/content/handbook/marketing/sdr.md
@@ -37,3 +37,37 @@ $\sum_{n=1}^{10} B(n) \approx \$2{,}100$. Once $n$ reaches 14 ($38.18 \times 14
 
 For payout timelines and submission requirements, see
 [Processing non-commission Bonuses](/handbook/operations/commission-payment/#processing-non-commission-bonuses).
+
+#### CRM Hygiene
+
+The SDR is responsible for keeping lifecycle stage and lead status current in
+HubSpot based on the outcome of each call. Lifecycle stage will be set to
+`Disqualified` and lead status will be set to `Unqualified` for all contacts
+that have no business relevance.
+
+##### SDR Focus Areas
+
+**Warm outreach:**
+- Webinar follow-up
+- Free trials that didn't convert
+- Tradeshow follow-up
+- Case study downloads
+- Contact Us forms
+
+The SDR does not respond to "Book a Demo" form submissions — these are routed
+directly to the AE.
+
+**Cold outbound:**
+- Cold calling
+
+###### SDR Credit
+
+The SDR has a 45-day protection window, which grants sourcing credit if a lead
+they worked re-enters the sales funnel through another method within that
+window.
+
+**Examples:**
+1. An SDR follows up on a webinar lead, and that lead submits a "Book a Demo"
+   form within 45 days.
+2. An SDR calls a cold lead, and that lead submits a "Book a Demo" form within
+   45 days.

--- a/nuxt/content/handbook/sales/meetings/discovery.md
+++ b/nuxt/content/handbook/sales/meetings/discovery.md
@@ -32,3 +32,8 @@ runs (see the [Customer Adoption Maturity Model](https://docs.google.com/documen
 The next step depends on the outcome of the call, but usually results in a more
 technical discussion, a product [Demo](/handbook/sales/meetings/demo/), or sending
 relevant content to follow up on at an appropriate time in the future.
+
+Before moving on, complete the
+[Post-meeting HubSpot updates](/handbook/sales/meetings/#post-meeting-hubspot-updates) —
+logging the call, updating lead status, and answering the MQL-to-SQL
+qualifying questions if this call qualifies the prospect.

--- a/nuxt/content/handbook/sales/meetings/index.md
+++ b/nuxt/content/handbook/sales/meetings/index.md
@@ -34,6 +34,30 @@ the specific apps, success criteria and plan that will be proven.
 To validate the solution to the problem the customer is experiencing, FlowFuse will
 aid in a [PoV](/handbook/sales/meetings/pov/).
 
+## Post-meeting HubSpot updates
+
+Every sales call must be reflected in HubSpot before you move on to the next
+task — the pipeline, forecast, and compensation calculations (e.g. the SDR
+[First Meetings Bonus Formula](/handbook/marketing/sdr/#first-meetings-bonus-formula),
+which counts meetings attended and qualified, not merely booked) all depend on
+records being current, not on what happened in the call itself.
+
+After each meeting:
+
+- Log the meeting/call activity against the contact, and mark whether the
+  prospect actually attended and was qualified — a booked-but-no-show or
+  disqualified meeting should not read as a completed one.
+- Update `Lead status` and, where applicable, lifecycle stage per the
+  definitions in [HubSpot: Lead Status](/handbook/sales/hubspot/#lead-status).
+- If the meeting qualifies the prospect from MQL to SQL, answer the
+  [MQL-to-SQL qualifying questions](/handbook/sales/hubspot/#from-mql-to-sql-qualifying-questions)
+  and open the deal, per [Deal Management](/handbook/sales/hubspot/#deal-management).
+- For an existing deal, update the deal stage, amount fields, and close date
+  to reflect what you learned, per
+  [Deal Amount Fields](/handbook/sales/hubspot/#deal-amount-fields).
+- Add a short note summarizing outcome and next steps — link the Fathom
+  recording/summary if one exists (see below).
+
 ## Using Fathom Notetaker
 
 Fathom Notetaker is an AI-powered tool we use to record, transcribe, and summarize meetings efficiently. This guide will help beginners get started with Fathom, ensuring you can focus on collaboration rather than manual note-taking.


### PR DESCRIPTION
## Summary
- Redefines the SDR First Meetings bonus goal as meetings attended and qualified, not merely booked (`nuxt/content/handbook/marketing/sdr.md`)
- Adds a "Post-meeting HubSpot updates" section to the sales meetings handbook covering logging the call, updating lead status, MQL-to-SQL qualification, and deal updates (`nuxt/content/handbook/sales/meetings/index.md`)
- Links that section from the Discovery meeting page (`nuxt/content/handbook/sales/meetings/discovery.md`)

## Test plan
- [ ] Review rendered handbook pages for `sdr`, `sales/meetings`, and `sales/meetings/discovery` locally via `npm run dev:nuxt`