### PR TITLE
fix: add the missing comma in site.json

### DIFF
--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -5,7 +5,7 @@
     "messaging": {
         "tagLine": "The Edge-Native Platform for Industrial Applications",
         "heroTagLine": "The Edge-Native Platform for Industrial IT, OT, and IIOT Applications",
-        "subtitle": "Build industrial applications in minutes with AI, then deploy and govern production from cloud to edge."
+        "subtitle": "Build industrial applications in minutes with AI, then deploy and govern production from cloud to edge.",
         "title": "Build workflows and integrations that optimize your industrial operations",
         "keywords": "Node-RED, Application Development, IoT, IIoT, Low-Code, open source, Integration, Workflow, Automation, Data Processing, Data Integration, Data Transformation, Data Visualization, Industrial Automation, Industrial IoT, Industry 4.0"
     },


### PR DESCRIPTION
## Description

**Outcome: `main` builds again.**

`src/_data/site.json` lost the comma after `subtitle`, so the file does not parse. Eleventy reads it through `.eleventy.js`, so every build on main fails:

```
[11ty] src/_data/site.json: Expected ',' or '}' after property value
       in JSON at position 464 (line 9 column 9)
```

This takes down the website build and also `Test Documentation with website` on every open FlowFuse/flowfuse PR, since that job builds this repo. Introduced by https://github.com/FlowFuse/website/pull/5685.

One character. Worth merging as soon as someone sees it.

## Related Issue(s)

None.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))
