### PR TITLE
fix: hyphenate each space in integration README heading slugs

### DIFF
--- a/nuxt/server/utils/integrations-enrich.ts
+++ b/nuxt/server/utils/integrations-enrich.ts
@@ -24,13 +24,22 @@ const GITHUB_HEADERS = {
 
 // Mirrors GitHub's own heading slugger so anchors written against a README's
 // GitHub-rendered preview (e.g. `#egm-optional` for "## EGM (optional)") keep resolving here.
+//
+// One space per hyphen, not one per run of them. GitHub strips the punctuation first and
+// hyphenates whatever spaces are left, each on its own, so a heading with punctuation
+// between two words keeps the space on both sides of it and lands a double hyphen:
+// "Bugs / Feature request" is `#bugs--feature-request` there. Collapsing runs with \s+
+// gave `#bugs-feature-request` and every table-of-contents link a README author wrote
+// against GitHub for such a heading pointed at an id that did not exist. Headings whose
+// words are separated by a single space are identical either way, which is why only the
+// punctuated ones broke.
 function githubSlugify (heading: string): string {
     return encodeURIComponent(
         heading
             .trim()
             .toLowerCase()
             .replace(/[^\w一-龥\- ]/g, '')
-            .replace(/\s+/g, '-')
+            .replace(/\s/g, '-')
     )
 }
 


### PR DESCRIPTION
## Description

The link checker is failing on `main` with one bad anchor, `/integrations/node-red-contrib-counter#bugs--feature-request`. `githubSlugify` collapsed runs of whitespace into a single hyphen; GitHub strips the punctuation first and then hyphenates the remaining spaces one at a time, so a heading with punctuation between two words keeps the space on either side and lands a double hyphen. That README's `Bugs / Feature request` is `#bugs--feature-request` on GitHub and its own table of contents links to it, while we generated `#bugs-feature-request`.

One character, `\s+` to `\s`. It fixes every table-of-contents link a README author wrote against GitHub for a heading with punctuation in it, not just this one. Headings whose words are separated by single spaces slug identically either way, which is why one anchor broke rather than hundreds; the function's own documented example, `#egm-optional` for "EGM (optional)", is unchanged.

Checked all nine of that README's anchors against the ten headings it declares: one dangling before, none after.

## Related Issue(s)

Found while working on https://github.com/FlowFuse/website/pull/5671, which is blocked by this failure.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

`githubSlugify` is private to a `.ts` util and `npm test` only globs `.mjs` libs, so there is nowhere to unit test it without restructuring. The checker's own `--check-anchors` pass over the built integration pages is the regression guard.
