### PR TITLE
changelog: land a release deep link with its own label at the top

### DIFF
--- a/nuxt/components/ChangelogListing.vue
+++ b/nuxt/components/ChangelogListing.vue
@@ -101,11 +101,16 @@ onUnmounted(() => {
       <!-- The release label lives in a column beside its own entries rather than in a
            separate rail, so it lines up with the entries it belongs to, and sticks while
            you read through them. Two columns per release, not one list plus one nav. -->
+      <!-- -scroll-mt-7 cancels the label column's pt-7 below, so a deep link such as
+           /changelog/#release-3-0 rests with the release label itself just under the
+           header, at the site-wide 75px inset, rather than the section box that starts
+           28px above it. That also tucks the previous release's sticky label behind the
+           header, instead of leaving it poking out above the release you asked for. -->
       <section
         v-for="group in visibleGroups"
         :id="anchorId(group.release)"
         :key="group.release"
-        class="flex"
+        class="flex -scroll-mt-7"
       >
         <!-- pt-7 so the label lines up with the first entry's title rather than sitting
              above it: each entry carries `my-2 py-6` before its title, which this column


### PR DESCRIPTION
## Description

A link to a release, say `/changelog/#release-3-0`, landed with the previous release's sticky label still showing above the release it pointed at.

The anchor is the release section, and its box starts 28px above the release label, because the label column carries `pt-7` to line up with the first entry's title. `-scroll-mt-7` cancels that, so the label itself lands just under the header, and the previous release's label ends up behind it.

Before:

![Release 3.1 label showing above Release 3.0](https://github.com/user-attachments/assets/d82ddbaf-c3e0-49c6-ba20-033a816573ec)

After:

![Release 3.0 label at the top, previous label behind the header](https://github.com/user-attachments/assets/c5697e79-7a9b-4fa3-a0a4-cddfd0bc151e)

Follow-up to #5638, which removed a `scroll-mt-24` that was stacking with the same `scroll-padding-top`.

## Related Issue(s)

None.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))