### PR TITLE
Nuxt: Add CtaPricing as a fifth unified CTA destination

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -276,7 +276,7 @@ This also covers old `/docs/**` paths left behind by a rename in `flowfuse/flowf
 
 **Nuxt only** — 11ty pages still use hand-written `<a class="ff-btn ...">` links; these components have no 11ty equivalent yet.
 
-There are exactly four CTA destinations, each with its own component with **fixed copy and href** (a PostHog audit found dozens of different button texts pointing at the same four URLs, which made it impossible to tell which copy converted best — see `/handbook/marketing/website#call-to-action-buttons` for the non-engineer-facing explanation and a live gallery of every variant):
+There are exactly five CTA destinations, each with its own component with **fixed copy and href** (a PostHog audit found dozens of different button texts pointing at the same handful of URLs, which made it impossible to tell which copy converted best — see `/handbook/marketing/website#call-to-action-buttons` for the non-engineer-facing explanation and a live gallery of every variant):
 
 | Component | href | Fixed label |
 |---|---|---|
@@ -284,8 +284,9 @@ There are exactly four CTA destinations, each with its own component with **fixe
 | `nuxt/components/CtaSignIn.vue` | `site.appURL` | "Sign In" |
 | `nuxt/components/CtaContactUs.vue` | `/contact-us/` | "Contact Us" |
 | `nuxt/components/CtaBookDemo.vue` | `/book-demo/` | "Book a Demo" |
+| `nuxt/components/CtaPricing.vue` | `/pricing/` | "View Pricing" |
 
-All four are thin wrappers around `nuxt/components/cta/CtaButton.vue`, which does the actual styling/tracking and isn't meant to be used directly. If a page needs different wording, that's a sign a fifth destination-specific component is needed — not a prop that lets callers override copy on these four.
+All five are thin wrappers around `nuxt/components/cta/CtaButton.vue`, which does the actual styling/tracking and isn't meant to be used directly. If a page needs different wording, that's a sign a sixth destination-specific component is needed — not a prop that lets callers override copy on these five.
 
 **Props** (all optional except `variant`/`position`): `variant` (`primary` | `primary-outlined` | `highlight` | `highlight-outlined` | `ghost` | `nav-text`), `position` (free string, sent to PostHog — describes where on the page, e.g. `hero`, `pricing-card`), `plan` (e.g. `edge`/`hub`/`fleet`, sent to PostHog), `color` (`primary`|`highlight`|`white`, only for `variant="ghost"`, which has no background of its own), `icon` (Nuxt Icon name for a trailing icon), `uppercase`, `padded` (only for `variant="nav-text"` — whether it has the header-`<ul>` link padding or is true zero-padding inline text), `preview` (renders identically but doesn't navigate or call `capture()` — used by the handbook's live example gallery so clicking a doc example can't send a real event or leave the page).
 
@@ -293,7 +294,7 @@ All four are thin wrappers around `nuxt/components/cta/CtaButton.vue`, which doe
 
 There's no `size` prop — every real-button variant's padding/font-size is hardcoded to match `.ff-btn` exactly (see the Computed-tab note in the gotchas below), so a size knob would only ever have affected icon dimensions. It was removed once confirmed nothing used a non-default value.
 
-Click tracking: `capture(event, { position, variant, plan? })` via `nuxt/composables/useCapture.ts`, which wraps the global `window.capture()` from `src/_includes/analytics/body.html` (shared with 11ty, no-ops without analytics consent). Event names: `cta-sign-up`, `cta-sign-in`, `cta-contact-us`, `cta-book-demo`.
+Click tracking: `capture(event, { position, variant, plan? })` via `nuxt/composables/useCapture.ts`, which wraps the global `window.capture()` from `src/_includes/analytics/body.html` (shared with 11ty, no-ops without analytics consent). Event names: `cta-sign-up`, `cta-sign-in`, `cta-contact-us`, `cta-book-demo`, `cta-pricing`.
 
 ### Gotchas already solved here (don't re-discover them)
 

--- a/nuxt/components/BlogPostCta.vue
+++ b/nuxt/components/BlogPostCta.vue
@@ -4,10 +4,9 @@ const props = defineProps<{
     cta?: { type?: string, title?: string, description?: string } | null
 }>()
 
-// 'sign-up' / 'demo' / 'contact' now render one of the unified Cta* components
-// (fixed copy/href/event) instead of a local buttonText/buttonUrl pair, so the
-// blog CTA can't drift from the rest of the site's copy. 'pricing' isn't one
-// of the four unified destinations, so it keeps its own link.
+// All four types now render one of the unified Cta* components (fixed
+// copy/href/event) instead of a local buttonText/buttonUrl pair, so the blog
+// CTA can't drift from the rest of the site's copy.
 const CTA_VARIANTS: Record<string, { title: string, description: string }> = {
     'sign-up': {
         title: 'Start building with your own industrial data',
@@ -60,7 +59,7 @@ function onCtaClick (event: MouseEvent) {
         <CtaSignUp v-if="ctaType === 'sign-up'" variant="highlight" position="blog-post-cta" />
         <CtaBookDemo v-else-if="ctaType === 'demo'" variant="highlight" position="blog-post-cta" />
         <CtaContactUs v-else-if="ctaType === 'contact'" variant="highlight" position="blog-post-cta" />
-        <a v-else class="ff-btn ff-btn--highlight uppercase items-center text-base no-underline" href="/pricing">View Pricing</a>
+        <CtaPricing v-else variant="highlight" position="blog-post-cta" />
       </div>
     </div>
   </div>

--- a/nuxt/components/CtaPricing.vue
+++ b/nuxt/components/CtaPricing.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+// Fixed destination, copy, and tracked event - only the look (variant) and
+// where it lives on the page (position) vary per insertion.
+import CtaButton from './cta/CtaButton.vue'
+
+withDefaults(defineProps<{
+    variant: 'primary' | 'primary-outlined' | 'highlight' | 'highlight-outlined' | 'nav-text' | 'ghost'
+    position: string
+    plan?: string
+    color?: 'primary' | 'highlight' | 'white'
+    uppercase?: boolean
+    padded?: boolean
+    preview?: boolean
+    icon?: string
+}>(), { uppercase: undefined })
+
+const EVENT = 'cta-pricing'
+const HREF = '/pricing/'
+const LABEL = 'View Pricing'
+</script>
+
+<template>
+  <CtaButton :event="EVENT" :href="HREF" :external="false" :label="LABEL" :variant="variant" :position="position" :plan="plan" :icon="icon" :uppercase="uppercase" :padded="padded" :color="color" :preview="preview" />
+</template>

--- a/nuxt/components/content/CtaExample.vue
+++ b/nuxt/components/content/CtaExample.vue
@@ -8,8 +8,9 @@ import CtaSignUp from '../CtaSignUp.vue'
 import CtaSignIn from '../CtaSignIn.vue'
 import CtaContactUs from '../CtaContactUs.vue'
 import CtaBookDemo from '../CtaBookDemo.vue'
+import CtaPricing from '../CtaPricing.vue'
 
-const COMPONENTS = { CtaSignUp, CtaSignIn, CtaContactUs, CtaBookDemo }
+const COMPONENTS = { CtaSignUp, CtaSignIn, CtaContactUs, CtaBookDemo, CtaPricing }
 
 const props = defineProps<{
     component: keyof typeof COMPONENTS

--- a/nuxt/content/handbook/marketing/website.md
+++ b/nuxt/content/handbook/marketing/website.md
@@ -130,7 +130,7 @@ meta:
 
 ## Call-to-Action Buttons
 
-The site has four main call-to-action destinations, each with **fixed copy** — you cannot write new button text for these, only choose how the button looks and where it sits on the page:
+The site has five main call-to-action destinations, each with **fixed copy** — you cannot write new button text for these, only choose how the button looks and where it sits on the page:
 
 | Component        | Goes to                           | Button text                                          |
 | ---------------- | --------------------------------- | ---------------------------------------------------- |
@@ -138,8 +138,9 @@ The site has four main call-to-action destinations, each with **fixed copy** —
 | `<CtaSignIn>`    | `app.flowfuse.com`                | "Sign In"                                            |
 | `<CtaContactUs>` | `/contact-us/`                    | "Contact Us"                                         |
 | `<CtaBookDemo>`  | `/book-demo/`                     | "Book a Demo"                                        |
+| `<CtaPricing>`   | `/pricing/`                       | "View Pricing"                                       |
 
-If a page needs different wording than what's listed above, that's a sign the destination needs a fifth CTA, not a new prop on these four or custom inline code.
+If a page needs different wording than what's listed above, that's a sign the destination needs a sixth CTA, not a new prop on these five or custom inline code.
 
 **These components only exist on Nuxt-rendered pages** (`nuxt/pages/`, `nuxt/content/`), part of the site is still served by Eleventy and doesn't have access to them yet. On an Eleventy page, a CTA is still a hand-written `<a class="ff-btn ...">` link.
 
@@ -172,6 +173,13 @@ Every component takes the same `variant` prop, which controls the look. Click "S
   :::cta-example{component="CtaContactUs" variant="highlight-outlined"}
   ```mdc
   ::CtaContactUs{variant="highlight-outlined" position="hero"}
+  ::
+  ```
+  :::
+
+  :::cta-example{component="CtaPricing" variant="primary-outlined"}
+  ```mdc
+  ::CtaPricing{variant="primary-outlined" position="hero"}
   ::
   ```
   :::

--- a/nuxt/pages/product/[tier].vue
+++ b/nuxt/pages/product/[tier].vue
@@ -30,8 +30,6 @@ useSeoMeta({
     ogUrl: `https://flowfuse.com/product/${tierId}/`,
     twitterSite: '@FlowFuseinc',
 })
-
-const capture = useCapture()
 </script>
 
 <template>
@@ -49,12 +47,7 @@ const capture = useCapture()
           <p class="mt-6 text-lg max-w-xl mx-auto md:mx-0" v-html="tier.description" />
           <div class="mt-8 flex flex-row flex-wrap gap-4 items-center justify-center md:justify-start">
             <CtaBookDemo variant="highlight" :position="`${tierId}-hero`" />
-            <a class="ff-btn group flex flex-col" href="/pricing/" @click="capture('cta-pricing', { position: `${tierId}-hero` })">
-              <span class="flex items-center justify-center gap-2 text-base uppercase text-indigo-600 hover:text-indigo-800">
-                <span>VIEW PRICING</span>
-                <IconsArrowRightIcon class="w-5 h-5" />
-              </span>
-            </a>
+            <CtaPricing variant="ghost" :position="`${tierId}-hero`" icon="i-lucide-arrow-right" />
           </div>
         </div>
         <div class="rounded-lg shadow-2xl border-2 border-red-100 overflow-hidden">

--- a/nuxt/pages/product/index.vue
+++ b/nuxt/pages/product/index.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
 // Ported from src/platform/features.njk (11ty). Cta* components enforce
 // fixed copy/destinations (see CLAUDE.md), so the old custom-copy "Request a
-// Demo" buttons become <CtaBookDemo>; "View Pricing" isn't one of the four
-// unified destinations, so it keeps a plain ff-btn link, same precedent as
-// BlogPostCta.vue's pricing fallback.
+// Demo" and "View Pricing" buttons become <CtaBookDemo>/<CtaPricing>.
 useSeoMeta({
     title: 'Features',
     description: 'FlowFuse provides the features companies require to reliably deliver industrial applications to devices and cloud in a collaborative, secure manner.',
@@ -101,12 +99,7 @@ onUnmounted(() => {
               <p class="mt-6 text-lg max-w-xl mx-auto lg:mx-0">Bridge the gap between OT and IT teams using FlowFuse, the only comprehensive application platform with industrial AI and governance baked in.</p>
               <div class="mt-8 flex flex-row flex-wrap gap-4 items-center justify-center lg:justify-start">
                 <CtaBookDemo variant="highlight" position="hero" />
-                <a class="ff-btn group flex flex-col" href="/pricing/" @click="capture('cta-pricing', { position: 'hero' })">
-                  <span class="flex items-center justify-center gap-2 text-base uppercase text-indigo-600 hover:text-indigo-800">
-                    <span>VIEW PRICING</span>
-                    <IconsArrowRightIcon class="w-5 h-5" />
-                  </span>
-                </a>
+                <CtaPricing variant="ghost" position="hero" icon="i-lucide-arrow-right" />
               </div>
             </div>
             <div class="w-full">
@@ -191,12 +184,7 @@ onUnmounted(() => {
           <p class="text-indigo-50 font-light text-xl max-w-2xl m-0">Your first operational application could be running this week. Request a demo to see how, or explore pricing to find the right fit.</p>
           <div class="flex flex-col sm:flex-row gap-4 items-center">
             <CtaBookDemo variant="highlight" position="get-started" />
-            <a class="ff-btn group flex flex-col" href="/pricing/" @click="capture('cta-pricing', { position: 'get-started' })">
-              <span class="text-base uppercase items-center text-base flex gap-2 uppercase items-center text-white hover:text-gray-200">
-              <span>VIEW PRICING</span>
-                <IconsArrowRightIcon class="w-5 h-5" />
-              </span>
-            </a>
+            <CtaPricing variant="ghost" color="white" position="get-started" icon="i-lucide-arrow-right" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description

Follow-up to #5517 (the original unified CTA components PR).

Adds `CtaPricing` as a fifth fixed CTA destination (`/pricing/`, "View Pricing"), same pattern as `CtaSignUp`/`CtaSignIn`/`CtaContactUs`/`CtaBookDemo`: fixed copy/href, thin wrapper around `CtaButton.vue`, tracked via the `cta-pricing` PostHog event.

Found while auditing the site for hand-written CTA links outside the unified system: `BlogPostCta.vue`'s pricing fallback, `product/index.vue` (hero + get-started band), and `product/[tier].vue` were each repeating the same hardcoded "View Pricing" link and `cta-pricing` capture call. Migrated all three to `<CtaPricing>`.

Also updated `.claude/CLAUDE.md`, the marketing handbook, and the handbook's live CTA example gallery (`CtaExample.vue`) to document the fifth destination.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

