### PR TITLE
redirects: send /roi to the ROI calculator

### DIFF
--- a/nuxt/redirects.ts
+++ b/nuxt/redirects.ts
@@ -99,6 +99,7 @@ export const redirects: Record<string, NitroRouteRules> = {
     '/cloud/': { redirect: { to: 'https://app.flowfuse.com/account/create/', statusCode: 301 } },
     '/legal/terms/': { redirect: { to: '/terms/', statusCode: 301 } },
     '/book-a-demo/': { redirect: { to: '/book-demo/', statusCode: 301 } },
+    '/roi/': { redirect: { to: '/resources/roi-calculator/', statusCode: 301 } },
     '/education/': { redirect: { to: '/docs/node-red/', statusCode: 301 } },
     '/handbook/marketing/education/': { redirect: { to: '/handbook/marketing/', statusCode: 301 } },
     '/handbook/sales/org/account-executives/': { redirect: { to: '/handbook/sales/sales-team/', statusCode: 301 } },


### PR DESCRIPTION
## Description

Adds a `/roi` vanity redirect to `/resources/roi-calculator/`. `/roi` currently 404s.

Goes in `nuxt/redirects.ts` rather than `netlify.toml`: it is same-domain and lowercase, so a Nitro route rule handles it. `netlify.toml` is reserved for the cross-domain redirects and the case-sensitive legacy URLs, where a case-insensitive Nitro rule would also match the canonical URL and loop it onto itself.

One key with the trailing slash covers both forms, `/roi` and `/roi/`.

## Related Issue(s)

None.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))
