### PR TITLE
Fix internal links and breadcrumbs missing trailing slashes

### DIFF
--- a/nuxt/components/BlogListItem.vue
+++ b/nuxt/components/BlogListItem.vue
@@ -3,6 +3,8 @@ const props = defineProps<{
     entry: { path: string, title: string, description?: string, meta?: { description?: string }, date: string | Date, authors?: string[], image?: string }
 }>()
 
+const linkPath = computed(() => withTrailingSlash(props.entry.path))
+
 const authorNames = computed(() => useAuthorNames(props.entry.authors))
 const summary = computed(() => props.entry.description || props.entry.meta?.description || '')
 const formattedDate = computed(() => new Date(props.entry.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }))
@@ -11,7 +13,7 @@ const imageSrc = computed(() => props.entry.image || '/images/og-blog.jpg')
 
 <template>
   <li class="w-full md:w-1/3 my-2 px-2 pb-6 border-b">
-    <NuxtLink :to="entry.path" class="w-full flex flex-col group hover:no-underline">
+    <NuxtLink :to="linkPath" class="w-full flex flex-col group hover:no-underline">
       <time class="block text-xs mb-2 text-gray-500">{{ formattedDate }}</time>
       <div class="ff-blog-tile">
         <div class="w-full h-auto">

--- a/nuxt/components/BlogListing.vue
+++ b/nuxt/components/BlogListing.vue
@@ -7,6 +7,7 @@ const props = defineProps<{
 const { entries, totalPages } = useBlogList(props.tag ?? null, props.page)
 
 const featured = computed(() => props.page === 1 ? entries.value[0] : null)
+const featuredPath = computed(() => featured.value ? withTrailingSlash(featured.value.path) : '')
 const rest = computed(() => props.page === 1 ? entries.value.slice(1) : entries.value)
 const basePath = computed(() => props.tag ? `/blog/${props.tag}` : '/blog')
 
@@ -27,7 +28,7 @@ const featuredDate = computed(() => featured.value ? new Date(featured.value.dat
     <BlogTagNav :active-tag="tag" />
     <ul class="flex flex-wrap">
       <li v-if="featured" class="w-full mt-2 px-2 pb-4">
-        <NuxtLink :to="featured.path" class="w-full flex flex-col group hover:no-underline">
+        <NuxtLink :to="featuredPath" class="w-full flex flex-col group hover:no-underline">
           <div class="md:w-3/4 pr-2">
             <time class="block text-xs text-gray-500">{{ featuredDate }}</time>
             <h2 class="mb-0 text-xl font-medium group-hover:underline">{{ featured.title }}</h2>

--- a/nuxt/components/Breadcrumbs.vue
+++ b/nuxt/components/Breadcrumbs.vue
@@ -8,16 +8,21 @@ interface BreadcrumbItem {
 
 const props = defineProps<{ items: BreadcrumbItem[] }>()
 
+const normalizedItems = computed(() => props.items.map(item => ({
+    ...item,
+    ...(item.to ? { to: withTrailingSlash(item.to) } : {}),
+})))
+
 useSchemaOrg([
     defineBreadcrumb({
-        itemListElement: props.items.map(item => ({
+        itemListElement: normalizedItems.value.map(item => ({
             name: item.label,
             ...(item.to ? { item: item.to } : {}),
         })),
     }),
 ])
 
-const displayItems = computed(() => props.items.map((item, index) => ({
+const displayItems = computed(() => normalizedItems.value.map((item, index) => ({
     ...item,
     ui: {
         ...(item.to ? { link: 'hover:text-indigo-600' } : {}),

--- a/nuxt/components/DocsLeftNav.vue
+++ b/nuxt/components/DocsLeftNav.vue
@@ -8,7 +8,7 @@ const route = useRoute()
 const { data: navGroups } = await useDocsNavTree()
 
 const items = computed((): NavigationMenuItem[] => [
-    { label: 'Documentation', to: '/docs' },
+    { label: 'Documentation', to: '/docs/' },
     ...(navGroups.value ?? []).flatMap(group => [
         { type: 'label', label: group.name } satisfies NavigationMenuItem,
         ...buildNavigationMenuItems(group.children, route.path),

--- a/nuxt/composables/useApplicationGuideNav.ts
+++ b/nuxt/composables/useApplicationGuideNav.ts
@@ -78,7 +78,7 @@ export const applicationGuideNavGroups = (pages: ApplicationGuidePageSummary[] |
 // as Handbook and Docs, built inline in each page rather than through a dedicated
 // left-nav component, since there's no page-specific markup left to wrap.
 export const applicationGuideNavItems = (pages: ApplicationGuidePageSummary[] | null, currentPath: string): NavigationMenuItem[] => [
-    { label: 'Application Guide', to: '/application-guide' },
+    { label: 'Application Guide', to: '/application-guide/' },
     ...applicationGuideNavGroups(pages).flatMap(group => [
         { type: 'label', label: group.title } satisfies NavigationMenuItem,
         ...buildNavigationMenuItems(group.children ?? [], currentPath),
@@ -109,7 +109,7 @@ export function findGuideBreadcrumb(pages: ApplicationGuidePageSummary[] | null,
     }
 
     return [
-        { label: 'Application Guide', to: '/application-guide' },
+        { label: 'Application Guide', to: '/application-guide/' },
         ...ancestors.map((ancestor, i) => ({
             label: ancestor.title,
             ...(i === ancestors.length - 1 ? {} : { to: norm(ancestor.path) }),

--- a/nuxt/composables/useChangelogList.ts
+++ b/nuxt/composables/useChangelogList.ts
@@ -1,3 +1,5 @@
+import { withTrailingSlash } from '~/utils/withTrailingSlash'
+
 // How many entries are in the markup before any scrolling. The whole archive is
 // fetched in one query either way (it always was - the old paginated page fetched
 // everything and sliced it), so this only governs how much is rendered up front.
@@ -21,7 +23,10 @@ export interface ChangelogReleaseGroup {
 export function useChangelogList () {
     const { data: allEntries } = useAsyncData(
         'changelog-all',
-        () => queryCollection('changelog').order('date', 'DESC').all()
+        async () => {
+            const entries = await queryCollection('changelog').order('date', 'DESC').all()
+            return entries.map(entry => ({ ...entry, path: withTrailingSlash(entry.path) }))
+        }
     )
 
     const visibleCount = ref(CHANGELOG_INITIAL_VISIBLE)

--- a/nuxt/pages/blog/[...slug].vue
+++ b/nuxt/pages/blog/[...slug].vue
@@ -265,7 +265,7 @@ if (routeInfo.value.kind === 'post') {
             <h3 class="mb-3 pt-6 border-t-2">{{ relatedHeading }}</h3>
             <ul class="ml-6 list-disc">
               <li v-for="post in postsToShow" :key="post.path" class="mb-3">
-                <NuxtLink :to="post.path">{{ post.title }}</NuxtLink>
+                <NuxtLink :to="withTrailingSlash(post.path)">{{ post.title }}</NuxtLink>
               </li>
             </ul>
             <div class="mb-6 pb-6 pt-6 border-t-2">

--- a/nuxt/pages/changelog/[...slug].vue
+++ b/nuxt/pages/changelog/[...slug].vue
@@ -102,7 +102,7 @@ useSeoMeta({
             <h3 class="mb-3 pt-6 border-t-2">Recent Updates:</h3>
             <ul class="ml-6 list-disc">
               <li v-for="entry in otherRecentEntries" :key="entry.path" class="mb-3">
-                <NuxtLink :to="entry.path">{{ entry.title }}</NuxtLink>
+                <NuxtLink :to="withTrailingSlash(entry.path)">{{ entry.title }}</NuxtLink>
               </li>
             </ul>
 

--- a/nuxt/utils/navigationMenu.ts
+++ b/nuxt/utils/navigationMenu.ts
@@ -1,4 +1,5 @@
 import type { NavigationMenuItem } from '@nuxt/ui'
+import { withTrailingSlash } from './withTrailingSlash'
 
 // Shared by Handbook/Docs/Application Guide left navs: turns a generic {title, path,
 // children} tree into the NavigationMenuItem[] shape UNavigationMenu (vertical,
@@ -22,7 +23,7 @@ export function buildNavigationMenuItems(nodes: MenuTreeNode[], currentPath: str
         const children = node.children?.length ? buildNavigationMenuItems(node.children, currentPath) : undefined
         return {
             label: node.title,
-            to: node.path,
+            to: withTrailingSlash(node.path),
             icon: node.icon,
             defaultOpen: children ? isOrContains(node.path, currentPath) : undefined,
             children,

--- a/nuxt/utils/withTrailingSlash.ts
+++ b/nuxt/utils/withTrailingSlash.ts
@@ -1,0 +1,3 @@
+export function withTrailingSlash(path: string): string {
+    return path.endsWith('/') ? path : `${path}/`
+}


### PR DESCRIPTION
Internal links across blog, changelog, handbook, docs, and application-guide pages,  including breadcrumbs,  were missing a trailing slash. This didn't 404 (Netlify silently 301s to the correct URL), so it went unnoticed while quietly costing every click and crawl an extra redirect hop.

Added a withTrailingSlash() helper and applied it wherever a link is built from a collection or nav-tree path, including the shared Breadcrumbs component.
