### PR TITLE
Add the natural-language query angle to the homepage subtitle

### DIFF
--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -5,7 +5,7 @@
     "messaging": {
         "tagLine": "The Edge-Native Platform for Industrial Applications",
         "heroTagLine": "The Edge-Native Platform for Industrial IT, OT, and IIOT Applications",
-        "subtitle": "Build industrial applications in minutes with AI, then deploy and govern production from cloud to edge.",
+        "subtitle": "Build industrial applications in minutes with AI, deploy and govern production from cloud to edge, then ask your plant floor anything.",
         "title": "Build workflows and integrations that optimize your industrial operations",
         "keywords": "Node-RED, Application Development, IoT, IIoT, Low-Code, open source, Integration, Workflow, Automation, Data Processing, Data Integration, Data Transformation, Data Visualization, Industrial Automation, Industrial IoT, Industry 4.0"
     },


### PR DESCRIPTION
## Description

Follow-up to #5685. That PR led the subtitle with AI and speed, but dropped the one capability that is hardest for competitors to match: asking your operations questions in plain language (Insights mode).

This keeps every element of the merged line and adds the query angle as a closing clause.

- Current: "Build industrial applications in minutes with AI, then deploy and govern production from cloud to edge."
- New: "Build industrial applications in minutes with AI, deploy and govern production from cloud to edge, then ask your plant floor anything."

134 characters, so it still fits a search snippet. As noted in #5685, `site.messaging.subtitle` is reused as the meta description, OG description, JSON-LD description and the `/about` description, so this propagates beyond the homepage hero.

## Related Issue(s)

Follows https://github.com/FlowFuse/website/pull/5685

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))
