### PR TITLE
app-guide: link component call-outs to the docs

### DIFF
--- a/nuxt/content/application-guide/flowfuse/app-delivery-methods.md
+++ b/nuxt/content/application-guide/flowfuse/app-delivery-methods.md
@@ -35,10 +35,10 @@ Take the whole app — every flow, setting and dependency — as a versioned sna
 
 **Major components**
 
-- **Snapshot** — the whole app, frozen as one versioned build
-- **Pipeline** — promotes that snapshot through dev → staging → prod
-- **Dev instance** — where you build and test the project
-- **Remote / Hosted Instances** — the fleet each snapshot rolls out to
+- **[Snapshot](/docs/user/snapshots/)** — the whole app, frozen as one versioned build
+- **[Pipeline](/docs/user/devops-pipelines/)** — promotes that snapshot through dev → staging → prod
+- **[Dev instance](/docs/user/concepts/#instance)** — where you build and test the project
+- **[Remote / Hosted Instances](/docs/user/concepts/#instance)** — the fleet each snapshot rolls out to
 
 **Where config & data live** depends on the kind of app you're shipping — a hardware app tied to a device, or a software app on the platform. See [Hardware apps →](/application-guide/flowfuse/hardware-apps/) and [Software apps →](/application-guide/flowfuse/software-apps/).
 
@@ -85,11 +85,11 @@ Package a single piece of a flow — a block of logic or UI — as a reusable su
 
 **Major components**
 
-- **Subflow** — the one reusable piece you package
-- **Custom node** — the installable package your subflow is exported to
-- **Team Library** — example flows the team shares (a custom node can ship with one to show its use)
-- **Instances** — the apps that install and run the piece
-- **Bill of Materials** — tracks which version each app runs
+- **[Subflow](/docs/user/packaging-subflows/)** — the one reusable piece you package
+- **[Custom node](/docs/user/custom-npm-packages/)** — the installable package your subflow is exported to
+- **[Team Library](/docs/user/shared-library/)** — example flows the team shares (a custom node can ship with one to show its use)
+- **[Instances](/docs/user/concepts/#instance)** — the apps that install and run the piece
+- **[Bill of Materials](/docs/user/bill-of-materials/)** — tracks which version each app runs
 
 **Where config & data live**
 

--- a/nuxt/content/application-guide/flowfuse/foundations.md
+++ b/nuxt/content/application-guide/flowfuse/foundations.md
@@ -36,11 +36,11 @@ edges:
 ## The core pieces
 
 - **Single platform** — Manage, secure, and govern everything from one place.
-- **Instances** — Node-RED runtimes. A **Hosted Instance** runs on FlowFuse-managed infrastructure (cloud or your own server); a **Remote Instance** runs on your own edge hardware via the Device Agent. Same runtime either way — it connects to whatever the job needs (hardware, data, cloud) and can serve its own Dashboard. [What an instance connects to →](/application-guide/node-red/foundations/)
-- **Team Broker** — A shared message bus that ties data together across sites.
-- **Database** — One shared operational data store.
-- **Dashboards** — Operator-facing UIs for the people who run it.
-- **Edge & device management** — Deploy and manage across many devices, lines, and plants.
+- **[Instances](/docs/user/concepts/#instance)** — Node-RED runtimes. A **Hosted Instance** runs on FlowFuse-managed infrastructure (cloud or your own server); a **Remote Instance** runs on your own edge hardware via the [Device Agent](/docs/device-agent/introduction/). Same runtime either way — it connects to whatever the job needs (hardware, data, cloud) and can serve its own Dashboard. [What an instance connects to →](/application-guide/node-red/foundations/)
+- **[Team Broker](/docs/user/teambroker/)** — A shared message bus that ties data together across sites.
+- **[Database](/docs/user/ff-tables/)** — One shared operational data store.
+- **[Dashboards](https://dashboard.flowfuse.com/)** — Operator-facing UIs for the people who run it.
+- **[Edge & device management](/docs/device-agent/introduction/)** — Deploy and manage across many devices, lines, and plants.
 
 ::callout{icon="i-lucide-square-stack"}
 **Remote Instance** — A Remote Instance lives in both worlds: edge execution down in OT, or an on-prem worker under an IT/cloud platform.


### PR DESCRIPTION
## What & why

On the Application Guide's **Foundations** and **App delivery methods** pages, the components we name (Snapshot, Pipeline, Instances, etc.) were plain bold text. This links each call-out to its docs reference so a reader can jump straight from the concept to the details.

## Changes

- **Foundations** — Instances, Device Agent, Team Broker, Database (Tables), **Dashboards → the Dashboard 2.0 docs (dashboard.flowfuse.com)**, Edge & device management.
- **App delivery methods** — Snapshot, Pipeline, Dev/Remote/Hosted Instances, Team Library, Bill of Materials, Custom node, and **Subflow → a new `/docs/user/packaging-subflows/` page**.
