### PR TITLE
Route page CTAs to sales: drop self-serve sign-up from page bodies

### DIFF
--- a/nuxt/components/BlogPostCta.vue
+++ b/nuxt/components/BlogPostCta.vue
@@ -8,10 +8,6 @@ const props = defineProps<{
 // copy/href/event) instead of a local buttonText/buttonUrl pair, so the blog
 // CTA can't drift from the rest of the site's copy.
 const CTA_VARIANTS: Record<string, { title: string, description: string }> = {
-    'sign-up': {
-        title: 'Start building with your own industrial data',
-        description: 'Connect your systems, automate workflows, and see what’s possible in your environment.',
-    },
     demo: {
         title: 'See how FlowFuse works in real environments',
         description: 'Walk through real use cases and see how teams connect systems, automate workflows, and deploy at scale.',
@@ -26,14 +22,28 @@ const CTA_VARIANTS: Record<string, { title: string, description: string }> = {
     },
 }
 
-// Missing type, or an unrecognised one (e.g. typo'd `type: signup`), falls
-// back to 'sign-up'.
-const KNOWN_TYPES = new Set(['sign-up', 'demo', 'contact', 'pricing'])
+// Self-serve sign-up is not offered from page content for now, so a post
+// asking for the sign-up CTA gets the demo one instead. That covers 320 of
+// the 415 posts: 274 declare no `cta` block at all and reach this through
+// the fallback, 43 ask for `sign-up` and 3 for a typo'd `signup`.
+//
+// Those posts' own `cta.title`/`cta.description` are ignored too (see
+// `heading`/`body`): 46 of them say "Sign up for FlowFuse" or "start a free
+// trial" in the copy directly above the button, which would otherwise now
+// sit above a Book a Demo. Ignoring the override keeps every post's copy
+// truthful without editing 46 markdown files, so putting sign-up back is
+// this block and nothing else.
+const SIGNUP_TYPES = new Set(['sign-up', 'signup'])
+const KNOWN_TYPES = new Set(['demo', 'contact', 'pricing'])
+const FALLBACK_TYPE = 'demo'
 const ctaType = computed(() => {
     const type = props.cta?.type
-    return type && KNOWN_TYPES.has(type) ? type : 'sign-up'
+    return type && KNOWN_TYPES.has(type) ? type : FALLBACK_TYPE
 })
 const currentCta = computed(() => CTA_VARIANTS[ctaType.value])
+const isRedirectedSignUp = computed(() => SIGNUP_TYPES.has(props.cta?.type ?? ''))
+const heading = computed(() => (isRedirectedSignUp.value ? currentCta.value.title : props.cta?.title || currentCta.value.title))
+const body = computed(() => (isRedirectedSignUp.value ? currentCta.value.description : props.cta?.description || currentCta.value.description))
 
 // Kept as-is from Eleventy for data continuity - fires alongside, not
 // instead of, each Cta* component's own cta-* event.
@@ -53,11 +63,10 @@ function onCtaClick (event: MouseEvent) {
 <template>
   <div class="ff-blue-card blog-post-cta p-8 sm:p-12 m-auto">
     <div class="flex flex-col gap-6 sm:gap-8 text-center sm:text-left">
-      <h3 class="mt-0 mb-0 !text-3xl text-indigo-800">{{ cta?.title || currentCta.title }}</h3>
-      <p class="mt-0 mb-0 max-w-4xl mx-auto sm:mx-0 leading-relaxed">{{ cta?.description || currentCta.description }}</p>
+      <h3 class="mt-0 mb-0 !text-3xl text-indigo-800">{{ heading }}</h3>
+      <p class="mt-0 mb-0 max-w-4xl mx-auto sm:mx-0 leading-relaxed">{{ body }}</p>
       <div class="flex justify-center sm:justify-start" @click="onCtaClick">
-        <CtaSignUp v-if="ctaType === 'sign-up'" variant="highlight" position="blog-post-cta" />
-        <CtaBookDemo v-else-if="ctaType === 'demo'" variant="highlight" position="blog-post-cta" />
+        <CtaBookDemo v-if="ctaType === 'demo'" variant="highlight" position="blog-post-cta" />
         <CtaContactUs v-else-if="ctaType === 'contact'" variant="highlight" position="blog-post-cta" />
         <CtaPricing v-else variant="highlight" position="blog-post-cta" />
       </div>

--- a/nuxt/components/RoiCalculator.vue
+++ b/nuxt/components/RoiCalculator.vue
@@ -246,7 +246,6 @@ const faultFields = [
       </div>
 
       <div class="mt-6 flex flex-col sm:flex-row gap-3">
-        <CtaSignUp variant="highlight" :position="ctaPosition" />
         <CtaBookDemo variant="ghost" color="white" icon="i-lucide-arrow-right" :position="ctaPosition" />
       </div>
       <p class="text-xs text-indigo-200 mt-4 leading-snug">Directional estimate for comparison, not a quote. Every input is yours to change.</p>

--- a/nuxt/components/content/AgentSetupTabs.vue
+++ b/nuxt/components/content/AgentSetupTabs.vue
@@ -46,7 +46,7 @@ const CLIENTS = [
         name: 'FlowFuse Expert',
         builtIn: true,
         step1Title: 'Sign in to FlowFuse',
-        step1Body: 'A new account puts you in a hosted instance with Expert already in the editor. Nothing to add, no connector, no token.',
+        step1Body: 'A hosted instance has Expert already in the editor. Nothing to add, no connector, no token.',
         step2Title: 'Or start with the Device Agent',
         step2Body: 'Already running Node-RED on your own hardware? Connect it as a remote instance and Expert works there in the same way.',
         step2Label: 'Install the Device Agent',
@@ -147,7 +147,7 @@ function selectClient (id: string) {
         <p class="ff-agent-step__title"><span class="ff-agent-step__num">01</span>{{ client.builtIn ? client.step1Title : STEP1.title }}</p>
         <p class="ff-agent-step__body">{{ client.builtIn ? client.step1Body : STEP1.description }}</p>
         <div v-if="client.builtIn" class="ff-agent-step__cta">
-          <CtaSignUp variant="primary" :position="`${surface}-tab-expert`" class="w-full" />
+          <CtaSignIn variant="primary" :position="`${surface}-tab-expert`" class="w-full" />
         </div>
         <div v-else class="ff-agent-step__cta">
           <FfCommand :command="ENDPOINT" event="cta-copy-mcp-endpoint" :position="pos(client.id)" stacked host-swap />

--- a/nuxt/pages/integrations/opcua.vue
+++ b/nuxt/pages/integrations/opcua.vue
@@ -318,7 +318,6 @@ function toggleFaq (i: number) {
             </p>
             <div class="flex gap-3 max-md:max-w-sm max-md:mx-auto max-sm:flex-col max-md:justify-center">
               <CtaBookDemo variant="highlight" position="opcua-hero" />
-              <CtaSignUp variant="ghost" position="opcua-hero" icon="i-lucide-arrow-right" />
             </div>
           </div>
           <div class="md:w-1/2 flex-grow relative max-md:mt-12">
@@ -628,10 +627,9 @@ function toggleFaq (i: number) {
       <div class="max-w-screen-lg mx-auto">
         <div class="rounded-xl px-6 md:px-9 py-8 md:py-12 flex flex-col items-center gap-8 text-center ff-get-started-bg">
           <h2 class="text-white font-medium">Ready to build an OPC UA client or server the right way?</h2>
-          <p class="text-indigo-50 font-light text-xl max-w-3xl mt-0">No per-tag licensing. No Security Policy left at None. Connect to any OPC UA server, host your own, and bridge both to Modbus, MQTT, or a historian without extra middleware. See it live, or start free.</p>
+          <p class="text-indigo-50 font-light text-xl max-w-3xl mt-0">No per-tag licensing. No Security Policy left at None. Connect to any OPC UA server, host your own, and bridge both to Modbus, MQTT, or a historian without extra middleware. See it live.</p>
           <div class="flex flex-col sm:flex-row gap-4 items-center">
             <CtaBookDemo variant="highlight" position="opcua-final" />
-            <CtaSignUp variant="ghost" color="white" icon="i-lucide-arrow-right" position="opcua-final" />
           </div>
         </div>
       </div>

--- a/nuxt/pages/product/[tier].vue
+++ b/nuxt/pages/product/[tier].vue
@@ -133,7 +133,6 @@ useSeoMeta({
         <h2 class="text-white font-medium m-0 max-w-2xl">Join hundreds of global organizations building, governing, and deploying operational applications.</h2>
         <div class="flex flex-col sm:flex-row gap-4 items-center">
           <CtaBookDemo variant="highlight" :position="`${tierId}-final`" />
-          <CtaSignUp variant="ghost" color="white" icon="i-lucide-arrow-right" :position="`${tierId}-final`" />
         </div>
       </div>
     </div>

--- a/nuxt/pages/resources/roi-calculator.vue
+++ b/nuxt/pages/resources/roi-calculator.vue
@@ -174,7 +174,6 @@ useSchemaOrg([
         <div class="rounded-xl px-6 md:px-9 py-8 md:py-12 flex flex-col items-center gap-6 text-center ff-get-started-bg">
           <h2 class="text-white font-medium max-w-2xl">Stop paying for the work your team keeps redoing</h2>
           <div class="flex flex-col sm:flex-row gap-4 items-center">
-            <CtaSignUp variant="highlight" position="roi-final" />
             <CtaBookDemo variant="ghost" color="white" icon="i-lucide-arrow-right" position="roi-final" />
           </div>
         </div>

--- a/src/_includes/layouts/abm-landing.njk
+++ b/src/_includes/layouts/abm-landing.njk
@@ -2,7 +2,6 @@
 layout: page
 nohero: true
 ---
-{% from "components/cta/cta-sign-up.njk" import ctaSignUp %}
 {% from "components/cta/cta-book-demo.njk" import ctaBookDemo %}
 <!--Hero Content-->
 <div class="w-full px-6">
@@ -24,7 +23,6 @@ nohero: true
                 </div>
                 <div class="md:mt-3 gap-4 hidden md:flex md:flex-row md:inline md:items-start md:justify-start md:m-0">
                     {{ ctaBookDemo('primary', 'hero', extraClass='inline min-h-[40px]') }}
-                    {{ ctaSignUp(site, 'ghost', 'hero', icon=true, extraClass='inline') }}
                 </div>
             </div>
             <div class="md:w-2/5 flex-grow relative">
@@ -35,7 +33,6 @@ nohero: true
             </div>
             <div class="flex flex-col sm:flex-row md:hidden gap-3">
                 {{ ctaBookDemo('primary', 'hero-mobile', extraClass='w-full mt-12 min-h-[40px]') }}
-                {{ ctaSignUp(site, 'ghost', 'hero-mobile', icon=true, extraClass='flex flex-col w-full m-auto sm:mt-12') }}
             </div>
         </div>
     </div>
@@ -170,7 +167,6 @@ nohero: true
         <p class="text-center">{{ ctaSection.description }}</p>
         <div class="flex max-sm:flex-col max-md:mx-auto gap-3 justify-center mt-8">
             {{ ctaBookDemo('primary', 'secondary', extraClass='min-h-[40px]') }}
-            {{ ctaSignUp(site, 'primary-outlined', 'secondary', extraClass='min-h-[40px]') }}
         </div>
     </div>
 </div>

--- a/src/_includes/layouts/use-case.njk
+++ b/src/_includes/layouts/use-case.njk
@@ -2,7 +2,6 @@
 layout: layouts/base.njk
 sitemapPriority: 0.7
 ---
-{% from "components/cta/cta-sign-up.njk" import ctaSignUp %}
 {% from "components/cta/cta-book-demo.njk" import ctaBookDemo %}
 {# ============================================================
    USE CASE LAYOUT (content-driven, pain-led narrative)
@@ -315,10 +314,9 @@ sitemapPriority: 0.7
     <div class="w-full px-6 py-20">
         <div class="ff-blue-card max-md:max-w-xl md:max-w-screen-lg mx-auto pt-12 pb-10 text-center">
             <h3 class="mb-4 w-full text-center">{{ closingCta.heading or "See it on your operations" }}</h3>
-            <p class="text-gray-600 mb-8 max-w-xl mx-auto text-center">{{ closingCta.description or "Talk to an expert, or get started with FlowFuse today." }}</p>
+            <p class="text-gray-600 mb-8 max-w-xl mx-auto text-center">{{ closingCta.description or "Talk to an expert about your operations." }}</p>
             <div class="flex flex-wrap gap-4 justify-center">
                 {{ ctaBookDemo('highlight', 'footer', extraClass='min-h-[40px]') }}
-                {{ ctaSignUp(site, 'primary-outlined', 'footer', extraClass='min-h-[40px]') }}
             </div>
         </div>
     </div>

--- a/src/index.njk
+++ b/src/index.njk
@@ -113,7 +113,6 @@ hubspot:
   cta: "cta-blog-subscribe"
   reference: "homepage"
 ---
-{% from "components/cta/cta-sign-up.njk" import ctaSignUp %}
 {% from "components/cta/cta-book-demo.njk" import ctaBookDemo %}
 <!--Hero Content-->
 <section class="w-full relative bg-indigo-800 md:min-h-[800px]">
@@ -145,7 +144,6 @@ hubspot:
                     <div class="flex flex-col mt-12">
                         <div class="m-auto flex gap-4 items-center justify-center flex-row">
                             {{ ctaBookDemo('highlight', 'hero', extraClass='flex flex-col mb-6') }}
-                            {{ ctaSignUp(site, 'ghost', 'hero', color='white', icon=true, extraClass='flex flex-col mb-6') }}
                         </div>
                     </div>
                 </div>
@@ -255,7 +253,6 @@ hubspot:
         <p>Whether you're extending an existing system, standardizing a proven solution across sites, or connecting OT and IT data flows, FlowFuse gives your team the platform to <strong>build once and run everywhere</strong>.</p>
         <div class="flex gap-4 items-center max-md:justify-center flex-wrap mt-6">
             {{ ctaBookDemo('primary', 'secondary') }}
-            {{ ctaSignUp(site, 'ghost', 'secondary', icon=true) }}
         </div>
     </div>
 </div>
@@ -419,7 +416,7 @@ hubspot:
     <!-- Get Started -->
     {% set cta = {
         title: "Get Started with FlowFuse",
-        description: "Your first operational application could be running this week. Book a demo to see how, or start a free trial and build it yourself.",
+        description: "Your first operational application could be running this week. Book a demo and we will show you how.",
         buttonText: "BOOK A DEMO",
         buttonLink: "/book-demo/",
         position: "get-started"

--- a/src/industries.njk
+++ b/src/industries.njk
@@ -6,7 +6,6 @@ meta:
   title: "Industries"
   description: "FlowFuse helps industrial teams connect, automate, and standardize operations across sectors. Explore how FlowFuse is applied in your industry."
 ---
-{% from "components/cta/cta-sign-up.njk" import ctaSignUp %}
 {% from "components/cta/cta-contact-us.njk" import ctaContactUs %}
 <div class="w-full">
 
@@ -52,10 +51,9 @@ meta:
     <div class="w-full px-6 py-20">
         <div class="ff-blue-card max-md:max-w-xl md:max-w-screen-lg mx-auto pt-12 pb-10 text-center">
             <h3 class="mb-4 w-full text-center">See it in your plant</h3>
-            <p class="text-gray-600 mb-8 max-w-xl mx-auto text-center">Talk to an expert, or get started with FlowFuse today.</p>
+            <p class="text-gray-600 mb-8 max-w-xl mx-auto text-center">Talk to an expert about your plant.</p>
             <div class="flex flex-wrap gap-4 justify-center">
                 {{ ctaContactUs('highlight', 'footer', extraClass='min-h-[40px]') }}
-                {{ ctaSignUp(site, 'primary-outlined', 'footer', extraClass='min-h-[40px]') }}
             </div>
         </div>
     </div>

--- a/src/landing/plc.njk
+++ b/src/landing/plc.njk
@@ -142,7 +142,6 @@ resources:
     alt: "Diagnosing and fixing PLC communication latency"
     url: "/blog/2026/06/plc-communication-latency-causes-and-fixes/"
 ---
-{% from "components/cta/cta-sign-up.njk" import ctaSignUp %}
 {% from "components/cta/cta-contact-us.njk" import ctaContactUs %}
 {% from "components/cta/cta-book-demo.njk" import ctaBookDemo %}
 <div class="nohero w-full">
@@ -162,7 +161,6 @@ resources:
                     </p>
                     <div class="flex gap-3 max-md:max-w-sm max-md:mx-auto max-sm:flex-col max-md:justify-center">
                         {{ ctaContactUs('primary', 'primary', extraClass='min-h-[40px]') }}
-                        {{ ctaSignUp(site, 'primary-outlined', 'primary', extraClass='min-h-[40px]') }}
                     </div>
                 </div>
                 <div class="md:w-2/5 flex-grow relative">
@@ -461,11 +459,10 @@ resources:
             <div class="ff-blue-card">
                 <h4 class="mb-6 w-full text-center">Ready to unlock your PLC data?</h4>
                 <p class="text-center text-gray-600 mb-8">
-                    Stop paying for expensive gateways and inflexible SCADA licenses. See how FlowFuse connects your PLCs to the modern industrial stack, in a live demo or a free trial.
+                    Stop paying for expensive gateways and inflexible SCADA licenses. See how FlowFuse connects your PLCs to the modern industrial stack, in a live demo.
                 </p>
                 <div class="flex max-sm:flex-col max-md:mx-auto gap-3 justify-center">
                     {{ ctaBookDemo('primary', 'secondary', extraClass='min-h-[40px]') }}
-                    {{ ctaSignUp(site, 'primary-outlined', 'secondary', extraClass='min-h-[40px]') }}
                 </div>
             </div>
         </div>

--- a/src/node-red/index.njk
+++ b/src/node-red/index.njk
@@ -56,7 +56,6 @@ installCommandsHeading: "Or install Node-RED on your own machine"
 description: Node-RED is the low-code programming language of choice for industrial applications. Industrial engineers use Node-RED to collect, transform, and integrate data through visualized dashboards.
 sitemapPriority: 0.8
 ---
-{% from "components/cta/cta-sign-up.njk" import ctaSignUp %}
 {% from "components/cta/cta-book-demo.njk" import ctaBookDemo %}
 <!--First two sections-->
 <div class="nohero w-full">
@@ -74,9 +73,9 @@ sitemapPriority: 0.8
             <p><span class="font-semibold">FlowFuse enhances Node-RED with enterprise features</span> to accelerate digitalization and optimize industrial processes.</p>
             <p class="md:mb-6">Ready to <span class="font-semibold">get started building with Node-RED</span>? There are two ways in.</p>
             <div class="max-md:hidden md:mb-10">
-                {{ ctaSignUp(site, 'primary', 'nodered', extraClass='min-h-[40px] md:inline') }}
+                {{ ctaBookDemo('primary', 'nodered', extraClass='min-h-[40px] md:inline') }}
                 <p class="font-light mt-3 mb-0">
-                    Nothing to install, you get an editor in the browser. Or
+                    See FlowFuse's hosted Node-RED editor with our team. Or
                     <a href="#install-node-red-from-your-terminal" onclick="capture('cta-install-terminal', {'position': 'nodered-hero'})">install Node-RED on your own machine</a>
                     with one command.
                 </p>
@@ -86,9 +85,9 @@ sitemapPriority: 0.8
             {% image "../images/pseudo-editor.png", "Node-RED pseudo UI", [500] %}
         </div>
         <div class="md:hidden w-full max-w-md m-auto">
-            {{ ctaSignUp(site, 'primary', 'nodered-mobile', extraClass='flex flex-col w-full') }}
+            {{ ctaBookDemo('primary', 'nodered-mobile', extraClass='flex flex-col w-full') }}
             <p class="font-light mt-3 mb-0 text-center">
-                Nothing to install, you get an editor in the browser. Or
+                See FlowFuse's hosted Node-RED editor with our team. Or
                 <a href="#install-node-red-from-your-terminal" onclick="capture('cta-install-terminal', {'position': 'nodered-hero'})">install Node-RED on your own machine</a>
                 with one command.
             </p>
@@ -97,7 +96,7 @@ sitemapPriority: 0.8
 </div>
 
     <!--Install commands, directly under the hero. This is the second of the two routes
-        the hero names: TRY IT NOW signs you up for a hosted editor, this one runs
+        the hero names: BOOK A DEMO walks you through the hosted editor, this one runs
         Node-RED on hardware you already have. Shared with /platform/device-agent/.-->
     <div id="install-node-red-from-your-terminal" class="w-full scroll-mt-24 pb-16">
         <div class="max-w-screen-lg mx-auto px-6">

--- a/src/platform/dashboard.njk
+++ b/src/platform/dashboard.njk
@@ -409,7 +409,6 @@ meta:
             </p>
             <div class="flex flex-col sm:flex-row gap-4 items-center">
                 <a class="ff-btn ff-btn--highlight uppercase" href="/book-demo/" onclick="capture('cta-book-demo', {'position': 'dashboard-footer'})">Book a Demo</a>
-                <a class="ff-btn uppercase text-white hover:text-gray-200" href="https://app.flowfuse.com/account/create" rel="noopener noreferrer">Try it out &rarr;</a>
             </div>
         </div>
     </div>

--- a/src/platform/why-flowfuse.njk
+++ b/src/platform/why-flowfuse.njk
@@ -60,7 +60,6 @@ meta:
           answer: >
             Yes! FlowFuse is designed for seamless migration, fully compatible with existing Node-RED logic and integrations. 
 ---
-{% from "components/cta/cta-sign-up.njk" import ctaSignUp %}
 {% from "components/cta/cta-book-demo.njk" import ctaBookDemo %}
 <div class="nohero w-full px-6">
     <!--Hero Content-->
@@ -84,7 +83,6 @@ meta:
                 </div>
                 <div class="flex gap-3 max-md:mx-auto max-sm:flex-col max-md:justify-center">
                     {{ ctaBookDemo('primary', 'primary', extraClass='min-h-[40px]') }}
-                    {{ ctaSignUp(site, 'ghost', 'primary', icon=true, extraClass='min-h-[40px]') }}
                 </div>
             </div>
             <div class="flex max-md:hidden justify-center m-auto max-w-[550px] ff-image-rounded rounded-lg drop-shadow-lg w-full">

--- a/src/use-cases.njk
+++ b/src/use-cases.njk
@@ -6,7 +6,6 @@ meta:
   title: "Use Cases"
   description: "Generic operational workflow patterns for industrial teams. Turn events into action with FlowFuse. Placeholder skeleton hub."
 ---
-{% from "components/cta/cta-sign-up.njk" import ctaSignUp %}
 {% from "components/cta/cta-contact-us.njk" import ctaContactUs %}
 <div class="w-full">
 
@@ -70,10 +69,9 @@ meta:
     <div class="w-full px-6 py-20">
         <div class="ff-blue-card max-md:max-w-xl md:max-w-screen-lg mx-auto pt-12 pb-10 text-center">
             <h3 class="mb-4 w-full text-center">See it on your workflow</h3>
-            <p class="text-gray-600 mb-8 max-w-xl mx-auto text-center">Talk to an expert, or get started with FlowFuse today.</p>
+            <p class="text-gray-600 mb-8 max-w-xl mx-auto text-center">Talk to an expert about your workflow.</p>
             <div class="flex flex-wrap gap-4 justify-center">
                 {{ ctaContactUs('highlight', 'footer', extraClass='min-h-[40px]') }}
-                {{ ctaSignUp(site, 'primary-outlined', 'footer', extraClass='min-h-[40px]') }}
             </div>
         </div>
     </div>

--- a/src/use-cases/it-ot-middleware.njk
+++ b/src/use-cases/it-ot-middleware.njk
@@ -29,7 +29,6 @@ heroImg: ./images/pictograms/factory_blue.png
 description:
     <p>FlowFuse streamlines manufacturing automation, from production monitoring to supply chain management. Our intuitive, customizable platform enables simple creation of custom solutions for unique manufacturing needs.</p>
 ---
-{% from "components/cta/cta-sign-up.njk" import ctaSignUp %}
 {% from "components/cta/cta-book-demo.njk" import ctaBookDemo %}
 <div class="w-full flex justify-center mt-6">
     <div class="mx-auto text-center flex flex-row gap-8">
@@ -251,10 +250,10 @@ description:
                             </h4>
                         </div>
                         <p class="mb-0 text-left">
-                            The easiest way to start building industrial applications. No installation required! Simply sign up and gain immediate access to the editor.
+                            The easiest way to build industrial applications. No installation required, hosted and maintained by the FlowFuse team.
                         </p>
                     </div>
-                    {{ ctaSignUp(site, 'primary-outlined', 'manufacturing', extraClass='md:self-end align-baseline w-full mt-3') }}
+                    {{ ctaBookDemo('primary-outlined', 'manufacturing', extraClass='md:self-end align-baseline w-full mt-3') }}
                 </div>
                 <div class="deployment-card white-bg">
                     <div>

--- a/src/use-cases/mes.njk
+++ b/src/use-cases/mes.njk
@@ -54,7 +54,6 @@ meta:
     description: "FlowFuse provides everything you need to build the robust Manufacturing Execution System (MES) you want, providing everything from production tracking to data analysis, with the components you need and the flexibility to customize as you see fit."
     keywords: "FlowFuse, manufacturing, MES, Industry 4.0, Siemens S7, PLC, Sentron"
 ---
-{% from "components/cta/cta-sign-up.njk" import ctaSignUp %}
 {% from "components/cta/cta-contact-us.njk" import ctaContactUs %}
 {% from "components/cta/cta-book-demo.njk" import ctaBookDemo %}
 <div class="nohero w-full px-6">
@@ -75,7 +74,6 @@ meta:
                 </div>
                 <div class="flex gap-3 max-md:max-w-sm max-md:mx-auto max-sm:flex-col max-md:justify-center">
                     {{ ctaContactUs('primary', 'primary', extraClass='min-h-[40px]') }}
-                    {{ ctaSignUp(site, 'primary-outlined', 'primary', extraClass='min-h-[40px]') }}
                 </div>
             </div>
             <div class="flex max-md:hidden justify-center m-auto max-w-[550px]">
@@ -144,7 +142,6 @@ meta:
         <h4 class="mb-6 w-full text-center">{{ ctaSection.title }}</h4>
         <div class="flex max-sm:flex-col max-md:mx-auto gap-3 justify-center">
             {{ ctaBookDemo('primary', 'secondary', extraClass='min-h-[40px]') }}
-            {{ ctaSignUp(site, 'primary-outlined', 'secondary', extraClass='min-h-[40px]') }}
         </div>
     </div>
 </div>

--- a/src/use-cases/scada.njk
+++ b/src/use-cases/scada.njk
@@ -48,7 +48,6 @@ meta:
     description: "FlowFuse provides SCADA value in an Industry 4.0 way and unlocks the potential to modernize your SCADA system with its powerful, customizable, modular components that streamline operations, reduce dependence on costly, monolithic solutions."
     keywords: "FlowFuse, manufacturing, SCADA, Industry 4.0, Siemens S7, PLC, Sentron"
 ---
-{% from "components/cta/cta-sign-up.njk" import ctaSignUp %}
 {% from "components/cta/cta-contact-us.njk" import ctaContactUs %}
 {% from "components/cta/cta-book-demo.njk" import ctaBookDemo %}
 <div class="nohero w-full px-6">
@@ -69,7 +68,6 @@ meta:
                 </div>
                 <div class="flex gap-3 max-md:max-w-sm max-md:mx-auto max-sm:flex-col max-md:justify-center">
                     {{ ctaContactUs('primary', 'primary', extraClass='min-h-[40px]') }}
-                    {{ ctaSignUp(site, 'primary-outlined', 'primary', extraClass='min-h-[40px]') }}
                 </div>
             </div>
             <div class="flex max-md:hidden justify-center m-auto max-w-[450px]">
@@ -128,7 +126,6 @@ meta:
         <h4 class="mb-6 w-full text-center">{{ ctaSection.title }}</h4>
         <div class="flex max-sm:flex-col max-md:mx-auto gap-3 justify-center">
             {{ ctaBookDemo('primary', 'secondary', extraClass='min-h-[40px]') }}
-            {{ ctaSignUp(site, 'primary-outlined', 'secondary', extraClass='min-h-[40px]') }}
         </div>
     </div>
 </div>

--- a/src/use-cases/uns.njk
+++ b/src/use-cases/uns.njk
@@ -9,7 +9,6 @@ meta:
     description: "FlowFuse simplifies UNS adoption for manufacturing companies by providing a user-friendly, low-code platform for deploying and using data from a UNS."
     keywords: "FlowFuse, UNS, Unified Namespace, manufacturing, data, data integration, data management, data visualization, data analysis, data-driven decisions, data silos, real-time data, collaboration, Node-RED, MQTT Broker, low-code, open-source, rapid implementation, seamless integration"
 ---
-{% from "components/cta/cta-sign-up.njk" import ctaSignUp %}
 {% from "components/cta/cta-contact-us.njk" import ctaContactUs %}
 {% from "components/cta/cta-book-demo.njk" import ctaBookDemo %}
 <!--First two sections-->
@@ -29,7 +28,6 @@ meta:
                 </div>
                 <div class="flex gap-3 max-md:max-w-sm max-md:mx-auto max-sm:flex-col max-md:justify-center">
                     {{ ctaContactUs('primary', 'primary', extraClass='min-h-[40px]') }}
-                    {{ ctaSignUp(site, 'primary-outlined', 'primary', extraClass='min-h-[40px]') }}
                 </div>
             </div>
             <div class="flex max-md:hidden justify-center m-auto max-w-[400px]">
@@ -153,7 +151,6 @@ meta:
         <h4 class="mb-6 w-full text-center">Ready to simplify your UNS journey and unlock the power of your industrial data?</h4>
         <div class="flex max-sm:flex-col max-md:mx-auto gap-3 justify-center">
             {{ ctaBookDemo('primary', 'secondary', extraClass='min-h-[40px]') }}
-            {{ ctaSignUp(site, 'primary-outlined', 'secondary', extraClass='min-h-[40px]') }}
         </div>
     </div>
     <!-- Learn UNS -->

--- a/src/vs/ignition.njk
+++ b/src/vs/ignition.njk
@@ -54,7 +54,6 @@ cta:
     title: "Exploring Alternatives to Ignition?"
     content: "Most teams don't replace Ignition overnight, they start by building the next application somewhere else. <a href='https://meetings-eu1.hubspot.com/michael-davis/round-robin-michael-omar-kasheef?utm_campa[…]113138546&utm_content=113138546&utm_source=hs_automation' class='font-semibold'>Book a demo with a FlowFuse expert</a>."
 ---
-{% from "components/cta/cta-sign-up.njk" import ctaSignUp %}
 <!--Hero Content-->
 <div class="w-full px-6">
     <div class="w-full pt-12 pb-20 md:pt-6 md:pb-8">
@@ -75,7 +74,6 @@ cta:
                     </a>
                     {% endmacro %}
                     {{ migrationExpertButton() }}
-                    {{ ctaSignUp(site, 'ghost', 'hero', icon=true, extraClass='inline-flex items-center') }}
                 </div>
             </div>
             <div class="md:w-1/2 flex-grow relative">
@@ -86,7 +84,6 @@ cta:
             </div>
             <div class="flex flex-col sm:flex-row md:hidden gap-3">
                 {{ migrationExpertButton(false) }}
-                {{ ctaSignUp(site, 'ghost', 'hero-mobile', icon=true, extraClass='flex flex-col w-full m-auto sm:mt-12') }}
             </div>
         </div>
     </div>

--- a/src/vs/kepware.njk
+++ b/src/vs/kepware.njk
@@ -54,7 +54,6 @@ cta:
     title: "Ready to Leave Kepware Behind?"
     content: "See how FlowFuse helps teams like yours modernize their industrial automation infrastructure, faster, more flexibly, and at lower cost. <a href='https://meetings-eu1.hubspot.com/michael-davis/round-robin-michael-omar-kasheef?utm_campa[…]113138546&utm_content=113138546&utm_source=hs_automation' class='font-semibold'>Book a Demo with a FlowFuse Expert</a>."
 ---
-{% from "components/cta/cta-sign-up.njk" import ctaSignUp %}
 <!--Hero Content-->
 <div class="w-full">
     <div class="w-full pt-12 pb-20 md:pt-6 md:pb-12">
@@ -75,7 +74,6 @@ cta:
                     </a>
                     {% endmacro %}
                     {{ migrationExpertButton() }}
-                    {{ ctaSignUp(site, 'ghost', 'hero', icon=true, extraClass='inline') }}
                 </div>
             </div>
             <div class="md:w-1/2 flex justify-center items-end m-auto relative">
@@ -86,7 +84,6 @@ cta:
             </div>
             <div class="flex flex-col sm:flex-row md:hidden gap-3">
                 {{ migrationExpertButton(false) }}
-                {{ ctaSignUp(site, 'ghost', 'hero-mobile', icon=true, extraClass='flex flex-col w-full m-auto sm:mt-12') }}
             </div>
         </div>   
     </div>

--- a/src/vs/litmus.njk
+++ b/src/vs/litmus.njk
@@ -51,7 +51,6 @@ cta:
     title: "Exploring Alternatives to Litmus?"
     content: "Discover how FlowFuse can help your team modernize its industrial edge and data infrastructure with an open, flexible platform that complements your existing AI and analytics strategy. <a href='https://meetings-eu1.hubspot.com/michael-davis/round-robin-michael-omar-kasheef?utm_campa[…]113138546&utm_content=113138546&utm_source=hs_automation' class='font-semibold'>Book a Demo with a FlowFuse Expert</a>."
 ---
-{% from "components/cta/cta-sign-up.njk" import ctaSignUp %}
 <!--Hero Content-->
 <div class="w-full px-6">
     <div class="w-full pt-12 pb-20 md:pt-6 md:pb-8">
@@ -72,7 +71,6 @@ cta:
                     </a>
                     {% endmacro %}
                     {{ migrationExpertButton() }}
-                    {{ ctaSignUp(site, 'ghost', 'hero', icon=true, extraClass='inline') }}
                 </div>
             </div>
             <div class="md:w-1/2 flex-grow relative">
@@ -83,7 +81,6 @@ cta:
             </div>
             <div class="flex flex-col sm:flex-row md:hidden gap-3">
                 {{ migrationExpertButton(false) }}
-                {{ ctaSignUp(site, 'ghost', 'hero-mobile', icon=true, extraClass='flex flex-col w-full m-auto sm:mt-12') }}
             </div>
         </div>   
     </div>


### PR DESCRIPTION
## Description

Removes the self-serve sign-up CTA from page bodies, leaving the sales CTA that already sat beside it. The header "Free Trial", the mobile sticky bar and the blueprint "Deploy" buttons are untouched. 23 buttons are deleted outright, 4 that stood alone become Book a Demo (`/node-red/` hero, the Cloud deployment card on `/use-cases/it-ot-middleware/`, `/platform/dashboard/`), and the AI setup tabs point at Sign In since that step is a prerequisite, not a pitch.

Blog posts switch in `BlogPostCta` rather than in content: 320 of 415 posts render the sign-up CTA but only 43 declare it, so the fallback does the work and this reverts in one commit. Those posts' own `cta.title`/`cta.description` are ignored, because 46 say "Sign up for FlowFuse" in the copy directly above the button.

Copy promising a trial the page no longer offers is corrected in the same places. Verified against a local Eleventy build: every page now renders exactly two sign-up links, both from the layout.

One call for you: `/node-red/` and the it-ot-middleware Cloud card now say Book a Demo where they said Try It Out; showing nothing there instead is a one-line change either way.

## Related Issue(s)

None.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))
