### PR TITLE
BlogCta: Remove max width

### DIFF
--- a/nuxt/components/BlogPostCta.vue
+++ b/nuxt/components/BlogPostCta.vue
@@ -51,7 +51,7 @@ function onCtaClick (event: MouseEvent) {
 </script>
 
 <template>
-  <div class="ff-blue-card blog-post-cta p-8 sm:p-12 m-auto max-w-prose">
+  <div class="ff-blue-card blog-post-cta p-8 sm:p-12 m-auto">
     <div class="flex flex-col gap-6 sm:gap-8 text-center sm:text-left">
       <h3 class="mt-0 mb-0 !text-3xl text-indigo-800">{{ cta?.title || currentCta.title }}</h3>
       <p class="mt-0 mb-0 max-w-4xl mx-auto sm:mx-0 leading-relaxed">{{ cta?.description || currentCta.description }}</p>


### PR DESCRIPTION
## Description

The class on the card used to be unlayered, which made its w-full class override everything else. That has now been moved into a layer, and an unnecessary max-width that was being ignored before was affecting the appearance of the component. This PR fixes that.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))

