### PR TITLE
css: stop prose stretching the agent picker brand marks

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -3379,8 +3379,15 @@ lite-youtube::before {
     outline-offset: 2px;
 }
 /* The brand marks are <img>, so they keep their own colours; our own glyphs are
-   masked spans that inherit currentColor and turn white with the label. */
-.ff-agent-tab img {
+   masked spans that inherit currentColor and turn white with the label.
+
+   Three classes on purpose. Unlayered beats layered, but it does not beat a more
+   specific unlayered rule, and .prose:not(.prose-natural-size-images) img is
+   (0,2,1) while .ff-agent-tab img is only (0,1,1). On the surfaces whose prose
+   container opts out (docs) that rule never applies, but the blog post and the
+   changelog entry use a plain .prose, so there it won and every mark rendered at
+   width:100% of the column: the ChatGPT square came out 780px. */
+.ff-agent-card .ff-agent-tabs .ff-agent-tab img {
     height: 1rem;
     width: auto;
     flex: none;


### PR DESCRIPTION
## Description

The agent picker's brand marks rendered at full column width on any surface that wraps it in a plain `.prose`. On the changelog entry the ChatGPT square came out 780px.

`.prose:not(.prose-natural-size-images) img` is `(0,2,1)` and forces `width:100%`. `.ff-agent-tab img` was only `(0,1,1)`, so it lost regardless of source order. The component's styles are deliberately unlayered to beat Tailwind's `@layer utilities`, but unlayered does not beat a *more specific* unlayered rule, which is the case that was missed.

Scoping the rule through the card and the tab strip takes it to `(0,3,1)`.

Affected:
- changelog entry: broken, fixed here
- blog post in https://github.com/FlowFuse/website/pull/5671: broken, fixed here
- docs page: was already fine, its container carries `prose-natural-size-images`
- `/ai`: was already fine, renders outside `.prose`

Verified all four surfaces at 375, 414, 768, 1024, 1280 and 1536px. Every mark measures 16x16 in all 24 combinations, and the tab strip still wraps correctly at 375px.

## Related Issue(s)

Found while reviewing https://github.com/FlowFuse/website/pull/5671, which adds a fourth surface for this component.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))
