### PR TITLE
handbook: add Product Levels

### DIFF
--- a/nuxt/content/handbook/peopleops/job-descriptions/product-levels.md
+++ b/nuxt/content/handbook/peopleops/job-descriptions/product-levels.md
@@ -1,0 +1,219 @@
+---
+title: "Product Levels"
+---
+
+# FlowFuse Product Levels
+
+## Purpose
+
+This document defines expectations for Product Managers at FlowFuse.
+
+It exists to:
+
+- Clarify what strong performance looks like
+- Define scope at each level
+- Support evidence-based quarterly reviews
+- Make promotion decisions predictable and defensible
+
+This applies to:
+
+- Product Managers
+- Lead Product Managers
+
+Levels reflect scope of ownership and influence. "Meets Expectations" at a level represents strong performance. Promotion requires sustained demonstration of next-level behaviors.
+
+Product work is judged on outcomes, not output. A shipped feature that did not change customer behavior is not evidence of performance at any level. The [product methodology](/handbook/engineering/product/methodology/) describes the practice these levels measure.
+
+## Core Dimensions
+
+All Product Managers are evaluated across five dimensions.
+
+### 1. Discovery Craft
+
+Quality of the evidence behind product decisions, and how honestly that evidence is represented.
+
+Examples:
+- Opportunities grounded in specific past stories from distinct customers, rung 3 or higher, rather than a paraphrased deal ask
+- Opportunities framed as customer needs, so more than one solution could address them, rather than a solution in disguise
+- Hypothesis and Evidenced states used honestly, so a hunch is never presented as research
+- Risky assumptions named across desirability, viability, feasibility, usability and ethics, with a deliberate call on whether a spike is worth running
+- Evidence linked to its source, so anyone can check the reasoning without asking
+
+### 2. Outcome Ownership
+
+Reliable movement of product objectives, traceable to a change in customer behavior.
+
+Examples:
+- Objectives that move measurably within the horizon they were set for
+- Adoption and activation observed in PostHog after a solution ships, rather than assumed
+- Solutions chosen by comparing sibling opportunities across sizing, market, company and customer, with the reasoning shown
+- Committed work landing in the release it was planned for, so engineering and go-to-market can rely on the plan
+- Calling a bet wrong early and redirecting, rather than defending a shipped solution that moved nothing
+
+### 3. Product System Thinking
+
+Understanding and improving the wider product system, in line with FlowFuse's "think big picture" value: a decision taken in one lane is paid for in all the others.
+
+Examples:
+- Cross-lane conflicts caught during planning, not during a release
+- Packaging and tier placement decided with the pricing and positioning consequences understood
+- Downstream load on support, documentation and go-to-market anticipated and planned for, not discovered after launch
+- The tree kept coherent, so any committed issue can be traced back to the objective it serves
+- Recurring customer friction traced to its cause rather than patched one request at a time
+
+### 4. Collaboration and Influence
+
+Working effectively with engineering and the wider company, and amplifying impact through others.
+
+Examples:
+- Specifications precise enough that engineers never have to guess what "done" means
+- Discovery and delivery held as separate conversations, so refinement is not reopened
+- Leadership, sales and community input absorbed, filtered and sequenced, rather than forwarded
+- Product decisions made in the room, so the team is not left waiting on an answer
+- Coaching others toward sharper opportunity framing and stronger evidence
+
+### 5. Ecosystem and Market Stewardship
+
+Responsible contribution to the health of our open source and user ecosystem, and a current read on the market we compete in.
+
+Examples:
+- Professional engagement in public issues and community channels
+- Community-reported needs in owned areas triaged and answered
+- Node-RED ecosystem direction tracked and factored into planning
+- Competitive and market movement understood well enough to inform positioning
+- Roadmap communication that sets expectations the company can keep
+
+Community work is considered real work and should be planned and visible.
+
+## Levels
+
+Levels represent increasing scope of ownership and influence.
+
+
+### Level 1 - Guided Contributor
+
+Scope: Well-defined opportunities within one product lane.
+
+Demonstrates:
+
+- Writes issues and specifications to the expected standard with guidance
+- Gathers evidence from customer calls and product analytics, and grades it honestly
+- Frames opportunities as customer needs rather than solutions, with review
+- Understands the lane, its customers, and the objectives currently in play
+- Engages constructively in feedback
+- Acts professionally in ecosystem interactions
+
+Promotion to Level 2 requires:
+- Independent ownership of an opportunity area
+- Reduced need for day-to-day oversight
+  - Able to run discovery, choose a solution, and flag risk without step-by-step direction
+
+### Level 2 - Independent Owner
+
+Scope: An opportunity area and the solutions that address it.
+
+Demonstrates:
+
+- Independently runs discovery for an area and carries it from evidence to committed work
+- Names the risky assumptions behind a solution and decides deliberately whether a spike is warranted
+- Hands engineering solutions that hold up in refinement without reopening the why
+- Anticipates local risk and raises blockers early rather than at the deadline
+- Participates meaningfully in roadmap planning and sequencing
+- Handles ecosystem issues in owned areas
+
+Promotion to Level 3 requires:
+- Ownership of a full product lane, including its objectives
+- Evidence of raising the product standard beyond their own work
+
+
+### Level 3 - Domain Leader
+
+Scope: A product lane end to end, including its objectives, roadmap, and engineering squad.
+
+A Level 3 Product Manager operates as a force multiplier within Product.
+
+Demonstrates:
+
+- Owns a lane outright: vision, objectives, opportunity space, roadmap, and backlog
+- Sets objectives that describe a real change in customer behavior, and is accountable for moving them
+- Keeps the lane's tree evidenced and current, so investment goes where the evidence points
+- Anticipates cross-lane impact and prevents downstream problems
+- Runs Outcome to Solution and refinement so engineering stays focused and unblocked
+- Elevates the quality of others through review of their opportunities and specifications
+- Identifies recurring ecosystem or customer friction and drives reduction
+
+Level 3 performance requires sustained lane-level impact, not isolated strong releases. For most Product Managers, Level 3 is the ceiling, sustained performance here is a strong, complete career at FlowFuse, and most will not promote beyond this point.
+
+Promotion to Level 4 requires:
+- Sustained influence across lanes
+- Strategic impact beyond a single lane
+
+
+### Level 4 - Cross-Lane Strategist
+
+Scope: Multiple product lanes.
+
+Demonstrates:
+
+- Shapes product direction across lanes and resolves the conflicts between them
+- Models and reinforces discovery discipline across Product; identifies systemic patterns in weak evidence or missed outcomes and drives structural fixes
+- Drives packaging, tier placement, and positioning decisions that hold across the portfolio
+- Influences company strategy through customer and market insight
+- Leads the resolution of major product bets where the answer is genuinely unclear
+- Strengthens company credibility with customers and in the industrial ecosystem
+
+Promotion to Level 5 requires:
+- Multi-quarter strategic impact
+- Ensures the organization sustains evidence-based decisions and outcome accountability at scale; sets the standard for how product commitments are made and communicated company-wide
+- Organization-level product leadership
+
+
+### Level 5 - Organizational Authority
+
+Scope: Company-wide product direction.
+
+Demonstrates:
+
+- Defines multi-year product strategy and is accountable for its outcomes
+  - Strategy is judged by what it produces, not by the act of proposing it
+- Makes high-impact portfolio tradeoffs, including what FlowFuse will not build
+- Elevates product standards across the organization
+- Elevates the organization's rate of learning, not only its rate of shipping
+- Represents FlowFuse product at an industry level
+- Drives outcome accountability company-wide
+
+This level is rare and not time-based.
+
+
+## Performance and Reviews
+
+### Mid-Quarter Check-Ins
+
+Each quarter includes an informal mid-point check-in between the Product Manager and manager. The goal is to identify early whether anything is off-track and course-correct before the quarter closes, not to evaluate, but to make sure no one is surprised.
+
+### Quarterly Reviews
+
+Quarterly reviews are informal. The manager leads evidence gathering ahead of each conversation, drawing on:
+
+- The state of owned objectives and the opportunity trees beneath them
+- Issues and specifications written, including the refinement discussion around them
+- Customer call participation and the evidence drawn from it
+- Geekbot standup history
+- Relevant Slack threads and direct messages
+- Notes logged during the quarter
+
+The manager synthesizes this into a draft evaluation across the five core dimensions before the review conversation.
+
+In the review itself, the Product Manager and manager go through the evaluation together. The goal is to make sure nothing meaningful was missed and that the Product Manager feels accurately and well represented. Product Managers should come prepared to flag anything they want to add or clarify.
+
+### Annual Reviews
+
+Annual reviews are formal and synthesize evidence from all four quarters of the year.
+
+The manager evaluates sustained scope and impact across dimensions, identifies patterns, and uses this as the basis for compensation and promotion decisions.
+
+### What Product Managers Should Expect
+
+- Your manager is doing the legwork. Both the Product Manager and manager flag notable things during the quarter as they happen.
+- Reviews are based on observable behavior and documented impact. A release counts for what it changed, not for having shipped. A bet called wrong early and redirected counts in your favor.
+- The review conversation is collaborative. If something feels off, say so.

--- a/nuxt/content/handbook/peopleops/job-descriptions/product-levels.md
+++ b/nuxt/content/handbook/peopleops/job-descriptions/product-levels.md
@@ -58,7 +58,7 @@ Examples:
 - Cross-lane conflicts caught during planning, not during a release
 - Packaging and tier placement decided with the pricing and positioning consequences understood
 - Downstream load on support, documentation and go-to-market anticipated and planned for, not discovered after launch
-- The tree kept coherent, so any committed issue can be traced back to the objective it serves
+- There is an adequate and maintained artifact that connects and translates engineering outcomes to business outcomes.
 - Recurring customer friction traced to its cause rather than patched one request at a time
 
 ### 4. Collaboration and Influence


### PR DESCRIPTION
## Description

Adds `/handbook/peopleops/job-descriptions/product-levels/`, the Product Manager counterpart to the existing Engineering Levels page.

Same skeleton as Engineering Levels (Purpose, five Core Dimensions, five Levels, Performance and Reviews) so the two ladders stay comparable in reviews. Applies to Product Managers and Lead Product Managers.

Dimensions: Discovery Craft, Outcome Ownership, Product System Thinking, Collaboration and Influence, Ecosystem and Market Stewardship.

Levels: Guided Contributor, Independent Owner, Domain Leader (a product lane end to end, and the ceiling for most), Cross-Lane Strategist, Organizational Authority.

Written in the vocabulary already established in [Product Methodology](https://flowfuse.com/handbook/engineering/product/methodology/): evidence rungs, opportunity framing, assumption categories, lane ownership, outcomes over output.

## Related Issue(s)

None.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
 - [ ] For blog PRs, an Art Request has been created ([instructions](https://flowfuse.com/handbook/design/art-requests/#creating-an-art-request))