### PR TITLE
components: extract PageHero.vue, dedup the hero block across 6 pages

### DIFF
--- a/nuxt/components/PageHero.vue
+++ b/nuxt/components/PageHero.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+// The centered title/subtitle/description block repeated verbatim at the top of every
+// plain marketing/support/thank-you page. `subtitle` is a slot rather than a prop because
+// a couple of callers (the thank-you pages) put a link inside it.
+defineProps<{
+    title: string
+    description?: string
+}>()
+</script>
+
+<template>
+  <div class="hero container m-auto text-center flex flex-wrap pt-6 px-6 pb-12 md:flex-nowrap md:max-w-4xl md:pt-12">
+    <div class="mx-auto max-w-screen-xl md:max-w-xl">
+      <h1>{{ title }}</h1>
+      <h4 v-if="$slots.subtitle" class="text-gray-500">
+        <slot name="subtitle" />
+      </h4>
+      <p v-if="description" class="lead-p m-auto mt-3">
+        {{ description }}
+      </p>
+    </div>
+  </div>
+</template>

--- a/nuxt/pages/professional-services/index.vue
+++ b/nuxt/pages/professional-services/index.vue
@@ -7,14 +7,10 @@ useSeoMeta({
 
 <template>
   <div class="w-full">
-    <div class="hero container m-auto text-center flex flex-wrap pt-6 px-6 pb-12 md:flex-nowrap md:max-w-4xl md:pt-12">
-      <div class="mx-auto max-w-screen-xl md:max-w-xl">
-        <h1>Professional Services</h1>
-        <p class="lead-p m-auto mt-3">
-          At FlowFuse, we partner with our customers to ensure their successful deployment of FlowFuse and Node-RED. Our professional services are available to Enterprise tier customers, providing expert support for critical projects.
-        </p>
-      </div>
-    </div>
+    <PageHero
+        title="Professional Services"
+        description="At FlowFuse, we partner with our customers to ensure their successful deployment of FlowFuse and Node-RED. Our professional services are available to Enterprise tier customers, providing expert support for critical projects."
+    />
     <div class="text-left max-w-full">
       <div class="w-full pt-0 md:pt-12 px-0">
         <div class="m-auto max-w-4xl pb-8 md:pb-16">

--- a/nuxt/pages/support/index.vue
+++ b/nuxt/pages/support/index.vue
@@ -7,14 +7,10 @@ useSeoMeta({
 
 <template>
   <div class="w-full">
-    <div class="hero container m-auto text-center flex flex-wrap pt-6 px-6 pb-12 md:flex-nowrap md:max-w-4xl md:pt-12">
-      <div class="mx-auto max-w-screen-xl md:max-w-xl">
-        <h1>Help Center</h1>
-        <p class="lead-p m-auto mt-3">
-          Search through our extensive range of resources, knowledge base, or reach out to our dedicated support team by submitting a ticket.
-        </p>
-      </div>
-    </div>
+    <PageHero
+        title="Help Center"
+        description="Search through our extensive range of resources, knowledge base, or reach out to our dedicated support team by submitting a ticket."
+    />
     <div class="text-left max-w-full">
       <div class="w-full pt-10 md:pt-8 px-0 ff-prose">
         <div class="text-center mb-8">

--- a/nuxt/pages/thank-you/contact.vue
+++ b/nuxt/pages/thank-you/contact.vue
@@ -8,17 +8,14 @@ useSeoMeta({
 
 <template>
   <div class="w-full">
-    <div class="hero container m-auto text-center flex flex-wrap pt-6 px-6 pb-12 md:flex-nowrap md:max-w-4xl md:pt-12">
-      <div class="mx-auto max-w-screen-xl md:max-w-xl">
-        <h1>Thank you for contacting us</h1>
-        <h4 class="text-gray-500">
-          <a href="https://meetings-eu1.hubspot.com/flowfuse/book-a-demo-call?uuid=22122d0b-0581-44fb-ab2c-4ae4ff8dc4f5" class="underline">Schedule a call right now</a>
-        </h4>
-        <p class="lead-p m-auto mt-3">
-          Or get inspired by our customer success stories while you wait for someone from our team to reach out to you.
-        </p>
-      </div>
-    </div>
+    <PageHero
+        title="Thank you for contacting us"
+        description="Or get inspired by our customer success stories while you wait for someone from our team to reach out to you."
+    >
+      <template #subtitle>
+        <a href="https://meetings-eu1.hubspot.com/flowfuse/book-a-demo-call?uuid=22122d0b-0581-44fb-ab2c-4ae4ff8dc4f5" class="underline">Schedule a call right now</a>
+      </template>
+    </PageHero>
     <div class="flex flex-col max-w-5xl mx-auto gap-x-10 px-6">
       <div class="max-w-md sm:max-w-screen-lg m-auto pb-6">
         <ThankYouExploreMore reading-resources="stories" hubspot-reference="thank-you-contact" />

--- a/nuxt/pages/thank-you/download-platform-overview.vue
+++ b/nuxt/pages/thank-you/download-platform-overview.vue
@@ -8,17 +8,11 @@ useSeoMeta({
 
 <template>
   <div class="w-full">
-    <div class="hero container m-auto text-center flex flex-wrap pt-6 px-6 pb-12 md:flex-nowrap md:max-w-4xl md:pt-12">
-      <div class="mx-auto max-w-screen-xl md:max-w-xl">
-        <h1>Thank you for your interest!</h1>
-        <h4 class="text-gray-500">
-          <a href="https://26586079.fs1.hubspotusercontent-eu1.net/hubfs/26586079/FlowFuse%20Platform%20Overview-October%202024.pdf">Click here</a> to access the The FlowFuse Platform Overview
-        </h4>
-        <p class="lead-p m-auto mt-3">
-          We've also sent a copy to your inbox
-        </p>
-      </div>
-    </div>
+    <PageHero title="Thank you for your interest!" description="We've also sent a copy to your inbox">
+      <template #subtitle>
+        <a href="https://26586079.fs1.hubspotusercontent-eu1.net/hubfs/26586079/FlowFuse%20Platform%20Overview-October%202024.pdf">Click here</a> to access the The FlowFuse Platform Overview
+      </template>
+    </PageHero>
     <div class="flex flex-col max-w-5xl mx-auto gap-x-10 px-6">
       <div class="max-w-md sm:max-w-screen-lg m-auto pb-6">
         <ThankYouExploreMore download-follow-up hubspot-reference="thank-you-flowfuse-overview" />

--- a/nuxt/pages/thank-you/download.vue
+++ b/nuxt/pages/thank-you/download.vue
@@ -8,17 +8,11 @@ useSeoMeta({
 
 <template>
   <div class="w-full">
-    <div class="hero container m-auto text-center flex flex-wrap pt-6 px-6 pb-12 md:flex-nowrap md:max-w-4xl md:pt-12">
-      <div class="mx-auto max-w-screen-xl md:max-w-xl">
-        <h1>Thank you!</h1>
-        <h4 class="text-gray-500">
-          <a href="https://26586079.fs1.hubspotusercontent-eu1.net/hubfs/26586079/ebook_%20The%20Ultimate%20Beginner%20Guide%20to%20a%20Professional%20Node-RED-V2.pdf">Click here</a> to access The Ultimate Beginner Guide to a Professional Node-RED
-        </h4>
-        <p class="lead-p m-auto mt-3">
-          We've also sent a copy to your inbox
-        </p>
-      </div>
-    </div>
+    <PageHero title="Thank you!" description="We've also sent a copy to your inbox">
+      <template #subtitle>
+        <a href="https://26586079.fs1.hubspotusercontent-eu1.net/hubfs/26586079/ebook_%20The%20Ultimate%20Beginner%20Guide%20to%20a%20Professional%20Node-RED-V2.pdf">Click here</a> to access The Ultimate Beginner Guide to a Professional Node-RED
+      </template>
+    </PageHero>
     <div class="flex flex-col max-w-5xl mx-auto gap-x-10 px-6">
       <div class="max-w-md sm:max-w-screen-lg m-auto pb-6">
         <ThankYouExploreMore download-follow-up hubspot-reference="thank-you-node-red-ebook" />

--- a/nuxt/pages/thank-you/download_ebook-flowfuse-dashboard.vue
+++ b/nuxt/pages/thank-you/download_ebook-flowfuse-dashboard.vue
@@ -8,17 +8,11 @@ useSeoMeta({
 
 <template>
   <div class="w-full">
-    <div class="hero container m-auto text-center flex flex-wrap pt-6 px-6 pb-12 md:flex-nowrap md:max-w-4xl md:pt-12">
-      <div class="mx-auto max-w-screen-xl md:max-w-xl">
-        <h1>Thank you!</h1>
-        <h4 class="text-gray-500">
-          <a href="https://26586079.fs1.hubspotusercontent-eu1.net/hubfs/26586079/eBook_%20Ultimate%20Guide%20to%20Building%20Applications%20with%20FlowFuse%20Dashboard%20for%20Node-RED.pdf">Click here</a> to access The Ultimate Guide to Building Applications with FlowFuse Dashboard for Node-RED
-        </h4>
-        <p class="lead-p m-auto mt-3">
-          We've also sent a copy to your inbox
-        </p>
-      </div>
-    </div>
+    <PageHero title="Thank you!" description="We've also sent a copy to your inbox">
+      <template #subtitle>
+        <a href="https://26586079.fs1.hubspotusercontent-eu1.net/hubfs/26586079/eBook_%20Ultimate%20Guide%20to%20Building%20Applications%20with%20FlowFuse%20Dashboard%20for%20Node-RED.pdf">Click here</a> to access The Ultimate Guide to Building Applications with FlowFuse Dashboard for Node-RED
+      </template>
+    </PageHero>
     <div class="flex flex-col max-w-5xl mx-auto gap-x-10 px-6">
       <div class="max-w-md sm:max-w-screen-lg m-auto pb-6">
         <ThankYouExploreMore download-follow-up collection-name="dashboard" hubspot-reference="thank-you-dashboard-ebook" />


### PR DESCRIPTION
The centered title/subtitle/description block at the top of professional-services, support, and the four thank-you pages was copy-pasted verbatim in each file. PageHero.vue takes title/description as props and a `subtitle` slot for the two callers (thank-you pages) whose subtitle line contains a link.

