### PR TITLE
Handbook: document the HubSpot quote naming convention

### DIFF
--- a/nuxt/content/handbook/sales/engagements.md
+++ b/nuxt/content/handbook/sales/engagements.md
@@ -46,6 +46,39 @@ When preparing a quote, include the product, quantities, and any required add-on
 
 Use the internal pricing calculator linked above to configure each product sale, including the correct quantities and add-ons.
 
+### Quote Naming Convention
+
+Every quote is named the same way, so that quotes are identifiable at a glance
+in HubSpot and stay identifiable once the signed copy is filed in Drive
+alongside purchase orders and agreements:
+
+`Quote - [Company] - [Order Type] - [Product] - [Year] - v##`
+
+For example: `Quote - Acme Corp - Renewal - Hub - 2026 - v01`
+
+- **Company** - the company name exactly as it appears on the HubSpot Company
+  record. This is internal identification only; the contracting legal entity is
+  set in the Buyer Information section of the quote itself.
+- **Order Type** - `New Business`, `Expansion`, or `Renewal`, matching the
+  deal's [Deal Type](#creating-a-deal). Use `Amendment` for a change to an
+  already-executed contract; it is a document type only and has no
+  corresponding Deal Type.
+- **Product** - `Edge`, `Hub`, or `Fleet`, matching the Quote Template selected
+  in [Creating a Quote](#creating-a-quote). For more than one product, join them
+  with a slash (`Edge/Hub`, `Edge/Fleet`). Use `Services` for a Professional
+  Services-only quote.
+- **Year** - the year the subscription term starts, not the year the quote is
+  written. A renewal quoted in December 2026 for a term starting January 2027 is
+  `2027`.
+- **v##** - the version, starting at `v01`. Increment it for each quote created
+  for the same transaction. Never reuse a number, including for a quote that was
+  voided.
+
+Do not put the HubSpot record ID or the execution status in the name. HubSpot
+tracks both, and the Company Quote Reference Number printed on the quote is the
+identifier customers cite on a purchase order (see
+[Closing a deal](#closing-a-deal)).
+
 ### Creating a Quote
 
 Follow these steps to create a quote.
@@ -53,6 +86,7 @@ Follow these steps to create a quote.
 1. In HubSpot, open the relevant Deal. In the Quotes area, click Add to begin a
    new quote.
    - Ensure the Deal Type is set up, "Expension" is an in-term upsel
+   - Name the quote per the [Quote Naming Convention](#quote-naming-convention)
 2. Fill in the Buyer Information section. This will pre-fill with the
    information from the contact in the Deal.
 3. The default Quote creator will be you. Change this if necessary.

--- a/nuxt/content/handbook/sales/hubspot.md
+++ b/nuxt/content/handbook/sales/hubspot.md
@@ -72,7 +72,7 @@ through other marketing activities too, but wasn't nurtured to the point of a me
 
 ## Deal Management
 
-A HubSpot deal represents a specific revenue opportunity with a customer or prospect: an active buying process with an engaged buyer, a realistic close date, and next steps the deal owner can work. We open a deal for each type of revenue opportunity: new business, expansion (in-term or at renewal), pilot-contingent expansion, and renewal. The rules for each type are below. Once a deal is open, quoting and closing it follows [Engagements & Pricing](/handbook/sales/engagements/#creating-a-deal).
+A HubSpot deal represents a specific revenue opportunity with a customer or prospect: an active buying process with an engaged buyer, a realistic close date, and next steps the deal owner can work. We open a deal for each type of revenue opportunity: new business, expansion (in-term or at renewal), pilot-contingent expansion, and renewal. The rules for each type are below. Once a deal is open, quoting and closing it follows [Engagements & Pricing](/handbook/sales/engagements/#creating-a-deal), including the [quote naming convention](/handbook/sales/engagements/#quote-naming-convention).
 
 ### Deal Amount Fields
 


### PR DESCRIPTION
## What

Adds a **Quote Naming Convention** section to [Engagements & Pricing](https://github.com/FlowFuse/website/blob/handbook-quote-naming-convention/nuxt/content/handbook/sales/engagements.md), under *Generating a Quote*, standardizing the name of every HubSpot quote:

```
Quote - [Company] - [Order Type] - [Product] - [Year] - v##
```

Example: `Quote - Acme Corp - Renewal - Hub - 2026 - v01`

## Why

Quote names were unspecified, so they varied by rep. The name also becomes the filename of the signed PDF once it is filed in the [signed quotes and P.O.'s](https://drive.google.com/drive/folders/1Nb3UqFiE56ymgQnyfkDKHMAe6L3akNzQ) Drive folder next to purchase orders and agreements, so an inconsistent name costs us twice.

## Notes on the design

Each segment is anchored to something that already exists, so there is nothing new to maintain:

- **Company** — the HubSpot Company record. Called out as internal identification only, since the contracting legal entity comes from the quote's Buyer Information; without that note reps are tempted to "correct" it to the legal entity.
- **Order Type** — matches the existing Deal Type picklist (`New Business` / `Expansion` / `Renewal`), so the two fields share one taxonomy. `Amendment` is flagged as document-level only, as it has no Deal Type equivalent.
- **Product** — matches the Edge / Hub / Fleet Quote Template already selected in step 6. `Edge/Hub` style for multi-product, `Services` for a Professional Services-only quote.
- **Year** — deliberately the **subscription term start year**, not the authoring year. An earlier draft used the full contract effective date; that date is frequently unknown at quote time and moves when a deal slips, which would have meant renaming quotes to keep them accurate. A year gives per-transaction uniqueness without the staleness.
- **v##** — versions increment per transaction and are never reused, including for voided quotes. Dropping the date entirely would have made this ambiguous between "revision of this deal" and "next year's renewal", which is why the year segment stayed.

The section also states that the HubSpot record ID and execution status stay out of the name, because HubSpot tracks both and the **Company Quote Reference Number** printed on the quote is already the identifier customers cite on a PO.

Terminology is "Quote" throughout, matching the defined term in the [Subscription Agreement](https://github.com/FlowFuse/website/blob/main/nuxt/content/handbook/sales/subscription-agreement-1.5.md), the rest of this page, and HubSpot's own object name.

## Placement

Cross-referenced from the two places someone arrives from:

- Step 1 of *Creating a Quote*, where the name is actually typed.
- *Deal Management* on the [HubSpot page](https://github.com/FlowFuse/website/blob/handbook-quote-naming-convention/nuxt/content/handbook/sales/hubspot.md), extending the existing pointer to Engagements & Pricing.

No nav changes — this is a section on an existing page.

## Follow-up (not in this PR)

`subscription-agreement-1.5.md` has find-and-replace damage from an earlier term change: nine instances of `"an Quote"` that should read `"a Quote"`, plus a doubled `an Quote Quote No.` in the Acceptance definition. That file is live customer-facing legal text still referenced in contracts and quotes, so it is being handled as a separate PR rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)