### PR TITLE
Fix robots.txt 502 and the crashing Nitro fallback function

### DIFF
--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -342,6 +342,20 @@ export default defineNuxtConfig({
 
     nitro: {
         preset: 'netlify',
+        // sanitize-html is CommonJS but depends on htmlparser2 ^12, which is ESM-only
+        // ("type": "module", main ./dist/index.js). Left external, Nitro require()s it from
+        // /var/task/node_modules in the deployed function, and require() of an ES module only
+        // works on Node >= 22.12 - which is why sanitize-html declares engines node >=22.12.0.
+        // The Lambda runtime under this site is older than that, so the require threw
+        // ERR_REQUIRE_ESM at module load. server/utils is auto-imported by Nitro, so that one
+        // throw took down every route the fallback function serves: robots.txt, /api/*, and
+        // every 404, all returning 502. Inlining it makes rollup resolve htmlparser2 at build
+        // time, so the function no longer require()s ESM and this holds on any runtime.
+        // The runtime version itself is a Netlify site setting (AWS_LAMBDA_JS_RUNTIME); it
+        // cannot be set from netlify.toml, so it is not fixable here.
+        externals: {
+            inline: ['sanitize-html']
+        },
         // Nitro emits a .mjs.map next to every server chunk, so the Netlify functions bundle
         // ships one map file per chunk. Skipping them keeps the bundle smaller and the
         // server build a little shorter. The cost is that a server-side stack trace in the
@@ -395,6 +409,13 @@ export default defineNuxtConfig({
                     // content-urls.get.ts) silently resolves to undefined. Explicitly listing
                     // it here bakes it at build time instead, inside the git checkout.
                     '/sitemap.xml',
+                    // Same hybrid-preset gate as /sitemap.xml above: @nuxtjs/robots only
+                    // writes robots.txt to nuxt/dist when isNuxtGenerate() is true, so on the
+                    // netlify preset it was served live by the fallback function instead. Any
+                    // fault in that function therefore turned robots.txt into a 5xx, and
+                    // Google reads a 5xx on robots.txt as "crawl nothing" for the first ~12h.
+                    // Listing it here makes it a static file, independent of the function.
+                    '/robots.txt',
                     '/contact-us',
                     '/book-demo',
                     '/support',


### PR DESCRIPTION
## Description

`flowfuse.com/robots.txt` returns 502 in production. Reported in [this Slack thread](https://flowfuse.slack.com/archives/C02TG4WH5PC/p1788447069102829). It turned out to be two faults, and the blast radius is wider than robots.txt.

**1. `/robots.txt` was never a static file.** `@nuxtjs/robots` only writes it into `nuxt/dist` when `isNuxtGenerate()` is true. The `netlify` preset is hybrid (prerendered pages plus a fallback function), so it does not qualify and the route was served live by that function. This is the same gate that already bit `/sitemap.xml`, fixed the same way in `nuxt.config.ts` a few lines above.

**2. The fallback function crashes at module load.**

```
Error [ERR_REQUIRE_ESM]: require() of ES Module
/var/task/node_modules/htmlparser2/dist/index.js
from /var/task/node_modules/sanitize-html/index.js
```

`sanitize-html@2.17.7` is CommonJS but depends on `htmlparser2@^12`, which is ESM-only. `require()` of an ES module needs Node >= 22.12 (hence sanitize-html's `engines: node >=22.12.0`); the Lambda runtime is below that. `sanitize-html` is imported by `nuxt/server/utils/integrations-enrich.ts`, and Nitro auto-imports `server/utils`, so that single throw takes down every route the function serves.

Measured on production before this change:

| Route | Status |
|---|---|
| `/robots.txt` | 502 |
| `/api/handbook-changes` | 502 |
| `/api/integrations/opcua` | 502 |
| any 404 (`/this-page-does-not-exist-xyz/`) | 502 |
| prerendered pages (`/`, `/pricing/`, `/blog/`, `/sitemap.xml`) | 200 |

## Changes

- Add `/robots.txt` to `nitro.prerender.routes`, so it is a static file and never depends on the function.
- Add `nitro.externals.inline: ['sanitize-html']`, so rollup resolves `htmlparser2` at build time and the function stops `require()`ing ESM. This holds on any runtime version.

## Follow-up outside this repo

The runtime version is the underlying cause of fault 2 and is a Netlify **site setting** (`AWS_LAMBDA_JS_RUNTIME`), which cannot be set from `netlify.toml`. Worth checking whether it is pinned to an old `nodejs*.x` and clearing it so functions track the build's Node version.

## Verification

Once the deploy preview builds, on the preview URL:

- `/robots.txt` returns 200 with the expected `User-agent` / `Sitemap` lines
- a nonexistent path returns 404, not 502
- `/api/handbook-changes` returns 200

## Related Issue(s)

None. Reported via Slack.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))
