### PR TITLE
Remove the "overrides" CSS layer

### DIFF
--- a/nuxt/components/content/AgentSetupTabs.vue
+++ b/nuxt/components/content/AgentSetupTabs.vue
@@ -8,9 +8,9 @@
 // Styling comes from the .ff-agent-* rules in src/css/style.css, which nuxt.config.ts
 // links on every Nuxt page, rather than from utility classes on the elements. That is
 // forced: this renders inside .prose on the changelog and docs pages, and the site's
-// prose rules sit in @layer overrides, which outranks Tailwind's @layer utilities
-// whatever the specificity. As utilities, `h-4` on a tab logo lost to .prose img's
-// width:100% and the marks blew up to full column width.
+// prose rules are unlayered, which outranks Tailwind's @layer utilities whatever the
+// specificity. As utilities, `h-4` on a tab logo lost to .prose img's width:100% and
+// the marks blew up to full column width.
 const props = withDefaults(defineProps<{
     // Drops the FlowFuse Expert tab. For surfaces that are specifically about
     // connecting your own agent, where Expert is not one of the options.

--- a/src/css/algolia-theme.css
+++ b/src/css/algolia-theme.css
@@ -1,5 +1,3 @@
-@layer overrides {
-
 #algolia-search {
     border-color: #dedede;
     flex: auto;
@@ -101,4 +99,3 @@
     color: #2563eb;
 }
 
-} /* end @layer components */

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,4 +1,4 @@
-@layer vendor, theme, base, components, utilities, overrides;
+@layer vendor, theme, base, components, utilities;
 
 @config "../../tailwind.config.js";
 @import "tailwindcss";
@@ -85,17 +85,15 @@
 @source not "../../nuxt/.netlify/**";
 @source "../../nuxt/**";
 
-@layer overrides {
-    .prose {
-        --tw-prose-body: var(--color-gray-700);
-        --tw-prose-headings: var(--color-gray-600);
-        --tw-prose-links: var(--color-blue-600);
-        --tw-prose-code: var(--color-red-700);
-        --tw-prose-bold: var(--color-gray-500);
-    }
-    .prose img { max-width: 100%; }
-    .prose:not(.prose-natural-size-images) img { width: 100%; height: auto; }
+.prose {
+    --tw-prose-body: var(--color-gray-700);
+    --tw-prose-headings: var(--color-gray-600);
+    --tw-prose-links: var(--color-blue-600);
+    --tw-prose-code: var(--color-red-700);
+    --tw-prose-bold: var(--color-gray-500);
 }
+.prose img { max-width: 100%; }
+.prose:not(.prose-natural-size-images) img { width: 100%; height: auto; }
 
 @import "./style.page.css";
 @import "./style.nohero.css";
@@ -161,8 +159,8 @@ html, body {
 }
 
 /* Layered (not a bare unlayered `*` rule) so Tailwind utilities — which compile
-   into @layer utilities, later in the `vendor, theme, base, components, utilities,
-   overrides` order declared above — can override transition-property/duration on
+   into @layer utilities, later in the `vendor, theme, base, components, utilities`
+   order declared above — can override transition-property/duration on
    individual elements through normal cascade rules, instead of this always
    winning outright regardless of specificity. */
 @layer base {
@@ -3316,8 +3314,8 @@ lite-youtube::before {
 
 /* AgentSetupTabs: the agent picker and its three setup steps. Unlayered on purpose.
    The component renders inside .prose on the changelog entry and the third-party-agents
-   docs page as well as standalone on /ai, and the site's prose rules live in
-   @layer overrides, which outranks Tailwind's @layer utilities however specific the
+   docs page as well as standalone on /ai, and the site's prose rules are also unlayered
+   (see .prose above), which outranks Tailwind's @layer utilities however specific the
    utility is. So the component's look cannot live in utility classes on the elements:
    .prose img's width:100% beat `h-4` and blew the tab marks up to full column width,
    and .prose p forced the step text to 12px. Unlayered outranks every layer, so these


### PR DESCRIPTION
## Description

`overrides` added an extra named layer that did nothing `unlayered` doesn't already do more simply, since nothing was ever declared after it in the layer order. Removing it collapses two equivalent mechanisms into one and keeps the codebase's existing unlayered-CSS convention (already used for `.handbook-content` in `nuxt/assets/css/theme.css` and elsewhere) as the single documented escape hatch for "must always win the cascade."

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

